### PR TITLE
Update Navigate Back to return the target ViewModel

### DIFF
--- a/src/CrissCross.Avalonia/ViewModelRoutedViewHost.cs
+++ b/src/CrissCross.Avalonia/ViewModelRoutedViewHost.cs
@@ -222,7 +222,8 @@ public class ViewModelRoutedViewHost : ReactiveTransitioningContentControl, IVie
     /// Navigates back.
     /// </summary>
     /// <param name="parameter">The parameter.</param>
-    public void NavigateBack(object? parameter = null)
+    /// <returns>The target ViewModel.</returns>
+    public IRxObject? NavigateBack(object? parameter = null)
     {
         if (NavigateBackIsEnabled == true && CanNavigateBack == true && NavigationStack.Count > 1)
         {
@@ -245,6 +246,7 @@ public class ViewModelRoutedViewHost : ReactiveTransitioningContentControl, IVie
 
         CanNavigateBack = NavigationStack.Count > 1;
         _canNavigateBackSubject.OnNext(CanNavigateBack);
+        return _toViewModel;
     }
 
     /// <summary>

--- a/src/CrissCross.MAUI/NavigationShell.cs
+++ b/src/CrissCross.MAUI/NavigationShell.cs
@@ -231,7 +231,8 @@ public class NavigationShell : Shell, ISetNavigation, IViewModelRoutedViewHost, 
     /// Navigates back.
     /// </summary>
     /// <param name="parameter">The parameter.</param>
-    public void NavigateBack(object? parameter = null)
+    /// <returns>The target ViewModel.</returns>
+    public IRxObject? NavigateBack(object? parameter = null)
     {
         if (NavigateBackIsEnabled == true && CanNavigateBack == true && NavigationStack.Count > 1)
         {
@@ -256,6 +257,7 @@ public class NavigationShell : Shell, ISetNavigation, IViewModelRoutedViewHost, 
 
         CanNavigateBack = NavigationStack.Count > 1;
         _canNavigateBackSubject.OnNext(CanNavigateBack);
+        return _toViewModel;
     }
 
     /// <summary>

--- a/src/CrissCross.WPF.UI/Controls/BreadcrumbBar/BreadcrumbBar.cs
+++ b/src/CrissCross.WPF.UI/Controls/BreadcrumbBar/BreadcrumbBar.cs
@@ -151,6 +151,28 @@ public partial class BreadcrumbBar : System.Windows.Controls.ItemsControl, IUseH
     }
 
     /// <summary>
+    /// Navigates back and updates the Breadcrumb to remove the last item.
+    /// </summary>
+    /// <param name="parameter">The parameter.</param>
+    /// <returns>The target ViewModel.</returns>
+    /// <exception cref="System.InvalidOperationException">Host name is not set. Call SetupNavigation and pass the Host Name of the Navigation host.</exception>
+    public IRxObject? NavigateBack(object? parameter = null)
+    {
+        if (string.IsNullOrEmpty(_hostName))
+        {
+            throw new InvalidOperationException("Host name is not set. Call SetupNavigation and pass the Host Name of the Navigation host.");
+        }
+
+        if (Items.Count != 0)
+        {
+            Items.RemoveAt(Items.Count - 1);
+            return this.NavigateBack(_hostName, parameter);
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Called when [item clicked].
     /// </summary>
     /// <param name="item">The item.</param>

--- a/src/CrissCross.WPF/ViewModelRoutedViewHost.cs
+++ b/src/CrissCross.WPF/ViewModelRoutedViewHost.cs
@@ -196,7 +196,8 @@ public class ViewModelRoutedViewHost : TransitioningContentControl, IViewModelRo
     /// Navigates back.
     /// </summary>
     /// <param name="parameter">The parameter.</param>
-    public void NavigateBack(object? parameter = null)
+    /// <returns>The target ViewModel.</returns>
+    public IRxObject? NavigateBack(object? parameter = null)
     {
         if (NavigateBackIsEnabled == true && CanNavigateBack == true && NavigationStack.Count > 1)
         {
@@ -219,6 +220,7 @@ public class ViewModelRoutedViewHost : TransitioningContentControl, IViewModelRo
 
         CanNavigateBack = NavigationStack.Count > 1;
         _canNavigateBackSubject.OnNext(CanNavigateBack);
+        return _toViewModel;
     }
 
     /// <inheritdoc />

--- a/src/CrissCross.WinForms/ViewModelRoutedViewHost.cs
+++ b/src/CrissCross.WinForms/ViewModelRoutedViewHost.cs
@@ -200,7 +200,8 @@ public partial class ViewModelRoutedViewHost : UserControl, IViewModelRoutedView
     /// Navigates back.
     /// </summary>
     /// <param name="parameter">The parameter.</param>
-    public void NavigateBack(object? parameter = null)
+    /// <returns>The target ViewModel.</returns>
+    public IRxObject? NavigateBack(object? parameter = null)
     {
         if (NavigateBackIsEnabled == true && CanNavigateBack == true && NavigationStack.Count > 1)
         {
@@ -223,6 +224,7 @@ public partial class ViewModelRoutedViewHost : UserControl, IViewModelRoutedView
 
         CanNavigateBack = NavigationStack.Count > 1;
         _canNavigateBackSubject.OnNext(CanNavigateBack);
+        return _toViewModel;
     }
 
     /// <summary>

--- a/src/CrissCross.XamForms/NavigationShell.cs
+++ b/src/CrissCross.XamForms/NavigationShell.cs
@@ -227,7 +227,8 @@ public class NavigationShell : Shell, ISetNavigation, IViewModelRoutedViewHost, 
     /// Navigates back.
     /// </summary>
     /// <param name="parameter">The parameter.</param>
-    public void NavigateBack(object? parameter = null)
+    /// <returns>The target ViewModel.</returns>
+    public IRxObject? NavigateBack(object? parameter = null)
     {
         if (NavigateBackIsEnabled == true && CanNavigateBack == true && NavigationStack.Count > 1)
         {
@@ -252,6 +253,7 @@ public class NavigationShell : Shell, ISetNavigation, IViewModelRoutedViewHost, 
 
         CanNavigateBack = NavigationStack.Count > 1;
         _canNavigateBackSubject.OnNext(CanNavigateBack);
+        return _toViewModel;
     }
 
     /// <summary>

--- a/src/CrissCross.XamForms/ReactiveNavigationShell.cs
+++ b/src/CrissCross.XamForms/ReactiveNavigationShell.cs
@@ -217,7 +217,8 @@ public class ReactiveNavigationShell<TViewModel> : ReactiveShell<TViewModel>, IS
     /// Navigates back.
     /// </summary>
     /// <param name="parameter">The parameter.</param>
-    public void NavigateBack(object? parameter = null)
+    /// <returns>The target ViewModel.</returns>
+    public IRxObject? NavigateBack(object? parameter = null)
     {
         if (NavigateBackIsEnabled == true && CanNavigateBack == true && NavigationStack.Count > 1)
         {
@@ -242,6 +243,7 @@ public class ReactiveNavigationShell<TViewModel> : ReactiveShell<TViewModel>, IS
 
         CanNavigateBack = NavigationStack.Count > 1;
         _canNavigateBackSubject.OnNext(CanNavigateBack);
+        return _toViewModel;
     }
 
     /// <summary>

--- a/src/CrissCross/IViewModelRoutedViewHost.cs
+++ b/src/CrissCross/IViewModelRoutedViewHost.cs
@@ -118,7 +118,8 @@ public interface IViewModelRoutedViewHost : IActivatableView, IEnableLogger
     /// Navigates the back.
     /// </summary>
     /// <param name="parameter">The parameter.</param>
-    void NavigateBack(object? parameter = null);
+    /// <returns>The target ViewModel.</returns>
+    IRxObject? NavigateBack(object? parameter = null);
 
     /// <summary>
     /// Refreshes this instance.

--- a/src/CrissCross/ViewModelRoutedViewHostMixins.cs
+++ b/src/CrissCross/ViewModelRoutedViewHostMixins.cs
@@ -233,7 +233,9 @@ public static class ViewModelRoutedViewHostMixins
     /// <param name="dummy">The dummy.</param>
     /// <param name="hostName">Name of the host.</param>
     /// <param name="parameter">The parameter.</param>
-    public static void NavigateBack(this IUseHostedNavigation dummy, string hostName = "", object? parameter = null)
+    /// <returns>The target ViewModel.</returns>
+    /// <exception cref="System.InvalidOperationException">No navigation host registered, please ensure that the NavigationShell has a Name.</exception>
+    public static IRxObject? NavigateBack(this IUseHostedNavigation dummy, string? hostName = "", object? parameter = null)
     {
         if (NavigationHost.Count == 0)
         {
@@ -245,17 +247,18 @@ public static class ViewModelRoutedViewHostMixins
             switch (hostName.Length)
             {
                 case 0:
-                    NavigationHost.First().Value.NavigateBack(parameter);
-                    break;
+                    return NavigationHost.First().Value.NavigateBack(parameter);
                 default:
                     if (NavigationHost.TryGetValue(hostName, out var value))
                     {
-                        value.NavigateBack(parameter);
+                        return value.NavigateBack(parameter);
                     }
 
                     break;
             }
         }
+
+        return null;
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request includes changes to the `NavigateBack` method across multiple files to ensure it returns the target ViewModel instead of void. This change improves the method's usability by providing feedback on the navigation operation.

### Changes to `NavigateBack` method:

* [`src/CrissCross.Avalonia/ViewModelRoutedViewHost.cs`](diffhunk://#diff-230b9219afb56e61e6ff18146ae2157c7c2b2e30e531178edbd07cc26e9cca2dL225-R226): Modified `NavigateBack` to return `IRxObject?` and updated the method signature and body accordingly. [[1]](diffhunk://#diff-230b9219afb56e61e6ff18146ae2157c7c2b2e30e531178edbd07cc26e9cca2dL225-R226) [[2]](diffhunk://#diff-230b9219afb56e61e6ff18146ae2157c7c2b2e30e531178edbd07cc26e9cca2dR249)
* [`src/CrissCross.MAUI/NavigationShell.cs`](diffhunk://#diff-138319cfb95fa787f275277ff5eae908a86b909f8e9a815b967ec89d262057faL234-R235): Modified `NavigateBack` to return `IRxObject?` and updated the method signature and body accordingly. [[1]](diffhunk://#diff-138319cfb95fa787f275277ff5eae908a86b909f8e9a815b967ec89d262057faL234-R235) [[2]](diffhunk://#diff-138319cfb95fa787f275277ff5eae908a86b909f8e9a815b967ec89d262057faR260)
* [`src/CrissCross.WPF.UI/Controls/BreadcrumbBar/BreadcrumbBar.cs`](diffhunk://#diff-2fae5a168e0f01f5ac031f47daa0c3a6a4b22a991f3390c8f007048032be573bR153-R174): Added a new `NavigateBack` method that updates the Breadcrumb and returns `IRxObject?`.
* [`src/CrissCross.WPF/ViewModelRoutedViewHost.cs`](diffhunk://#diff-45a33f0a886bacbb562435d3d2cc20941767f31aca7a600e67eadd614339718bL199-R200): Modified `NavigateBack` to return `IRxObject?` and updated the method signature and body accordingly. [[1]](diffhunk://#diff-45a33f0a886bacbb562435d3d2cc20941767f31aca7a600e67eadd614339718bL199-R200) [[2]](diffhunk://#diff-45a33f0a886bacbb562435d3d2cc20941767f31aca7a600e67eadd614339718bR223)
* [`src/CrissCross.WinForms/ViewModelRoutedViewHost.cs`](diffhunk://#diff-2308b80214ff6120d0ccbbad81027b5e3ca797dd36eeac73963363c3f1004040L203-R204): Modified `NavigateBack` to return `IRxObject?` and updated the method signature and body accordingly. [[1]](diffhunk://#diff-2308b80214ff6120d0ccbbad81027b5e3ca797dd36eeac73963363c3f1004040L203-R204) [[2]](diffhunk://#diff-2308b80214ff6120d0ccbbad81027b5e3ca797dd36eeac73963363c3f1004040R227)
* [`src/CrissCross.XamForms/NavigationShell.cs`](diffhunk://#diff-4f0b97f793eef91793c041f5f4c9189e97db574e009e44fe4a95350c5286a84eL230-R231): Modified `NavigateBack` to return `IRxObject?` and updated the method signature and body accordingly. [[1]](diffhunk://#diff-4f0b97f793eef91793c041f5f4c9189e97db574e009e44fe4a95350c5286a84eL230-R231) [[2]](diffhunk://#diff-4f0b97f793eef91793c041f5f4c9189e97db574e009e44fe4a95350c5286a84eR256)
* [`src/CrissCross.XamForms/ReactiveNavigationShell.cs`](diffhunk://#diff-abaab48eb8b84d60c0b61f9fa6f65c085a7698984cea859ea0f71dc45cd26a0dL220-R221): Modified `NavigateBack` to return `IRxObject?` and updated the method signature and body accordingly. [[1]](diffhunk://#diff-abaab48eb8b84d60c0b61f9fa6f65c085a7698984cea859ea0f71dc45cd26a0dL220-R221) [[2]](diffhunk://#diff-abaab48eb8b84d60c0b61f9fa6f65c085a7698984cea859ea0f71dc45cd26a0dR246)
* [`src/CrissCross/IViewModelRoutedViewHost.cs`](diffhunk://#diff-1435de6d6c335421f68ecbe89fbcc5a0f9b5b668479baddc97b213d8c4570da7L121-R122): Updated the `NavigateBack` method signature to return `IRxObject?`.
* [`src/CrissCross/ViewModelRoutedViewHostMixins.cs`](diffhunk://#diff-d8429bd5f7b67993b96567b02e57af45f9e9707a499b2648c325fc6213a8e9e1L236-R238): Modified the `NavigateBack` extension method to return `IRxObject?` and updated the method signature and body accordingly. [[1]](diffhunk://#diff-d8429bd5f7b67993b96567b02e57af45f9e9707a499b2648c325fc6213a8e9e1L236-R238) [[2]](diffhunk://#diff-d8429bd5f7b67993b96567b02e57af45f9e9707a499b2648c325fc6213a8e9e1L248-R261)