### PR TITLE
Add .NET 10 support and update MAUI dependencies

### DIFF
--- a/.github/workflows/BuildDeploy.yml
+++ b/.github/workflows/BuildDeploy.yml
@@ -47,9 +47,9 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
             8.0.x
             9.0.x
+            10.0.x
 
       - name: Get Latest Visual Studio Version
         shell: bash

--- a/.github/workflows/BuildOnly.yml
+++ b/.github/workflows/BuildOnly.yml
@@ -42,9 +42,9 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
             8.0.x
             9.0.x
+            10.0.x
 
       - name: Get Latest Visual Studio Version
         shell: bash

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,10 +34,10 @@
     <ReactiveUIVersion>21.0.1</ReactiveUIVersion>
     <XamarinReactiveUIVersion>19.6.12</XamarinReactiveUIVersion>
     <WebViewVersion>1.0.3485.44</WebViewVersion>
-    <CoreNetVersion>9.0.9</CoreNetVersion>
-    <CrissCrossCoreTargetFrameworks>netstandard2.0;net8.0;net9.0</CrissCrossCoreTargetFrameworks>
-    <CrissCrossWinTargetFrameworks>net472;net48;net8.0-windows10.0.17763.0;net9.0-windows10.0.17763.0</CrissCrossWinTargetFrameworks>
-    <CrissCrossWebviewTargetFrameworks>net472;net48;net8.0-windows;net9.0-windows</CrissCrossWebviewTargetFrameworks>
+    <CoreNetVersion>10.0.0-rc.*</CoreNetVersion>
+    <CrissCrossCoreTargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</CrissCrossCoreTargetFrameworks>
+    <CrissCrossWinTargetFrameworks>net472;net48;net8.0-windows10.0.17763.0;net9.0-windows10.0.17763.0;net10.0-windows10.0.17763.0</CrissCrossWinTargetFrameworks>
+    <CrissCrossWebviewTargetFrameworks>net472;net48;net8.0-windows;net9.0-windows;net10.0-windows</CrissCrossWebviewTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/src/CrissCross.MAUI.Benchmarks/CrissCross.MAUI.Benchmarks.csproj
+++ b/src/CrissCross.MAUI.Benchmarks/CrissCross.MAUI.Benchmarks.csproj
@@ -8,14 +8,14 @@
     <EnablePreviewMsixTooling>false</EnablePreviewMsixTooling>
     <SelfContained>false</SelfContained>
     <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
-    <Platforms>x64;arm64</Platforms>
+    <Platforms>x64;</Platforms>
     <PlatformTarget>x64</PlatformTarget>
-    <RuntimeIdentifiers>win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
-    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.100" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.110" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CrissCross.MAUI\CrissCross.MAUI.csproj" />

--- a/src/CrissCross.MAUI.Test/CrissCross.MAUI.Test.csproj
+++ b/src/CrissCross.MAUI.Test/CrissCross.MAUI.Test.csproj
@@ -54,8 +54,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(CoreNetVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(CoreNetVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(CoreNetVersion)" />
-    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.100" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.100" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.110" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.110" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CrissCross.MAUI/CrissCross.MAUI.csproj
+++ b/src/CrissCross.MAUI/CrissCross.MAUI.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -15,7 +15,7 @@
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0'))">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net9.0')) or $(TargetFramework.StartsWith('net10.0'))">
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
   <ItemGroup>
@@ -23,13 +23,13 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(CoreNetVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(CoreNetVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net8'))">
-    <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.100" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.100" />
-  </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
-    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.100" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.100" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.110" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.110" />
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net10'))">
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.0-rc.*" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.0-rc.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CrissCross\CrissCross.csproj" />


### PR DESCRIPTION
This commit updates build workflows, project files, and target frameworks to add support for .NET 10. It also updates Microsoft.Maui.Controls and related package versions to 9.0.110 and introduces 10.0.0-rc.* for .NET 10. Platform and runtime identifiers are adjusted in the benchmarks project, and obsolete .NET 8 references are removed from the main MAUI project.