### PR TITLE
Add navigation service support to NavigationModel

### DIFF
--- a/Version.json
+++ b/Version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "2.5.1",
+    "version": "2.5.2",
     "publicReleaseRefSpec": [
         "^refs/heads/master$",
         "^refs/heads/main$"

--- a/src/CrissCross.MAUI.Test/CrissCross.MAUI.Test.csproj
+++ b/src/CrissCross.MAUI.Test/CrissCross.MAUI.Test.csproj
@@ -54,8 +54,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(CoreNetVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(CoreNetVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(CoreNetVersion)" />
-    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.71" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.71" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.80" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.80" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CrissCross.MAUI/CrissCross.MAUI.csproj
+++ b/src/CrissCross.MAUI/CrissCross.MAUI.csproj
@@ -29,8 +29,8 @@
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.100" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.71" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.71" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.80" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.80" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CrissCross\CrissCross.csproj" />

--- a/src/CrissCross.WPF.Plot/CrissCross.WPF.Plot.csproj
+++ b/src/CrissCross.WPF.Plot/CrissCross.WPF.Plot.csproj
@@ -13,14 +13,14 @@
 
   <ItemGroup>
     <PackageReference Include="AppBarButton.WPF" Version="1.0.2" />
-    <PackageReference Include="ReactiveList" Version="2.2.0" />
+    <PackageReference Include="ReactiveList" Version="2.2.1" />
     <PackageReference Include="ReactiveMarbles.ObservableEvents.SourceGenerator" Version="1.3.1" PrivateAssets="all" />
     <PackageReference Include="ReactiveUI.SourceGenerators" Version="2.2.4" PrivateAssets="all" />
     <PackageReference Include="ScottPlot.WPF" Version="5.0.55" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="Polyfill" Version="8.0.0">
+    <PackageReference Include="Polyfill" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/CrissCross.WPF.UI.Gallery/ViewModels/MainWindowViewModel.cs
+++ b/src/CrissCross.WPF.UI.Gallery/ViewModels/MainWindowViewModel.cs
@@ -32,9 +32,9 @@ public partial class MainWindowViewModel : RxObject
         NavigationModels = [];
         NavigationModels.AddRange(
         [
-            new NavigationModel(null, NavigationModels) { IsExpander = true, Icon = new SymbolIcon(SymbolRegular.LineHorizontal320) },
-            new NavigationModel(typeof(MainViewModel), NavigationModels) { Name = "Main", Icon = new SymbolIcon(SymbolRegular.Home20), IsSelected = true },
-            new NavigationModel(typeof(AllControlsViewModel), NavigationModels) { Name = "All Controls", Icon = new SymbolIcon(SymbolRegular.ControlButton20) },
+            new NavigationModel(null, NavigationModels, MainWindow.Navigation) { IsExpander = true, Icon = new SymbolIcon(SymbolRegular.LineHorizontal320) },
+            new NavigationModel(typeof(MainViewModel), NavigationModels, MainWindow.Navigation) { Name = "Main", Icon = new SymbolIcon(SymbolRegular.Home20), IsSelected = true },
+            new NavigationModel(typeof(AllControlsViewModel), NavigationModels, MainWindow.Navigation) { Name = "All Controls", Icon = new SymbolIcon(SymbolRegular.ControlButton20) },
         ]);
 
         // Register ViewModels and Views

--- a/src/CrissCross.WPF.UI/Controls/NavigationControls/NavigationModel.cs
+++ b/src/CrissCross.WPF.UI/Controls/NavigationControls/NavigationModel.cs
@@ -15,6 +15,7 @@ public partial class NavigationModel : RxObject
 {
     private readonly Type? _viewModel;
     private readonly ICollection<NavigationModel> _navigationModels;
+    private readonly IUseHostedNavigation _navigationService;
 
     /// <summary>
     /// Gets or sets the name.
@@ -61,17 +62,22 @@ public partial class NavigationModel : RxObject
     [Reactive]
     private Visibility _visibility = Visibility.Visible;
 
+    [Reactive]
+    private object? _parameter;
+
     /// <summary>
-    /// Initializes a new instance of the <see cref="NavigationModel"/> class.
+    /// Initializes a new instance of the <see cref="NavigationModel" /> class.
     /// </summary>
     /// <param name="viewModel">The view model.</param>
     /// <param name="navigationModels">The navigation models.</param>
+    /// <param name="navigationService">The navigation service.</param>
     /// <exception cref="System.ArgumentNullException">navigationModels.</exception>
-    public NavigationModel(Type? viewModel, ICollection<NavigationModel> navigationModels)
+    public NavigationModel(Type? viewModel, ICollection<NavigationModel> navigationModels, IUseHostedNavigation? navigationService = null)
     {
         InitializeOAPH();
         _viewModel = viewModel;
         _navigationModels = navigationModels ?? throw new ArgumentNullException(nameof(navigationModels));
+        _navigationService = navigationService ?? this;
     }
 
     /// <summary>
@@ -113,7 +119,15 @@ public partial class NavigationModel : RxObject
             item.IsSelected = false;
         }
 
-        this.NavigateToView(_viewModel, NavigationHost);
+        if (_navigationService is BreadcrumbBar breadcrumbBar)
+        {
+            breadcrumbBar.NavigateTo(_viewModel, parameter: Parameter, breadcrumbItemContent: Name);
+        }
+        else
+        {
+            _navigationService.NavigateToView(_viewModel, hostName: NavigationHost, parameter: Parameter);
+        }
+
         IsSelected = true;
     }
 }

--- a/src/CrissCross.WPF.UI/CrissCross.WPF.UI.csproj
+++ b/src/CrissCross.WPF.UI/CrissCross.WPF.UI.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(CoreNetVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(CoreNetVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(CoreNetVersion)" />
-    <PackageReference Include="ReactiveList" Version="2.2.0" />
+    <PackageReference Include="ReactiveList" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="ReactiveMarbles.ObservableEvents.SourceGenerator" Version="1.3.1" PrivateAssets="all" />
     <PackageReference Include="AppBarButton.WPF" Version="1.0.2" />


### PR DESCRIPTION
This pull request includes several updates across multiple files, focusing on package version upgrades and enhancements to navigation functionality in the WPF UI. The most significant changes involve improving navigation services and parameters in the `NavigationModel` class, as well as updating package dependencies to newer versions.

### Package Updates:
* [`Version.json`](diffhunk://#diff-0826772c687c7936b7dbce71a16169011b0bb06f3afaca72c872f7e2d689926cL3-R3): Updated the project version from `2.5.1` to `2.5.2`.
* `CrissCross.MAUI.Test.csproj` and `CrissCross.MAUI.csproj`: Upgraded `Microsoft.Maui.Controls` and `Microsoft.Maui.Controls.Compatibility` versions from `9.0.71` to `9.0.80`. [[1]](diffhunk://#diff-238edcfd675ad182e2346e37458c4cec5cd99f24f5525ec8b8b8fc09dbe99719L57-R58) [[2]](diffhunk://#diff-e05a3d62e435a066f4b7ea34977e5d3f68059a8a4cd0cbb892ce7cdf5f00e026L32-R33)
* `CrissCross.WPF.Plot.csproj` and `CrissCross.WPF.UI.csproj`: Updated `ReactiveList` from `2.2.0` to `2.2.1` and `Polyfill` from `8.0.0` to `8.0.1`. [[1]](diffhunk://#diff-72bdbd0f21f82d6733762f5ce9d85f44dc72aa9946e288d923470df3038cda98L16-R23) [[2]](diffhunk://#diff-2689f0d76872b6abac9e346d363e175e4608a0f36dd92bb27006c07499921215L33-R33)

### Navigation Enhancements:
* [`MainWindowViewModel.cs`](diffhunk://#diff-0cdb0752967119306f8b60918d37e3eb2bf05033ed3b9a280da1068bf82060faL35-R37): Added support for `MainWindow.Navigation` in `NavigationModel` initialization to improve navigation handling.
* `NavigationModel.cs`:
  - Introduced a new field `_navigationService` to manage navigation services.
  - Added a reactive property `Parameter` to support passing parameters during navigation.
  - Enhanced the `Navigate()` method to handle navigation via `BreadcrumbBar` or other navigation services, enabling more flexible and feature-rich navigation. [[1]](diffhunk://#diff-0d240c606fbbeb7246cb917b89ad53f42616de847baf7a63b603be3a144a4ac2R18) [[2]](diffhunk://#diff-0d240c606fbbeb7246cb917b89ad53f42616de847baf7a63b603be3a144a4ac2R65-R80) [[3]](diffhunk://#diff-0d240c606fbbeb7246cb917b89ad53f42616de847baf7a63b603be3a144a4ac2L116-R130)