### PR TITLE
Add Edit Value To Number Button

### DIFF
--- a/src/CrissCross.WPF.UI.Gallery/CrissCross.WPF.UI.Gallery.csproj
+++ b/src/CrissCross.WPF.UI.Gallery/CrissCross.WPF.UI.Gallery.csproj
@@ -21,11 +21,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Models\" />
+    <Resource Include="Assets\**\*.png" />
   </ItemGroup>
 
   <ItemGroup>
-    <Resource Include="Assets\**\*.png" />
+    <Compile Remove="Models\**" />
+    <EmbeddedResource Remove="Models\**" />
+    <None Remove="Models\**" />
+    <Page Remove="Models\**" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CrissCross.WPF.UI.Gallery/Views/BasicControls/NumericPushButtonView.xaml
+++ b/src/CrissCross.WPF.UI.Gallery/Views/BasicControls/NumericPushButtonView.xaml
@@ -39,7 +39,7 @@
                 <RowDefinition />
                 <RowDefinition />
             </Grid.RowDefinitions>
-            <ui:NumberBox Margin="5" VerticalAlignment="Stretch" />
+            <ui:NumericPushButton Margin="5" UseSeperateEditValue="True" />
             <ui:NumericPushButton Grid.Column="1" Margin="5" />
 
             <ui:NumericPushButton Grid.Column="3" Margin="5" />

--- a/src/CrissCross.WPF.UI/Controls/NumberPad/INumberPadButton.cs
+++ b/src/CrissCross.WPF.UI/Controls/NumberPad/INumberPadButton.cs
@@ -63,6 +63,18 @@ public interface INumberPadButton
     double Value { get; set; }
 
     /// <summary>
+    /// Gets or sets the edited value.
+    /// </summary>
+    /// <value>The value.</value>
+    double EditedValue { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether gets or sets the edited value.
+    /// </summary>
+    /// <value>The value.</value>
+    bool UseSeperateEditValue { get; set; }
+
+    /// <summary>
     /// Gets the value double observable.
     /// </summary>
     /// <value>The value double observable.</value>

--- a/src/CrissCross.WPF.UI/Controls/NumberPad/NumberPad.xaml.cs
+++ b/src/CrissCross.WPF.UI/Controls/NumberPad/NumberPad.xaml.cs
@@ -267,7 +267,16 @@ public partial class NumberPad : IDisposable
                 return;
             }
 
-            _owner.Value = check;
+            if (_owner.UseSeperateEditValue)
+            {
+                _owner.EditedValue = check;
+            }
+            else
+            {
+                _owner.Value = check;
+                _owner.EditedValue = check;
+            }
+
             _owner.DisposeKeypad();
         }
 

--- a/src/CrissCross.WPF.UI/Controls/NumericPushButton/NumericPushButton.cs
+++ b/src/CrissCross.WPF.UI/Controls/NumericPushButton/NumericPushButton.cs
@@ -97,6 +97,16 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
             new PropertyMetadata(false, UpdateNewLine));
 
     /// <summary>
+    /// The units on new line property.
+    /// </summary>
+    public static readonly DependencyProperty UseSeperateEditValueProperty =
+        DependencyProperty.Register(
+            nameof(UseSeperateEditValue),
+            typeof(bool),
+            typeof(NumericPushButton),
+            new PropertyMetadata(false, UpdateValue));
+
+    /// <summary>
     /// Units Dependency Property.
     /// </summary>
     public static readonly DependencyProperty UnitsProperty =
@@ -112,6 +122,16 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
     public static readonly DependencyProperty ValueProperty =
         DependencyProperty.Register(
             nameof(Value),
+            typeof(double),
+            typeof(NumericPushButton),
+            new PropertyMetadata(0d, UpdateValue));
+
+    /// <summary>
+    /// Edited Value Change.
+    /// </summary>
+    public static readonly DependencyProperty EditedValueProperty =
+        DependencyProperty.Register(
+            nameof(EditedValue),
             typeof(double),
             typeof(NumericPushButton),
             new PropertyMetadata(0d, UpdateValue));
@@ -304,6 +324,19 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
     }
 
     /// <summary>
+    /// Gets or sets a value indicating whether [units on new line].
+    /// </summary>
+    /// <value><c>true</c> if [units on new line]; otherwise, <c>false</c>.</value>
+    [Description("Gets or sets a value indicating whether edited value and value are stored seperately or not")]
+    [Category("Common")]
+    public bool UseSeperateEditValue
+    {
+        get => (bool)GetValue(UseSeperateEditValueProperty);
+
+        set => SetValue(UseSeperateEditValueProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the user changed.
     /// </summary>
     /// <value><c>true</c> if [user changed]; otherwise, <c>false</c>.</value>
@@ -319,6 +352,18 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
         get => (double)GetValue(ValueProperty);
 
         set => SetValue(ValueProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the Value of Button.
+    /// </summary>
+    [Description("Gets or sets the Edited Value of Button")]
+    [Category("Common")]
+    public double EditedValue
+    {
+        get => (double)GetValue(EditedValueProperty);
+
+        set => SetValue(EditedValueProperty, value);
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request includes several changes to the `CrissCross.WPF.UI` project, primarily focusing on the `NumericPushButton` control. The changes introduce a new property `UseSeperateEditValue` and its associated logic to handle separate edited values for the numeric push button.

Key changes include:

### Project File Updates:
* Updated `CrissCross.WPF.UI.Gallery.csproj` to include assets as resources and remove the `Models` folder from compilation and resource inclusion.

### UI Control Updates:
* Modified `NumericPushButtonView.xaml` to use the new `UseSeperateEditValue` property in the `NumericPushButton` control.

### Interface Enhancements:
* Added `EditedValue` and `UseSeperateEditValue` properties to the `INumberPadButton` interface.

### Control Logic Updates:
* Updated `NumberPad.xaml.cs` to handle the new `UseSeperateEditValue` property when accepting input.

### Dependency Property Additions:
* Added `UseSeperateEditValueProperty` and `EditedValueProperty` to the `NumericPushButton` class, along with corresponding getters and setters. [[1]](diffhunk://#diff-b43f9efa3c720e359086b9871c6cb5ca8c292383118aa2d8bd0d3fde771d7d03R99-R108) [[2]](diffhunk://#diff-b43f9efa3c720e359086b9871c6cb5ca8c292383118aa2d8bd0d3fde771d7d03R129-R138) [[3]](diffhunk://#diff-b43f9efa3c720e359086b9871c6cb5ca8c292383118aa2d8bd0d3fde771d7d03R326-R338) [[4]](diffhunk://#diff-b43f9efa3c720e359086b9871c6cb5ca8c292383118aa2d8bd0d3fde771d7d03R357-R368)