### PR TITLE
Add UseCrissCrossThemeManager property to NumberPad control

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,11 +29,11 @@
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
-    <AvaloniaVersion>11.3.1</AvaloniaVersion>
-    <ReactiveUIVersion>20.3.1</ReactiveUIVersion>
+    <AvaloniaVersion>11.3.4</AvaloniaVersion>
+    <ReactiveUIVersion>20.4.1</ReactiveUIVersion>
     <XamarinReactiveUIVersion>19.6.12</XamarinReactiveUIVersion>
-    <WebViewVersion>1.0.3296.44</WebViewVersion>
-    <CoreNetVersion>9.0.6</CoreNetVersion>
+    <WebViewVersion>1.0.3405.78</WebViewVersion>
+    <CoreNetVersion>9.0.8</CoreNetVersion>
     <CrissCrossCoreTargetFrameworks>netstandard2.0;net8.0;net9.0</CrissCrossCoreTargetFrameworks>
     <CrissCrossWinTargetFrameworks>net462;net472;net48;net8.0-windows10.0.17763.0;net9.0-windows10.0.17763.0</CrissCrossWinTargetFrameworks>
     <CrissCrossWebviewTargetFrameworks>net462;net472;net48;net8.0-windows;net9.0-windows</CrissCrossWebviewTargetFrameworks>
@@ -56,7 +56,7 @@
     <!--<Compile Update="**\*.cs" DependentUpon="I%(Filename).cs" />-->
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115" PrivateAssets="all" Condition="!Exists('packages.config')" />
     <PackageReference Include="stylecop.analyzers" Version="1.2.0-beta.556" PrivateAssets="all" />
-    <PackageReference Include="Roslynator.Analyzers" Version="4.13.1" PrivateAssets="All" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.14.0" PrivateAssets="All" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 </Project>

--- a/Version.json
+++ b/Version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "2.5.2",
+    "version": "2.5.3",
     "publicReleaseRefSpec": [
         "^refs/heads/master$",
         "^refs/heads/main$"

--- a/src/CrissCross.Avalonia.Test.Android/CrissCross.Avalonia.Test.Android.csproj
+++ b/src/CrissCross.Avalonia.Test.Android/CrissCross.Avalonia.Test.Android.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia.Android" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.16" />
+    <PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.17" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CrissCross.MAUI.Test/CrissCross.MAUI.Test.csproj
+++ b/src/CrissCross.MAUI.Test/CrissCross.MAUI.Test.csproj
@@ -54,8 +54,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(CoreNetVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(CoreNetVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(CoreNetVersion)" />
-    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.80" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.80" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.100" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.100" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CrissCross.MAUI/CrissCross.MAUI.csproj
+++ b/src/CrissCross.MAUI/CrissCross.MAUI.csproj
@@ -19,7 +19,6 @@
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CompiledBindings.MAUI" Version="1.0.18" />
     <PackageReference Include="ReactiveUI.Maui" Version="$(ReactiveUIVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(CoreNetVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(CoreNetVersion)" />    
@@ -29,8 +28,8 @@
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.100" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.80" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.80" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.100" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.100" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CrissCross\CrissCross.csproj" />

--- a/src/CrissCross.WPF.Plot.Test/CrissCross.WPF.Plot.Test.csproj
+++ b/src/CrissCross.WPF.Plot.Test/CrissCross.WPF.Plot.Test.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="ReactiveMarbles.ObservableEvents.SourceGenerator" Version="1.3.1" PrivateAssets="all" />
-    <PackageReference Include="ReactiveUI.SourceGenerators" Version="2.2.4" PrivateAssets="all" />
+    <PackageReference Include="ReactiveUI.SourceGenerators" Version="2.3.1" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CrissCross.WPF.Plot/CrissCross.WPF.Plot.csproj
+++ b/src/CrissCross.WPF.Plot/CrissCross.WPF.Plot.csproj
@@ -15,12 +15,12 @@
     <PackageReference Include="AppBarButton.WPF" Version="1.0.2" />
     <PackageReference Include="ReactiveList" Version="2.2.1" />
     <PackageReference Include="ReactiveMarbles.ObservableEvents.SourceGenerator" Version="1.3.1" PrivateAssets="all" />
-    <PackageReference Include="ReactiveUI.SourceGenerators" Version="2.2.4" PrivateAssets="all" />
-    <PackageReference Include="ScottPlot.WPF" Version="5.0.55" />
+    <PackageReference Include="ReactiveUI.SourceGenerators" Version="2.3.1" PrivateAssets="all" />
+    <PackageReference Include="ScottPlot.WPF" Version="5.0.56" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="Polyfill" Version="8.0.1">
+    <PackageReference Include="Polyfill" Version="8.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/CrissCross.WPF.UI.Gallery/CrissCross.WPF.UI.Gallery.csproj
+++ b/src/CrissCross.WPF.UI.Gallery/CrissCross.WPF.UI.Gallery.csproj
@@ -16,8 +16,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ReactiveUI.SourceGenerators" Version="2.2.4" PrivateAssets="all" />
-    <PackageReference Include="CompiledBindings.WPF" Version="1.0.18" />
+    <PackageReference Include="ReactiveUI.SourceGenerators" Version="2.3.1" PrivateAssets="all" />
+    <PackageReference Include="CompiledBindings.WPF" Version="1.0.19" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CrissCross.WPF.UI.Gallery/Views/BasicControls/NumericPushButtonView.xaml
+++ b/src/CrissCross.WPF.UI.Gallery/Views/BasicControls/NumericPushButtonView.xaml
@@ -40,7 +40,10 @@
                 <RowDefinition />
             </Grid.RowDefinitions>
             <ui:NumericPushButton Margin="5" UseSeperateEditValue="True" />
-            <ui:NumericPushButton Grid.Column="1" Margin="5" />
+            <ui:NumericPushButton
+                Grid.Column="1"
+                Margin="5"
+                UseCrissCrossThemeManager="False" />
 
             <ui:NumericPushButton Grid.Column="3" Margin="5" />
             <ui:NumericPushButton Grid.Row="1" Margin="5" />

--- a/src/CrissCross.WPF.UI/Controls/NumberPad/NumberPad.xaml
+++ b/src/CrissCross.WPF.UI/Controls/NumberPad/NumberPad.xaml
@@ -17,12 +17,9 @@
     <Window.Background>
         <SolidColorBrush Opacity="0" Color="#00000000" />
     </Window.Background>
-    <Grid>
-        <Grid
-            x:Name="Mask"
-            Background="{Binding MaskColor}"
-            Opacity="0.1" />
-        <Grid
+    <controls:Grid>
+        <controls:Grid x:Name="Mask" Opacity="0.1" />
+        <controls:Grid
             x:Name="WGrid"
             Width="206"
             Height="366"
@@ -31,16 +28,16 @@
             VerticalAlignment="Top"
             Background="{DynamicResource ApplicationBackgroundBrush}"
             Opacity="1">
-            <StackPanel
+            <controls:StackPanel
                 Margin="8"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center">
-                <Border
+                <controls:Border
                     Width="184"
                     Height="40"
                     BorderBrush="Black"
                     BorderThickness="1">
-                    <StackPanel
+                    <controls:StackPanel
                         HorizontalAlignment="Right"
                         VerticalAlignment="Center"
                         Orientation="Horizontal">
@@ -55,7 +52,7 @@
                             SpinButtonPlacementMode="Hidden"
                             Text="0"
                             TextAlignment="Right" />
-                        <Label
+                        <controls:Label
                             x:Name="Unit"
                             Width="55"
                             VerticalAlignment="Center"
@@ -63,9 +60,9 @@
                             Content="Unit"
                             FontFamily="Tahoma"
                             FontSize="19" />
-                    </StackPanel>
-                </Border>
-                <StackPanel Margin="0,8,0,0" Orientation="Horizontal">
+                    </controls:StackPanel>
+                </controls:Border>
+                <controls:StackPanel Margin="0,8,0,0" Orientation="Horizontal">
                     <controls:Button
                         Width="56"
                         Height="48"
@@ -101,8 +98,8 @@
                             Text="9"
                             TextDecorations="Underline" />
                     </controls:Button>
-                </StackPanel>
-                <StackPanel Margin="0,8,0,0" Orientation="Horizontal">
+                </controls:StackPanel>
+                <controls:StackPanel Margin="0,8,0,0" Orientation="Horizontal">
                     <controls:Button
                         Width="56"
                         Height="48"
@@ -138,8 +135,8 @@
                             Text="6"
                             TextDecorations="Underline" />
                     </controls:Button>
-                </StackPanel>
-                <StackPanel Margin="0,8,0,0" Orientation="Horizontal">
+                </controls:StackPanel>
+                <controls:StackPanel Margin="0,8,0,0" Orientation="Horizontal">
                     <controls:Button
                         Width="56"
                         Height="48"
@@ -175,8 +172,8 @@
                             Text="3"
                             TextDecorations="Underline" />
                     </controls:Button>
-                </StackPanel>
-                <StackPanel Margin="0,8,0,0" Orientation="Horizontal">
+                </controls:StackPanel>
+                <controls:StackPanel Margin="0,8,0,0" Orientation="Horizontal">
                     <controls:Button
                         Width="56"
                         Height="48"
@@ -210,8 +207,8 @@
                             FontSize="19"
                             Text="-" />
                     </controls:Button>
-                </StackPanel>
-                <StackPanel Margin="0,8,0,0" Orientation="Horizontal">
+                </controls:StackPanel>
+                <controls:StackPanel Margin="0,8,0,0" Orientation="Horizontal">
                     <controls:Button
                         x:Name="CancelBtn"
                         Width="56"
@@ -241,8 +238,8 @@
                         FontSize="48"
                         FontWeight="Bold"
                         Foreground="White" />
-                </StackPanel>
-            </StackPanel>
-        </Grid>
-    </Grid>
+                </controls:StackPanel>
+            </controls:StackPanel>
+        </controls:Grid>
+    </controls:Grid>
 </Window>

--- a/src/CrissCross.WPF.UI/Controls/NumberPad/NumberPad.xaml.cs
+++ b/src/CrissCross.WPF.UI/Controls/NumberPad/NumberPad.xaml.cs
@@ -36,6 +36,16 @@ public partial class NumberPad : IDisposable
             typeof(NumberPad),
             new PropertyMetadata(Brushes.Black, UpdateMask));
 
+    /// <summary>
+    /// The use criss cross theme manager property.
+    /// </summary>
+    public static readonly DependencyProperty UseCrissCrossThemeManagerProperty =
+        DependencyProperty.Register(
+            nameof(UseCrissCrossThemeManager),
+            typeof(bool),
+            typeof(NumberPad),
+            new PropertyMetadata(true));
+
     private readonly CompositeDisposable _disposables = [];
     private readonly DispatcherTimer _limitsTimer;
     private readonly double[] _margin = new double[4];
@@ -59,7 +69,11 @@ public partial class NumberPad : IDisposable
         }
 
         DataContext = this;
-        SystemThemeWatcher.Watch(this);
+        if (UseCrissCrossThemeManager)
+        {
+            SystemThemeWatcher.Watch(this);
+        }
+
         InitializeComponent();
         Unit.Content = _owner.Units;
         _owner.IsEnabled = false;
@@ -118,9 +132,25 @@ public partial class NumberPad : IDisposable
     /// Gets or sets the color of the mask.
     /// </summary>
     /// <value>The color of the mask.</value>
+    [Description("Sets MaskColor of the Keypad")]
+    [Category("Brush")]
     public Brush MaskColor
     {
         get => (Brush)GetValue(MaskColorProperty); set => SetValue(MaskColorProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether [use criss cross theme manager].
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if [use criss cross theme manager]; otherwise, <c>false</c>.
+    /// </value>
+    [Description("Gets or sets a value indicating whether to use CrissCross Theme Manager or not")]
+    [Category("Common")]
+    public bool UseCrissCrossThemeManager
+    {
+        get => (bool)GetValue(UseCrissCrossThemeManagerProperty);
+        set => SetValue(UseCrissCrossThemeManagerProperty, value);
     }
 
     /// <summary>
@@ -213,7 +243,6 @@ public partial class NumberPad : IDisposable
         if (value > _owner.Maximum || value < _owner.Minimum)
         {
             _limitsTimer.Start();
-            ////Value.Background = Brushes.Orange;
             Accept.IsEnabled = false;
         }
 

--- a/src/CrissCross.WPF.UI/Controls/NumericPushButton/NumericPushButton.cs
+++ b/src/CrissCross.WPF.UI/Controls/NumericPushButton/NumericPushButton.cs
@@ -136,6 +136,16 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
             typeof(NumericPushButton),
             new PropertyMetadata(0d, UpdateValue));
 
+    /// <summary>
+    /// The use criss cross theme manager property.
+    /// </summary>
+    public static readonly DependencyProperty UseCrissCrossThemeManagerProperty =
+        DependencyProperty.Register(
+            nameof(UseCrissCrossThemeManager),
+            typeof(bool),
+            typeof(NumericPushButton),
+            new PropertyMetadata(true, UpdateUseCrissCross));
+
     private readonly DispatcherTimer _errrorTimer;
     private readonly DispatcherTimer _isEnabledFalseTimer;
     private readonly ReplaySubject<(bool UserChanged, double Value)> _valueD = new(1);
@@ -213,6 +223,20 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
     public event EventHandler<(bool, double)>? ValueChanged;
 
     /// <summary>
+    /// Gets or sets a value indicating whether [use criss cross theme manager].
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if [use criss cross theme manager]; otherwise, <c>false</c>.
+    /// </value>
+    [Description("Gets or sets a value indicating whether to use CrissCross Theme Manager or not")]
+    [Category("Common")]
+    public bool UseCrissCrossThemeManager
+    {
+        get => (bool)GetValue(UseCrissCrossThemeManagerProperty);
+        set => SetValue(UseCrissCrossThemeManagerProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets how many decimal places to visualize.
     /// </summary>
     [Description("Gets or sets how many decimal places to visualize")]
@@ -220,7 +244,6 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
     public int DecimalPlaces
     {
         get => (int)GetValue(DecimalPlacesProperty);
-
         set => SetValue(DecimalPlacesProperty, value);
     }
 
@@ -233,7 +256,6 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
     public string ErrorText
     {
         get => (string)GetValue(ErrorTextProperty);
-
         set => SetValue(ErrorTextProperty, value);
     }
 
@@ -246,7 +268,6 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
     public Visibility ErrorVisible
     {
         get => (Visibility)GetValue(ErrorVisibleProperty);
-
         set => SetValue(ErrorVisibleProperty, value);
     }
 
@@ -259,7 +280,6 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
     public Brush MaskColor
     {
         get => (Brush)GetValue(MaskColorProperty);
-
         set => SetValue(MaskColorProperty, value);
     }
 
@@ -271,7 +291,6 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
     public double? Maximum
     {
         get => (double?)GetValue(MaximumProperty);
-
         set => SetValue(MaximumProperty, value);
     }
 
@@ -283,7 +302,6 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
     public double? Minimum
     {
         get => (double?)GetValue(MinimumProperty);
-
         set => SetValue(MinimumProperty, value);
     }
 
@@ -294,7 +312,6 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
     public ReactiveCommand<Unit, Unit> ShowKeypad
     {
         get => (ReactiveCommand<Unit, Unit>)GetValue(ShowKeypadProperty);
-
         set => SetValue(ShowKeypadProperty, value);
     }
 
@@ -306,7 +323,6 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
     public string Units
     {
         get => (string)GetValue(UnitsProperty);
-
         set => SetValue(UnitsProperty, value);
     }
 
@@ -319,7 +335,6 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
     public bool UnitsOnNewLine
     {
         get => (bool)GetValue(UnitsOnNewLineProperty);
-
         set => SetValue(UnitsOnNewLineProperty, value);
     }
 
@@ -332,7 +347,6 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
     public bool UseSeperateEditValue
     {
         get => (bool)GetValue(UseSeperateEditValueProperty);
-
         set => SetValue(UseSeperateEditValueProperty, value);
     }
 
@@ -350,7 +364,6 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
     public double Value
     {
         get => (double)GetValue(ValueProperty);
-
         set => SetValue(ValueProperty, value);
     }
 
@@ -362,7 +375,6 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
     public double EditedValue
     {
         get => (double)GetValue(EditedValueProperty);
-
         set => SetValue(EditedValueProperty, value);
     }
 
@@ -528,6 +540,20 @@ public class NumericPushButton : System.Windows.Controls.Button, INumberPadButto
         if (d is NumericPushButton sb && e.OldValue != e.NewValue)
         {
             sb.UpdateSpinButtonContent();
+        }
+    }
+
+    /// <summary>
+    /// Updates the use criss cross.
+    /// </summary>
+    /// <param name="d">The d.</param>
+    /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs"/> instance containing the event data.</param>
+    private static void UpdateUseCrissCross(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is NumericPushButton c && c._keypad is NumberPad keypad)
+        {
+            c.UseCrissCrossThemeManager = (bool)e.NewValue;
+            keypad.UseCrissCrossThemeManager = c.UseCrissCrossThemeManager;
         }
     }
 

--- a/src/CrissCross.WPF.UI/Controls/NumericPushButton/NumericPushButton.xaml
+++ b/src/CrissCross.WPF.UI/Controls/NumericPushButton/NumericPushButton.xaml
@@ -7,7 +7,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type controls:NumericPushButton}">
-                    <Grid
+                    <controls:Grid
                         Width="{TemplateBinding ActualWidth}"
                         Height="{TemplateBinding ActualHeight}"
                         HorizontalAlignment="Center"
@@ -18,7 +18,7 @@
                             RadiusX="{DynamicResource ControlCornerRadiusSize}"
                             RadiusY="{DynamicResource ControlCornerRadiusSize}"
                             StrokeThickness="{TemplateBinding BorderThickness}" />
-                        <Grid Margin="{TemplateBinding BorderThickness}">
+                        <controls:Grid Margin="{TemplateBinding BorderThickness}">
                             <controls:Button
                                 x:Name="btn"
                                 HorizontalAlignment="Stretch"
@@ -43,8 +43,8 @@
                                 TextAlignment="Center"
                                 TextWrapping="Wrap"
                                 Visibility="{TemplateBinding ErrorVisible}" />
-                        </Grid>
-                    </Grid>
+                        </controls:Grid>
+                    </controls:Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="btn" Property="Background" Value="{DynamicResource ButtonBackgroundDisabled}" />

--- a/src/CrissCross.WPF.UI/CrissCross.WPF.UI.csproj
+++ b/src/CrissCross.WPF.UI/CrissCross.WPF.UI.csproj
@@ -37,8 +37,7 @@
     <PackageReference Include="BBCode.WPF" Version="0.2.0" />
     <PackageReference Include="CP.Xaml.Converters" Version="1.0.2" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
-    <PackageReference Include="CompiledBindings.WPF" Version="1.0.18" />
-    <PackageReference Include="ReactiveUI.SourceGenerators" Version="2.2.4" PrivateAssets="all" />
+    <PackageReference Include="ReactiveUI.SourceGenerators" Version="2.3.1" PrivateAssets="all" />
     <PackageReference Include="PolySharp" Version="1.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/CrissCross.XamForms/CrissCross.XamForms.csproj
+++ b/src/CrissCross.XamForms/CrissCross.XamForms.csproj
@@ -7,7 +7,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CompiledBindings.XF" Version="1.0.18" />
 		<PackageReference Include="ReactiveUI.XamForms" Version="$(XamarinReactiveUIVersion)" />
 	</ItemGroup>
 


### PR DESCRIPTION
Introduces the UseCrissCrossThemeManager property to NumberPad and NumericPushButton controls, allowing opt-out of automatic theme management. Updates related XAML and usage in the UI Gallery. Also updates multiple package dependencies and increments the project version.