### PR TITLE
Add MessageBoxAsync Owner

### DIFF
--- a/Version.json
+++ b/Version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "2.2.8",
+    "version": "2.3.0",
     "publicReleaseRefSpec": [
         "^refs/heads/master$",
         "^refs/heads/main$"

--- a/src/CrissCross.WPF.UI.Test/Views/Pages/DashboardPage.xaml.cs
+++ b/src/CrissCross.WPF.UI.Test/Views/Pages/DashboardPage.xaml.cs
@@ -4,7 +4,6 @@
 
 using CrissCross.WPF.UI.Test.ViewModels;
 using ReactiveMarbles.ObservableEvents;
-using MessageBoxButton = System.Windows.MessageBoxButton;
 
 namespace CrissCross.WPF.UI.Test.Views.Pages;
 
@@ -31,4 +30,12 @@ public partial class DashboardPage : INavigableView<DashboardViewModel>, ICanSho
     /// Optionally, it may implement <see cref="T:CrissCross.WPF.UI.Controls.INavigationAware" /> and be navigated by <see cref="T:CrissCross.WPF.UI.Controls.INavigationView" />.
     /// </summary>
     public DashboardViewModel ViewModel { get; }
+
+    /// <summary>
+    /// Gets the owner.
+    /// </summary>
+    /// <value>
+    /// The owner.
+    /// </value>
+    string ICanShowMessages.Owner => "mainWindow";
 }

--- a/src/CrissCross.WPF.UI.Test/Views/Pages/DataPage.xaml.cs
+++ b/src/CrissCross.WPF.UI.Test/Views/Pages/DataPage.xaml.cs
@@ -31,4 +31,12 @@ public partial class DataPage : INavigableView<DataViewModel>, ICanShowMessages
     /// Optionally, it may implement <see cref="T:CrissCross.WPF.UI.Controls.INavigationAware" /> and be navigated by <see cref="T:CrissCross.WPF.UI.Controls.INavigationView" />.
     /// </summary>
     public DataViewModel ViewModel { get; }
+
+    /// <summary>
+    /// Gets the owner.
+    /// </summary>
+    /// <value>
+    /// The owner.
+    /// </value>
+    string ICanShowMessages.Owner => "mainWindow";
 }

--- a/src/CrissCross.WPF.UI/Controls/FluentWindow/FluentWindow.cs
+++ b/src/CrissCross.WPF.UI/Controls/FluentWindow/FluentWindow.cs
@@ -84,6 +84,14 @@ public class FluentWindow : System.Windows.Window, ICanShowMessages
     }
 
     /// <summary>
+    /// Gets the owner.
+    /// </summary>
+    /// <value>
+    /// The owner.
+    /// </value>
+    string ICanShowMessages.Owner => Name;
+
+    /// <summary>
     /// Gets contains helper for accessing this window handle.
     /// </summary>
     protected WindowInteropHelper InteropHelper => _interopHelper ??= new WindowInteropHelper(this);

--- a/src/CrissCross.WPF.UI/Controls/MessageBoxAsync/MessageBoxAsync.xaml.cs
+++ b/src/CrissCross.WPF.UI/Controls/MessageBoxAsync/MessageBoxAsync.xaml.cs
@@ -16,7 +16,7 @@ namespace CrissCross.WPF.UI;
 /// <summary>
 /// Interaction logic for MessageBox.xaml.
 /// </summary>
-public partial class MessageBoxAsync : IListenForMessages, ICanShowMessages
+public partial class MessageBoxAsync : IListenForMessages
 {
     /// <summary>
     /// Identifies the Buttons dependency property.

--- a/src/CrissCross.WPF.UI/Controls/ModernWindow/ModernWindow.cs
+++ b/src/CrissCross.WPF.UI/Controls/ModernWindow/ModernWindow.cs
@@ -469,6 +469,14 @@ public class ModernWindow
     public bool IsDisposed => _cleanUp.IsDisposed;
 
     /// <summary>
+    /// Gets the owner.
+    /// </summary>
+    /// <value>
+    /// The owner.
+    /// </value>
+    string ICanShowMessages.Owner => Name;
+
+    /// <summary>
     /// Gets the status bar status text.
     /// </summary>
     /// <value>The status bar status text.</value>

--- a/src/CrissCross.WPF.UI/Controls/Window/Window.cs
+++ b/src/CrissCross.WPF.UI/Controls/Window/Window.cs
@@ -9,4 +9,13 @@ namespace CrissCross.WPF.UI.Controls;
 /// </summary>
 /// <seealso cref="System.Windows.Window" />
 /// <seealso cref="ICanShowMessages" />
-public class Window : System.Windows.Window, ICanShowMessages;
+public class Window : System.Windows.Window, ICanShowMessages
+{
+    /// <summary>
+    /// Gets the owner.
+    /// </summary>
+    /// <value>
+    /// The owner.
+    /// </value>
+    string ICanShowMessages.Owner => Name;
+}

--- a/src/CrissCross.WPF.UI/MagicInterfaces/ICanShowMessages.cs
+++ b/src/CrissCross.WPF.UI/MagicInterfaces/ICanShowMessages.cs
@@ -7,4 +7,13 @@ namespace CrissCross.WPF.UI;
 /// <summary>
 /// Enables showing messages on ModernWindow.
 /// </summary>
-public interface ICanShowMessages;
+public interface ICanShowMessages
+{
+    /// <summary>
+    /// Gets the owner.
+    /// </summary>
+    /// <value>
+    /// The owner.
+    /// </value>
+    string Owner { get; }
+}

--- a/src/CrissCross.WPF.UI/MagicInterfaces/MessageBoxShowMixins.cs
+++ b/src/CrissCross.WPF.UI/MagicInterfaces/MessageBoxShowMixins.cs
@@ -13,8 +13,8 @@ namespace CrissCross.WPF.UI;
 /// </summary>
 public static class MessageBoxShowMixins
 {
-    private static readonly SingleAssign<Func<Tuple<string, string, MessageBoxButton>, Task<MessageBoxResult>>> messageBoxFunc = new();
-    private static readonly SingleAssign<Func<Tuple<string, string, string, string?, string?, string?, string?, Tuple<string?, string?, string?, string?, string?>>, Task<CustomMessageBoxResult>>> messageBoxCustomFunc = new();
+    private static readonly Dictionary<string, SingleAssign<Func<Tuple<string, string, MessageBoxButton>, Task<MessageBoxResult>>>> messageBoxFunc = [];
+    private static readonly Dictionary<string, SingleAssign<Func<Tuple<string, string, string, string?, string?, string?, string?, Tuple<string?, string?, string?, string?, string?>>, Task<CustomMessageBoxResult>>>> messageBoxCustomFunc = [];
     private static readonly SingleAssign<Action<string, bool, string>> busyFunc = new();
 
     /// <summary>
@@ -29,34 +29,82 @@ public static class MessageBoxShowMixins
     /// </summary>
     /// <param name="dummy">The dummy.</param>
     /// <param name="e">The e.</param>
-    public static void ListenForMessages(this IListenForMessages dummy, Func<Tuple<string, string, MessageBoxButton>, Task<MessageBoxResult>> e) =>
-        messageBoxFunc.Assign(e);
+    public static void ListenForMessages(this IListenForMessages dummy, Func<Tuple<string, string, MessageBoxButton>, Task<MessageBoxResult>> e)
+    {
+        if (dummy == null)
+        {
+            throw new ArgumentNullException(nameof(dummy));
+        }
+
+        if (dummy is DependencyObject owner)
+        {
+            var window = System.Windows.Window.GetWindow(owner);
+
+            if (!messageBoxFunc.ContainsKey(window.Name))
+            {
+                SingleAssign<Func<Tuple<string, string, MessageBoxButton>, Task<MessageBoxResult>>> singleAssign = new();
+                singleAssign.Assign(e);
+                messageBoxFunc.Add(window.Name, singleAssign);
+            }
+        }
+    }
 
     /// <summary>
     /// Listens for custom messages.
     /// </summary>
     /// <param name="dummy">The dummy.</param>
     /// <param name="e">The e.</param>
-    public static void ListenForCustomMessages(this IListenForMessages dummy, Func<Tuple<string, string, string, string?, string?, string?, string?, Tuple<string?, string?, string?, string?, string?>>, Task<CustomMessageBoxResult>> e) =>
-        messageBoxCustomFunc.Assign(e);
+    public static void ListenForCustomMessages(this IListenForMessages dummy, Func<Tuple<string, string, string, string?, string?, string?, string?, Tuple<string?, string?, string?, string?, string?>>, Task<CustomMessageBoxResult>> e)
+    {
+        if (dummy == null)
+        {
+            throw new ArgumentNullException(nameof(dummy));
+        }
+
+        if (dummy is DependencyObject owner)
+        {
+            var window = System.Windows.Window.GetWindow(owner);
+
+            if (!messageBoxCustomFunc.ContainsKey(window.Name))
+            {
+                SingleAssign<Func<Tuple<string, string, string, string?, string?, string?, string?, Tuple<string?, string?, string?, string?, string?>>, Task<CustomMessageBoxResult>>> singleAssign = new();
+                singleAssign.Assign(e);
+                messageBoxCustomFunc.Add(window.Name, singleAssign);
+            }
+        }
+    }
 
     /// <summary>
     /// Displays a dismiss-able message-box. Click outside of the message area to dismiss.
     /// </summary>
-    /// <param name="dummy">The dummy.</param>
+    /// <param name="requester">The requester.</param>
     /// <param name="bbcode">The text. Use BBCode to style the text.</param>
     /// <param name="title">The title.</param>
     /// <param name="messageBoxButton">The message box button.</param>
     /// <returns>
     /// Task of MessageBoxResult.
     /// </returns>
-    public static Task<MessageBoxResult> MessageBoxShow(this ICanShowMessages? dummy, string bbcode, string title = "", MessageBoxButton messageBoxButton = MessageBoxButton.OK) =>
-        messageBoxFunc.Value?.Invoke(new Tuple<string, string, MessageBoxButton>(bbcode, title, messageBoxButton)) ?? Task.FromResult(MessageBoxResult.None);
+    /// <exception cref="System.ArgumentNullException">owner.</exception>
+    /// <exception cref="System.InvalidOperationException">No listener found for message box.</exception>
+    public static Task<MessageBoxResult> MessageBoxShow(this ICanShowMessages? requester, string bbcode, string title = "", MessageBoxButton messageBoxButton = MessageBoxButton.OK)
+    {
+        if (requester == null || string.IsNullOrWhiteSpace(requester?.Owner))
+        {
+            throw new ArgumentNullException(nameof(requester));
+        }
+
+        if (!messageBoxFunc.TryGetValue(requester!.Owner, out var value))
+        {
+            throw new InvalidOperationException("No listener found for message box.");
+        }
+
+        return value.Value?.Invoke(new Tuple<string, string, MessageBoxButton>(bbcode, title, messageBoxButton)) ?? Task.FromResult(MessageBoxResult.None);
+    }
 
     /// <summary>
     /// Displays a dismiss-able message-box. Click outside of the message area to dismiss, configure button text in custom buttons.
     /// </summary>
-    /// <param name="dummy">The dummy.</param>
+    /// <param name="requester">The requester.</param>
     /// <param name="bbcode">The bbcode.</param>
     /// <param name="title">The title.</param>
     /// <param name="custom0">The custom0 button text.</param>
@@ -72,8 +120,22 @@ public static class MessageBoxShowMixins
     /// <returns>
     /// A Value.
     /// </returns>
-    public static Task<CustomMessageBoxResult> MessageBoxShow(this ICanShowMessages? dummy, string bbcode, string title, string custom0, string? custom1 = null, string? custom2 = null, string? custom3 = null, string? custom4 = null, string? custom5 = null, string? custom6 = null, string? custom7 = null, string? custom8 = null, string? custom9 = null) =>
-        messageBoxCustomFunc.Value?.Invoke(new Tuple<string, string, string, string?, string?, string?, string?, Tuple<string?, string?, string?, string?, string?>>(bbcode, title, custom0, custom1, custom2, custom3, custom4, new Tuple<string?, string?, string?, string?, string?>(custom5, custom6, custom7, custom8, custom9))) ?? Task.FromResult(CustomMessageBoxResult.None);
+    /// <exception cref="System.ArgumentNullException">owner.</exception>
+    /// <exception cref="System.InvalidOperationException">No listener found for message box.</exception>
+    public static Task<CustomMessageBoxResult> MessageBoxShow(this ICanShowMessages? requester, string bbcode, string title, string custom0, string? custom1 = null, string? custom2 = null, string? custom3 = null, string? custom4 = null, string? custom5 = null, string? custom6 = null, string? custom7 = null, string? custom8 = null, string? custom9 = null)
+    {
+        if (requester == null || string.IsNullOrWhiteSpace(requester.Owner))
+        {
+            throw new ArgumentNullException(nameof(requester));
+        }
+
+        if (!messageBoxCustomFunc.TryGetValue(requester.Owner, out var value))
+        {
+            throw new InvalidOperationException("No listener found for message box.");
+        }
+
+        return value.Value?.Invoke(new Tuple<string, string, string, string?, string?, string?, string?, Tuple<string?, string?, string?, string?, string?>>(bbcode, title, custom0, custom1, custom2, custom3, custom4, new Tuple<string?, string?, string?, string?, string?>(custom5, custom6, custom7, custom8, custom9))) ?? Task.FromResult(CustomMessageBoxResult.None);
+    }
 
     /// <summary>
     /// Determines whether the specified call is busy.


### PR DESCRIPTION
This pull request includes multiple changes to the `CrissCross.WPF.UI` project, focusing on improving message handling and refactoring the codebase. The most important changes include updates to the `ICanShowMessages` interface, modifications to message handling logic, and version updates.

### Interface and Class Updates:
* [`src/CrissCross.WPF.UI/MagicInterfaces/ICanShowMessages.cs`](diffhunk://#diff-70363de8b17ae504701a75cbfba9f9b590b09fde77f3c88738b5cf2a692068f0L10-R19): Added `Owner` property to the `ICanShowMessages` interface.
* [`src/CrissCross.WPF.UI/Controls/Window/Window.cs`](diffhunk://#diff-dcdbe4d354799a5d1ccec3b4d579e67f06b19f5ebbeb16303f4d28e0e39339faL12-R21): Implemented the `Owner` property in the `Window` class.
* [`src/CrissCross.WPF.UI/Controls/MessageBoxAsync/MessageBoxAsync.xaml.cs`](diffhunk://#diff-8c47d2d1a4f6471c9151a1a50314b22a87eb45c86fddddff6cb4400823be868cL19-R19): Removed the `ICanShowMessages` implementation from `MessageBoxAsync`.

### Message Handling Logic:
* [`src/CrissCross.WPF.UI/MagicInterfaces/MessageBoxShowMixins.cs`](diffhunk://#diff-0972c2b98862680eb43b5c35de694af22dc95d95fb4b5d5b06d5a29ca96d89f0L16-R17): Refactored `messageBoxFunc` and `messageBoxCustomFunc` to use dictionaries keyed by window names and updated the `ListenForMessages` and `ListenForCustomMessages` methods to handle these changes. [[1]](diffhunk://#diff-0972c2b98862680eb43b5c35de694af22dc95d95fb4b5d5b06d5a29ca96d89f0L16-R17) [[2]](diffhunk://#diff-0972c2b98862680eb43b5c35de694af22dc95d95fb4b5d5b06d5a29ca96d89f0L32-R107)
* [`src/CrissCross.WPF.UI/MagicInterfaces/MessageBoxShowMixins.cs`](diffhunk://#diff-0972c2b98862680eb43b5c35de694af22dc95d95fb4b5d5b06d5a29ca96d89f0L75-R138): Updated `MessageBoxShow` and `MessageBoxShow` methods to throw exceptions if the requester is null or no listener is found.

### Version Update:
* [`Version.json`](diffhunk://#diff-0826772c687c7936b7dbce71a16169011b0bb06f3afaca72c872f7e2d689926cL3-R3): Updated the version from `2.2.8` to `2.3.0`.