### PR TITLE
feat(ui): standardize cross-platform controls and navigation

### DIFF
--- a/docs/navigation-property-migration.md
+++ b/docs/navigation-property-migration.md
@@ -1,0 +1,16 @@
+# Avalonia navigation property ownership
+
+`NavigationWindow.ViewModelProperty` and `NavigationUserControl.ViewModelProperty`
+are now registered on the non-generic base classes as `StyledProperty<object?>`.
+All closed generic navigation types share those property registrations. This
+makes the properties addressable from XAML and removes the AVP1002 suppressions.
+
+`NavigationWindow<TViewModel>.ViewModel` and
+`NavigationUserControl<TViewModel>.ViewModel` remain strongly typed. Ordinary
+view-model assignment and `IViewFor<TViewModel>` usage require no changes.
+
+Code that explicitly declares the property handle as
+`StyledProperty<TViewModel?>` must use `StyledProperty<object?>` instead. Code
+reading a value through the untyped Avalonia property API must cast the result,
+or use the strongly typed `ViewModel` property. This public handle-type change
+was approved for this update and should be called out in the next release notes.

--- a/docs/quality-audit.md
+++ b/docs/quality-audit.md
@@ -1,0 +1,70 @@
+# Quality and parity validation
+
+Date: 2026-09-07
+
+## Changes
+
+- Fixed pagination integer overflow and added boundary tests.
+- Added immutable process-value state with invalid-configuration, data-quality, and inclusive alarm thresholds. WPF, Avalonia, and MAUI provide a `ProcessValueIndicator` with the same state projections, compact layout, typography, and semantic status colors. Each gallery includes operating, alarm, and unavailable examples.
+- Moved Avalonia navigation `ViewModelProperty` ownership to non-generic base classes. The typed `ViewModel` wrappers remain; the public property-handle migration is documented in `navigation-property-migration.md`.
+- Added stable logical navigation host names, idempotent setup subscriptions, and disposal of desktop window hosts. Unregistration checks reference identity before removing aliases belonging to a host.
+- Fixed plot crosshair subscription replacement and WebView2 pending-window handler disposal. Regressions exercise runtime lifecycle behavior.
+- Adopted `ReactiveUI.Binding` observable primitives and generated `ReactiveUI.Primitives.ObservableEvents` in WPF plot views, retaining the existing ReactiveUI view contract for command bindings. Binding dispatch generation emitted no implementations for these WPF call sites, so calling its generated-only fallback methods caused an activation exception despite a clean build; explicit Binding primitives replace those calls.
+- Corrected the GIF stream factory's accidental self-recursion.
+- Removed production `SuppressMessage` attributes and all tracked `NoWarn` project/build entries. Analyzer fixes change code rather than introduce suppressions. Existing `.editorconfig` diagnostic configuration remains in effect.
+- Added explicit Avalonia high contrast resources. Runtime startup requires the custom variant key to be referenced with `x:Static`; a string key compiles but fails when the gallery loads.
+- Corrected Avalonia navigation attachment names and transition cancellation. Native gallery navigation now renders the current view; rapid replacement and disposal tests cover both standard and reactive hosts.
+- Avalonia wrapper themes reuse native templates explicitly while retaining CrissCross style selection. Rendering tests verify workflow templates, filter removal, chip command fallback, null-state clearing, and derived button styling. Native checks confirm filter labels/actions, workflow step navigation, and navigation after closing another window.
+- Added all nine Avalonia button appearances, semantic hover/pressed/disabled brushes, and derived command-button templates. Rendering tests check each appearance in Light, Dark, and HighContrast, including disabling a pressed button.
+- Corrected Avalonia disabled text opacity in HighContrast, retained compact wrapping for filter/chip items, and added wrapping to long gallery checkbox labels.
+- Corrected Gel button foregrounds and modern checkbox selection glyphs to use the active accent foreground. Their disabled opacity now remains fully visible in HighContrast; attached-window tests cover Light, Dark, and HighContrast.
+- Replaced 85 red placeholder color values in each WPF high-contrast palette with palette-consistent resources and distinct success/caution/critical colors. Four native resource-loading tests cover the status regression.
+- Fixed the Avalonia gallery import Cancel action to cancel its operation instead of clearing the query. Filter removal and clear actions preserve subsequent query changes.
+- Added actual MAUI busy, validation, empty-state, stepper, filter, property editor, date-range, pagination, and form-field compositions. Tests exercise content preservation, command availability, nullable dates and per-endpoint offsets, and theme changes.
+- Avalonia tests use a dedicated native dispatcher and TUnit executor; MAUI handler-free tests install a deterministic binding dispatcher.
+
+## Verification recorded so far
+
+These are fresh, bounded results, not a claim of whole-solution coverage or absence of bugs. Later integration runs supersede these results when source changes affect the tested projects.
+
+| Verification | Result |
+| --- | --- |
+| Full solution Release build with warnings as errors, `build-full12.log` | 0 warnings, 0 errors; completed in 7m 33s on Windows after the final source changes |
+| Core/MAUI TUnit suite, `test-core-final16.log` | 305 passed |
+| Reactive TUnit suite, `test-reactive-final2.log` | 155 passed |
+| Navigation TUnit suite, `test-navigation-final28.log` | 137 passed |
+| WPF gallery TUnit suite, `test-wpf-gallery-final10.log` | 32 passed |
+| Standard and reactive plot TUnit suites, `test-plot-final6.log` and `test-reactive-plot-final2.log` | 41 passed each |
+| WPF.UI coverage in its gallery test report | 52.44% lines; 21.47% branches |
+| Avalonia.UI coverage in the navigation test report | 60.65% lines; 41.97% branches |
+| Avalonia.UI.Reactive coverage in the navigation test report | 47.47% lines; 14.99% branches |
+| Shared core coverage from the core run | 99.94% lines (1792/1793); 94.93% branches (712/750) |
+| MAUI.UI coverage from the core run | 92.12% lines (1812/1967); 71.52% branches (545/762) |
+| `ProcessValueState` coverage | 100% lines and branches |
+| MAUI `ProcessValueIndicator` coverage | 100% lines and branches, including arranged range width and theme changes |
+| WPF.UI non-incremental net10 Windows analyzer build, pass 14 | 0 warnings, 0 errors |
+| Avalonia gallery net10 analyzer build, pass 8 | 0 warnings, 0 errors |
+| Avalonia gallery native launch | Final industrial layout verified in Dark, Light, HighContrast; first window navigates after closing the second; selection labels readable |
+| MAUI gallery Windows build, `build-maui-gallery-final3.log` | 0 warnings, 0 errors |
+| MAUI gallery native launch | Busy overlay, step navigation, property edit/commit, readable avatar initials, and HighContrast → Light → Dark → HighContrast switching verified after ReactiveUI startup registration |
+
+Coverage was inspected through Mtpunittestmcp using individual fresh Cobertura reports. Old reports from earlier runs must not be merged to represent current coverage. Test execution uses TUnit and Microsoft Testing Platform with builds enabled.
+
+## Integrated validation
+
+- The full solution build passed with warnings as errors across the target frameworks configured by the solution on this Windows host. The final source was unchanged throughout this build.
+- All six TUnit projects have passed with fresh per-run coverage (711 tests), including the modern checkbox selection-glyph correction.
+- Native Avalonia checks verify Gel button contrast, wrapped checkbox labels, compact filter tokens and removal, step navigation, and revised radio/icon resources. The corrected modern checkbox selection glyph was also verified in HighContrast and Light.
+- The original two-window gallery reproduction and real-host automated regression now pass after preserving owner host identity.
+- The six passing suites include high contrast resource loading, navigation cleanup, GIF stream factory, plot binding/subscription lifetime, and WebView2 pending-window lifecycle regressions. These bounded checks do not replace native device testing for every supported platform.
+
+## Remaining parity boundaries
+
+WPF/Avalonia wrappers and native MAUI equivalents are not automatically equivalent just because similarly named controls exist. The [Avalonia inventory](../src/CrissCross.Avalonia.UI/UI-PARITY.md), [MAUI inventory](../src/CrissCross.Maui.UI/UI-PARITY.md), and [theme audit](theme-parity-audit.md) describe remaining gaps.
+
+- MAUI exposes 28 composed controls; desktop-capable gaps include rich text, media, virtualization, plotting, and window/dialog hosting. Mobile size constraints do not account for all these gaps.
+- Avalonia `Frame` and `Page` remain compatibility wrappers without WPF-equivalent navigation behavior.
+- WPF has four named high-contrast palettes; Avalonia and MAUI currently expose one explicit palette. Complete control-by-control visual and interaction parity remains unverified.
+- Desktop UI branch coverage remains substantially below 100%, and supported mobile devices have not received full native visual and interaction validation.
+
+This work does not claim complete UI parity, 100% whole-solution coverage, or a proof that no bugs remain.

--- a/docs/theme-parity-audit.md
+++ b/docs/theme-parity-audit.md
@@ -1,0 +1,28 @@
+# Theme parity audit
+
+This audit distinguishes resource parity from rendered control parity. Equal resource keys or similarly named classes alone do not establish the same appearance or behavior.
+
+## Implemented corrections
+
+- Avalonia provides Light, Dark, and explicit HighContrast dictionaries with the same 276 semantic resource keys. The custom high-contrast variant inherits Dark and is registered with an `x:Static` key so resource loading succeeds at runtime.
+- Avalonia theme selection round-trips HighContrast through `ApplicationThemeManager`.
+- WPF theme detection recognizes its existing HC1, HC2, HCBlack, and HCWhite resource dictionaries.
+- MAUI provides dynamic semantic resources for Light, Dark, and HighContrast. Default and System selection follow application theme changes; explicit choices remain fixed. Theme dictionary replacement avoids accumulating obsolete overrides.
+- Avalonia thin wrappers reuse native control themes through explicit theme setters. Their own style keys remain available for CrissCross typography, appearance and behavior selectors; inherited native style keys previously bypassed those selectors. Workflow controls retain their dedicated item templates. Fresh rendering tests verify this integration.
+- Avalonia CheckBox and RadioButton string content inherits the semantic foreground, including the disabled state.
+- The new ProcessValueIndicator uses shared state, typography, spacing, a range bar, and semantic condition colors across WPF, Avalonia, and MAUI. Each gallery demonstrates nominal, alarm, and bad-quality readings.
+
+## Evidence and validation boundaries
+
+The Avalonia gallery was launched natively in Dark, Light, and HighContrast. This exposed and led to fixes for an invalid theme dictionary key and missing Expander headers. The compact process readout and all nine button appearances were verified in Dark, Light, and HighContrast. RadioButton checked indicators have been verified in Light and HighContrast; button icons are readable across the three themes. Rendering tests verify button hover/pressed/disabled states. Native HighContrast checks also verify readable disabled radio labels, Gel button text, wrapped checkbox labels, compact filter tokens and removal, and workflow step navigation. Modern checkbox selection glyphs now use the semantic accent foreground, with native HighContrast and Light checks and automated coverage across all three themes.
+
+The final full solution Release build passed with warnings treated as errors: zero warnings and zero errors. All six TUnit/MTP suites passed (711 tests). Project NoWarn entries were removed; see `quality-audit.md` for exact build, test, and coverage results.
+
+Tests cover semantic key completeness, contrast calculations, theme variant ownership, state projections, and resource switching. A source-resource assertion is not a substitute for rendered visual verification.
+
+## Remaining boundaries
+
+- WPF has four named high-contrast palettes; Avalonia and MAUI expose one explicit high-contrast palette.
+- Native platform controls can differ in rendering, sizing, focus, accessibility, and interaction even when their semantic colors match.
+- MAUI currently exposes 28 composed controls. Desktop-capable gaps include rich text, media, virtualization, plotting, and window/dialog hosting. These gaps cannot all be justified by mobile screen constraints.
+- Complete gallery control-by-control visual and functional parity, including all supported mobile devices, has not yet been established.

--- a/docs/ui-navigation-control-parity-implementation.md
+++ b/docs/ui-navigation-control-parity-implementation.md
@@ -2,6 +2,8 @@
 
 Task: `t_4d34bae8`.
 
+This document records the original implementation scope. The current integration results and remaining cross-platform boundaries are recorded in [quality-audit.md](quality-audit.md) and [theme-parity-audit.md](theme-parity-audit.md), updated on 2026-09-07.
+
 ## Implemented
 
 - Added a platform-neutral `CrissCross.NavigationJournal` helper for back/forward journal behavior.
@@ -120,12 +122,12 @@ The new property inspector keeps settings/admin/designer inspection platform-neu
 ## Remaining platform-specific gaps
 
 - WPF retains richer `NavigationVMLeft`/`NavigationVMTop` user-control styles, while Avalonia exposes `NavigationControls`; exact one-to-one API parity still needs a design decision before adding duplicate abstractions.
-- High-contrast resources remain WPF-only.
+- WPF provides four high-contrast palettes; Avalonia and MAUI now provide an explicit HighContrast theme. Exact palette parity remains open.
 - Gallery parity for Avalonia navigation, text, media, numeric, toggle, password, and tree pages is not covered by this slice.
-- Filter-token remove buttons are compile-verified but not yet wired to an Avalonia item-level command binding in the default template; consumers can still bind/remodel token removal through `FilterBar.RemoveFilterCommand` from custom templates.
-- Chip, ChipGroup, SegmentedControl, DataPager, Stepper, and DateTimeRangePicker styles are compile-verified but not manually rendered in WPF/Avalonia galleries.
+- Avalonia filter-token removal now binds the owning `FilterBar.RemoveFilterCommand` with the token payload. Native gallery interaction and rendering tests verify this behavior.
+- Avalonia ChipGroup and Stepper now have rendering and command-dispatch tests, and workflow step navigation has been verified in the native gallery. Complete control-by-control visual parity across all galleries remains open.
 - DataPager emits page requests and exposes navigation command hooks, but page-size picker and numbered-page templates remain future visual polish.
 - DateTimeRangePicker emits deterministic range snapshots and presets; richer shortcut menus, timezone labels, and validation integration with `ReactiveFormField` remain future visual/API polish.
-- ThemeSwitcher styles are compile-verified but not manually rendered in WPF/Avalonia galleries; persistence remains consumer-owned through settings or application preferences.
+- Theme switching has been exercised in the native WPF, Avalonia, and MAUI Windows galleries; persistence remains consumer-owned through settings or application preferences.
 - DataFilterPanel styles are compile-verified but not manually rendered in WPF/Avalonia galleries; saved filters, richer per-editor templates, and field-specific validation remain future API/visual polish.
 - PropertyGridLite styles are compile-verified but not manually rendered in WPF/Avalonia galleries; typed editor templates, two-way value editing, per-field focus routing, and saved inspector layouts remain future API/visual polish.

--- a/src/CrissCross.Avalonia.Reactive/Themes/ReactiveTransitioningContentControl.axaml
+++ b/src/CrissCross.Avalonia.Reactive/Themes/ReactiveTransitioningContentControl.axaml
@@ -6,12 +6,12 @@
       <ControlTemplate>
         <Panel>
           <ContentPresenter Name="PART_ContentPresenter"
-                            Content="{TemplateBinding Content}"
                             ContentTemplate="{TemplateBinding ContentTemplate}"
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                             Padding="{TemplateBinding Padding}" />
-          <ContentPresenter Name="PART_ContentPresenter2"
+                    <ContentPresenter Name="PART_ContentPresenter2"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                             Padding="{TemplateBinding Padding}" />

--- a/src/CrissCross.Avalonia.Test/CrissCross.Avalonia.Example.csproj
+++ b/src/CrissCross.Avalonia.Test/CrissCross.Avalonia.Example.csproj
@@ -1,9 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);RCS1198</NoWarn>
   </PropertyGroup>
 
   

--- a/src/CrissCross.Avalonia.UI.Gallery/App.axaml.cs
+++ b/src/CrissCross.Avalonia.UI.Gallery/App.axaml.cs
@@ -35,6 +35,7 @@ public class App : Application
         AppLocator.CurrentMutable.RegisterConstant<BBCodeBlockPageViewModel>(new());
         AppLocator.CurrentMutable.RegisterConstant<FeaturePlaygroundPageViewModel>(new());
         AppLocator.CurrentMutable.RegisterConstant<WorkflowPageViewModel>(new());
+        AppLocator.CurrentMutable.RegisterConstant<IndustrialPageViewModel>(new());
         AppLocator.CurrentMutable.RegisterConstant<ControlCatalogPageViewModel>(new());
         AppLocator.CurrentMutable.RegisterConstant<MainViewModel>(new());
 
@@ -54,6 +55,7 @@ public class App : Application
         AppLocator.CurrentMutable.Register<IViewFor<FeaturePlaygroundPageViewModel>>(static () =>
             new FeaturePlaygroundPageView());
         AppLocator.CurrentMutable.Register<IViewFor<WorkflowPageViewModel>>(static () => new WorkflowPageView());
+        AppLocator.CurrentMutable.Register<IViewFor<IndustrialPageViewModel>>(static () => new IndustrialPageView());
         AppLocator.CurrentMutable.Register<IViewFor<ControlCatalogPageViewModel>>(static () => new ControlCatalogPageView());
 
         // NOTE: SetupComplete is called in OnFrameworkInitializationCompleted() to ensure

--- a/src/CrissCross.Avalonia.UI.Gallery/ViewModels/ControlCatalogPageViewModel.cs
+++ b/src/CrissCross.Avalonia.UI.Gallery/ViewModels/ControlCatalogPageViewModel.cs
@@ -21,6 +21,9 @@ public sealed class ControlCatalogPageViewModel : RxObject
     /// <summary>Application window-host label used by dialog and chrome-control entries.</summary>
     private const string ApplicationHostExample = "MainWindow application host";
 
+    /// <summary>Industrial page label used by process-control entries.</summary>
+    private const string IndustrialExample = "Industrial Controls";
+
     /// <summary>Initializes a new instance of the <see cref="ControlCatalogPageViewModel"/> class.</summary>
     public ControlCatalogPageViewModel() => DisplayName = CatalogExample;
 
@@ -42,7 +45,7 @@ public sealed class ControlCatalogPageViewModel : RxObject
         new("EmptyState", CatalogExample, "Standalone empty-content presentation."),
         new("Expander", CatalogExample, "Standalone expandable content presentation."),
         new("Flyout", CatalogExample, "Attached flyout host example; requires an owning control."),
-        new("Frame", NavigationHostExample, "Navigation content host used by the gallery shell."),
+        new("Frame", NavigationHostExample, "Thin Avalonia UserControl wrapper retained for API compatibility; frame navigation behavior remains a tracked gap."),
         new("Gauges", "Progress", "CircularGauge sample exercises the shared gauge theme."),
         new("GifImage", CatalogExample, "Image-derived control hosted by the catalog."),
         new("GridView", CatalogExample, "Grid-oriented list host example."),
@@ -59,10 +62,11 @@ public sealed class ControlCatalogPageViewModel : RxObject
         new("MessageBox", ApplicationHostExample, "Window-backed dialog; must be owned and shown by the top-level host."),
         new("MessageBoxAsync", ApplicationHostExample, "Async window-backed dialog service owned by the top-level host."),
         new("NavigationControls", NavigationHostExample, "Back/forward controls require a navigation host."),
-        new("NavigationUserControl", NavigationHostExample, "Navigation-aware content is activated inside the navigation host."),
+        new("NavigationUserControl", CatalogExample, "Composes a per-instance routed view-model host and keeps supplied content inside that host."),
         new("NavigationView", NavigationHostExample, "Navigation host/control requires application-level routing."),
         new("NumericPushButton", CatalogExample, "Standalone numeric command button."),
-        new("Page", NavigationHostExample, "Page lifecycle requires a navigation host."),
+        new("Page", NavigationHostExample, "Thin Avalonia UserControl wrapper retained for API compatibility; page lifecycle behavior remains a tracked gap."),
+        new("ProcessValueIndicator", IndustrialExample, "Compact operator readout for process value, range, quality, and alarm state."),
         new("PropertyGridLite", CatalogExample, "Property inspection host for supplied property rows."),
         new("ScrollBar", CatalogExample, "Scroll infrastructure hosted by a scroll viewer."),
         new("ScrollViewer", CatalogExample, "Hosts the catalog’s vertically scrollable content."),

--- a/src/CrissCross.Avalonia.UI.Gallery/ViewModels/FeaturePlaygroundPageViewModel.cs
+++ b/src/CrissCross.Avalonia.UI.Gallery/ViewModels/FeaturePlaygroundPageViewModel.cs
@@ -55,8 +55,18 @@ public sealed class FeaturePlaygroundPageViewModel : RxObject
     /// <summary>Provides a caller-controlled clock for deterministic gallery diagnostics.</summary>
     private readonly TimeProvider _timeProvider;
 
+    /// <summary>Retains the user's active filters across searches and paging.</summary>
+    private readonly List<FilterToken> _activeFilters =
+    [
+        new("area", FilterOperator.Equals, "north", "Area: North"),
+        new("status", FilterOperator.NotEquals, "closed", "Status: Active"),
+    ];
+
     /// <summary>Tracks whether the import command is running.</summary>
     private ObservableAsPropertyHelper<bool>? _isOperationRunning;
+
+    /// <summary>Cancels the current import operation from the busy overlay.</summary>
+    private Action? _cancelImport;
 
     /// <summary>Provides the _searchText member.</summary>
     private string? _searchText = "pump alarm";
@@ -103,8 +113,11 @@ public sealed class FeaturePlaygroundPageViewModel : RxObject
         _themeState = CreateThemeState(_selectedTheme);
 
         RunImportCommand = ReactiveCommand.CreateFromTask(RunImportAsync);
+        CancelImportCommand = ReactiveCommand.Create(CancelImport);
         SearchCommand = ReactiveCommand.CreateFromTask<string>(SearchAsync);
         ClearSearchCommand = ReactiveCommand.Create(ClearSearch);
+        RemoveFilterCommand = ReactiveCommand.Create<FilterToken>(RemoveFilter);
+        ClearFiltersCommand = ReactiveCommand.Create(ClearFilters);
         PageRequestCommand = ReactiveCommand.Create<PageRequest>(ApplyPageRequest);
         RangeChangedCommand = ReactiveCommand.Create<DateTimeRange>(ApplyRange);
         SegmentChangedCommand = ReactiveCommand.Create<string>(ApplySegment);
@@ -115,11 +128,20 @@ public sealed class FeaturePlaygroundPageViewModel : RxObject
     /// <summary>Gets the async command used by the command button and busy overlay demos.</summary>
     public ReactiveCommand<Unit, Unit> RunImportCommand { get; }
 
+    /// <summary>Gets the command that cancels the current import operation.</summary>
+    public ReactiveCommand<Unit, Unit> CancelImportCommand { get; }
+
     /// <summary>Gets the search submit command.</summary>
     public ReactiveCommand<string, Unit> SearchCommand { get; }
 
     /// <summary>Gets the search clear command.</summary>
     public ReactiveCommand<Unit, Unit> ClearSearchCommand { get; }
+
+    /// <summary>Gets the command that removes one active filter.</summary>
+    public ReactiveCommand<FilterToken, Unit> RemoveFilterCommand { get; }
+
+    /// <summary>Gets the command that clears removable filters while preserving the search text.</summary>
+    public ReactiveCommand<Unit, Unit> ClearFiltersCommand { get; }
 
     /// <summary>Gets the page request command used by DataPager.</summary>
     public ReactiveCommand<PageRequest, Unit> PageRequestCommand { get; }
@@ -271,22 +293,6 @@ public sealed class FeaturePlaygroundPageViewModel : RxObject
         base.Dispose(disposing);
     }
 
-    /// <summary>Provides the CreateSearchState member.</summary>
-    /// <param name="text">The text value.</param>
-    /// <param name="isSearching">The isSearching value.</param>
-    /// <returns>The result.</returns>
-    private static SearchQueryState CreateSearchState(string? text, bool isSearching) =>
-        new(
-            text,
-            debouncedText: text?.Trim(),
-            submittedText: text?.Trim(),
-            isSearching: isSearching,
-            resultCount: string.IsNullOrWhiteSpace(text) ? SampleTotalItemCount : FilteredResultCount,
-            filters:
-            [
-                new FilterToken("area", FilterOperator.Equals, "north", "Area: North"),
-                new FilterToken("status", FilterOperator.NotEquals, "closed", "Status: Active"),]);
-
     /// <summary>Provides the CreateRange member.</summary>
     /// <param name="now">The now value.</param>
     /// <returns>The result.</returns>
@@ -362,6 +368,19 @@ public sealed class FeaturePlaygroundPageViewModel : RxObject
             _ => ThemeChoice.Light,
         };
 
+    /// <summary>Provides the CreateSearchState member.</summary>
+    /// <param name="text">The text value.</param>
+    /// <param name="isSearching">The isSearching value.</param>
+    /// <returns>The result.</returns>
+    private SearchQueryState CreateSearchState(string? text, bool isSearching) =>
+        new(
+            text,
+            debouncedText: text?.Trim(),
+            submittedText: text?.Trim(),
+            isSearching: isSearching,
+            resultCount: string.IsNullOrWhiteSpace(text) ? SampleTotalItemCount : FilteredResultCount,
+            filters: _activeFilters.ToArray());
+
     /// <summary>Gets the lazily initialized command execution state.</summary>
     /// <returns>Whether the import command is executing.</returns>
     private bool GetIsOperationRunningValue()
@@ -378,22 +397,38 @@ public sealed class FeaturePlaygroundPageViewModel : RxObject
     /// <returns>A task that represents the asynchronous operation.</returns>
     private async Task RunImportAsync(CancellationToken cancellationToken)
     {
+        using var importCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _cancelImport = importCancellation.Cancel;
         CommandState = CommandButtonState.Executing;
         CommandProgress = InitialCommandProgress;
         CurrentOperation = new(
             "Loading deterministic sample data",
             "Simulates a cancellable import without network access.",
             CommandProgress,
-            ClearSearchCommand);
+            CancelImportCommand);
 
-        await Task.Delay(ImportDelayMilliseconds, cancellationToken).ConfigureAwait(true);
-
-        CommandProgress = CompletedCommandProgress;
-        CurrentOperation = null;
-        CommandState = CommandButtonState.Succeeded;
-        PaginationState = new(0, DefaultPageSize, SampleTotalItemCount);
-        SearchState = CreateSearchState(SearchText, false);
+        try
+        {
+            await Task.Delay(ImportDelayMilliseconds, importCancellation.Token).ConfigureAwait(true);
+            CommandProgress = CompletedCommandProgress;
+            CommandState = CommandButtonState.Succeeded;
+            PaginationState = new(0, DefaultPageSize, SampleTotalItemCount);
+            SearchState = CreateSearchState(SearchText, false);
+        }
+        catch (OperationCanceledException) when (importCancellation.IsCancellationRequested)
+        {
+            CommandProgress = null;
+            CommandState = CommandButtonState.Cancelled;
+        }
+        finally
+        {
+            CurrentOperation = null;
+            _cancelImport = null;
+        }
     }
+
+    /// <summary>Requests cancellation without changing the current query or filter state.</summary>
+    private void CancelImport() => _cancelImport?.Invoke();
 
     /// <summary>Provides the SearchAsync member.</summary>
     /// <param name="submittedText">The submittedText value.</param>
@@ -411,6 +446,22 @@ public sealed class FeaturePlaygroundPageViewModel : RxObject
     private void ClearSearch()
     {
         SearchText = string.Empty;
+        SearchState = CreateSearchState(SearchText, false);
+    }
+
+    /// <summary>Removes the requested token and republishes the immutable query state.</summary>
+    /// <param name="token">The requested filter token.</param>
+    private void RemoveFilter(FilterToken token)
+    {
+        ArgumentNullException.ThrowIfNull(token);
+        _ = _activeFilters.RemoveAll(candidate => candidate.IsRemovable && candidate.Key == token.Key);
+        SearchState = CreateSearchState(SearchText, false);
+    }
+
+    /// <summary>Clears removable filters while preserving the current query.</summary>
+    private void ClearFilters()
+    {
+        _ = _activeFilters.RemoveAll(static token => token.IsRemovable);
         SearchState = CreateSearchState(SearchText, false);
     }
 

--- a/src/CrissCross.Avalonia.UI.Gallery/ViewModels/IndustrialPageViewModel.cs
+++ b/src/CrissCross.Avalonia.UI.Gallery/ViewModels/IndustrialPageViewModel.cs
@@ -1,0 +1,74 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVELIST_REACTIVE
+using ProcessValueOptions = CrissCross.Reactive.ProcessValueOptions;
+using ProcessValueState = CrissCross.Reactive.ProcessValueState;
+#else
+using ProcessValueOptions = CrissCross.ProcessValueOptions;
+using ProcessValueState = CrissCross.ProcessValueState;
+#endif
+
+namespace CrissCross.Avalonia.UI.Gallery.ViewModels;
+
+/// <summary>View model for industrial process controls.</summary>
+public sealed class IndustrialPageViewModel : RxObject
+{
+    /// <summary>The sample pressure measurement in bar.</summary>
+    private const double PressureReading = 72.4;
+
+    /// <summary>The pressure display maximum in bar.</summary>
+    private const double PressureMaximum = 100;
+
+    /// <summary>The high pressure alarm in bar.</summary>
+    private const double PressureAlarm = 85;
+
+    /// <summary>The sample temperature in degrees Celsius.</summary>
+    private const double TemperatureReading = 96.8;
+
+    /// <summary>The temperature display maximum in degrees Celsius.</summary>
+    private const double TemperatureMaximum = 120;
+
+    /// <summary>The high temperature alarm in degrees Celsius.</summary>
+    private const double TemperatureAlarm = 90;
+
+    /// <summary>The sample vibration measurement in millimeters per second.</summary>
+    private const double VibrationReading = 8.2;
+
+    /// <summary>The vibration display maximum in millimeters per second.</summary>
+    private const double VibrationMaximum = 20;
+
+    /// <summary>The high vibration alarm in millimeters per second.</summary>
+    private const double VibrationAlarm = 12;
+
+    /// <summary>Initializes a new instance of the <see cref="IndustrialPageViewModel"/> class.</summary>
+    public IndustrialPageViewModel() => this.BuildComplete(() => DisplayName = "Industrial Controls");
+
+    /// <summary>Gets a normal process reading.</summary>
+    public ProcessValueState NormalPressure { get; } = new(
+        "Pump discharge pressure",
+        PressureReading,
+        "bar",
+        0D,
+        PressureMaximum,
+        new ProcessValueOptions { HighAlarmLimit = PressureAlarm });
+
+    /// <summary>Gets a high-alarm process reading.</summary>
+    public ProcessValueState HighTemperature { get; } = new(
+        "Seal gas temperature",
+        TemperatureReading,
+        "degC",
+        0D,
+        TemperatureMaximum,
+        new ProcessValueOptions { HighAlarmLimit = TemperatureAlarm });
+
+    /// <summary>Gets a bad-quality process reading.</summary>
+    public ProcessValueState BadQualityVibration { get; } = new(
+        "Compressor vibration",
+        VibrationReading,
+        "mm/s",
+        0D,
+        VibrationMaximum,
+        new ProcessValueOptions { HighAlarmLimit = VibrationAlarm, IsGoodQuality = false });
+}

--- a/src/CrissCross.Avalonia.UI.Gallery/ViewModels/MainViewModel.cs
+++ b/src/CrissCross.Avalonia.UI.Gallery/ViewModels/MainViewModel.cs
@@ -13,6 +13,9 @@ public class MainViewModel : RxObject
     /// <summary>Initializes a new instance of the <see cref="MainViewModel"/> class.</summary>
     public MainViewModel() => DisplayName = "Gallery";
 
+    /// <summary>Gets the logical window host targeted by this gallery's navigation commands.</summary>
+    public string? NavigationHostName { get; init; }
+
     /// <summary>Gets the goto home command.</summary>
     public ICommand GotoHome => field ??= CreateNavigationCommand<HomePageViewModel>();
 
@@ -52,6 +55,9 @@ public class MainViewModel : RxObject
     /// <summary>Gets the workflow and feedback gallery navigation command.</summary>
     public ICommand GotoWorkflow => field ??= CreateNavigationCommand<WorkflowPageViewModel>();
 
+    /// <summary>Gets the industrial controls gallery navigation command.</summary>
+    public ICommand GotoIndustrial => field ??= CreateNavigationCommand<IndustrialPageViewModel>();
+
     /// <summary>Gets the control and host coverage catalog navigation command.</summary>
     public ICommand GotoControlCatalog => field ??= CreateNavigationCommand<ControlCatalogPageViewModel>();
 
@@ -60,5 +66,5 @@ public class MainViewModel : RxObject
     /// <returns>The navigation command.</returns>
     private ReactiveCommand<Unit, Unit> CreateNavigationCommand<TViewModel>()
         where TViewModel : class, IRxObject =>
-        ReactiveCommand.Create(() => this.NavigateToView(new NavigationKeyRequest<TViewModel>()));
+        ReactiveCommand.Create(() => this.NavigateToView(new NavigationKeyRequest<TViewModel> { Options = new() { HostName = NavigationHostName } }));
 }

--- a/src/CrissCross.Avalonia.UI.Gallery/Views/MainWindow.axaml.cs
+++ b/src/CrissCross.Avalonia.UI.Gallery/Views/MainWindow.axaml.cs
@@ -8,7 +8,7 @@ using Avalonia.Data;
 using Avalonia.Layout;
 using Avalonia.Media;
 using CrissCross.Avalonia.UI.Gallery.ViewModels;
-using Splat;
+using ReactiveUI;
 
 namespace CrissCross.Avalonia.UI.Gallery.Views;
 
@@ -47,18 +47,20 @@ public partial class MainWindow : NavigationWindow<MainViewModel>
     {
         // Set the window name for navigation registration BEFORE InitializeComponent
         Name = NavHostName;
+        HostName = $"{NavHostName}_{System.Guid.NewGuid():N}";
 
         InitializeComponent();
 
         if (NavigationFrame is not null)
         {
             NavigationFrame.Name = NavHostName;
-            NavigationFrame.HostName = NavHostName;
+            NavigationFrame.HostName = HostName;
             this.SetMainNavigationHost(NavigationFrame);
         }
 
         // Set the DataContext to the MainViewModel
-        DataContext = AppLocator.Current.GetService<MainViewModel>();
+        ViewModel = new() { NavigationHostName = HostName };
+        DataContext = ViewModel;
     }
 
     /// <inheritdoc/>
@@ -101,7 +103,12 @@ public partial class MainWindow : NavigationWindow<MainViewModel>
             titleBorder.Classes.Add("gallery-title");
             var titleText = new UI.Controls.TextBlock { Text = "CrissCross Avalonia UI Gallery", FontSize = TitleFontSize, FontWeight = FontWeight.Bold };
             titleText.Classes.Add("gallery-shell-text");
-            titleBorder.Child = titleText;
+            var titleGrid = new UI.Controls.Grid { ColumnDefinitions = new("*,Auto") };
+            titleGrid.Children.Add(titleText);
+            var newWindowButton = new UI.Controls.Button { Content = "New window", Command = ReactiveCommand.Create(static () => new MainWindow().Show()) };
+            Grid.SetColumn(newWindowButton, 1);
+            titleGrid.Children.Add(newWindowButton);
+            titleBorder.Child = titleGrid;
             mainGrid.Children.Add(titleBorder);
             Grid.SetRow(titleBorder, 0);
 
@@ -158,6 +165,7 @@ public partial class MainWindow : NavigationWindow<MainViewModel>
             CreateNavigationExpander("Progress", includeTopMargin: false, [("ProgressBar", "GotoProgress")]));
         AddNavigationButton(navStack, "BBCodeBlock", "GotoBBCodeBlock");
         AddNavigationButton(navStack, "Workflow & Feedback", "GotoWorkflow");
+        AddNavigationButton(navStack, "Industrial Controls", "GotoIndustrial");
         AddNavigationButton(navStack, "Control & Host Catalog", "GotoControlCatalog");
         AddNavigationButton(navStack, "✨ Reactive Feature Playground", "GotoFeaturePlayground");
 

--- a/src/CrissCross.Avalonia.UI.Gallery/Views/Pages/ButtonsPageView.axaml
+++ b/src/CrissCross.Avalonia.UI.Gallery/Views/Pages/ButtonsPageView.axaml
@@ -22,6 +22,13 @@
                     <controls:StackPanel Orientation="Horizontal" Spacing="8">
                         <controls:Button Content="Primary" Appearance="Primary" />
                         <controls:Button Content="Secondary" Appearance="Secondary" />
+                        <controls:Button Content="Info" Appearance="Info" />
+                        <controls:Button Content="Success" Appearance="Success" />
+                        <controls:Button Content="Caution" Appearance="Caution" />
+                        <controls:Button Content="Danger" Appearance="Danger" />
+                        <controls:Button Content="Dark" Appearance="Dark" />
+                        <controls:Button Content="Light" Appearance="Light" />
+                        <controls:Button Content="Transparent" Appearance="Transparent" />
                         <controls:Button Content="Disabled" IsEnabled="False" />
                     </controls:StackPanel>
                 </controls:StackPanel>

--- a/src/CrissCross.Avalonia.UI.Gallery/Views/Pages/CheckBoxPageView.axaml
+++ b/src/CrissCross.Avalonia.UI.Gallery/Views/Pages/CheckBoxPageView.axaml
@@ -48,8 +48,13 @@
                     <controls:TextBlock Text="CheckBox with Long Content" FontSize="18" FontWeight="Bold" />
                     <controls:TextBlock Text="CheckBox can contain longer text content that wraps." Opacity="0.7" />
                     <controls:StackPanel Spacing="8" MaxWidth="400">
-                        <controls:CheckBox Content="I accept the terms and conditions of use for this application and agree to the privacy policy." />
-                        <controls:CheckBox Content="Subscribe to newsletter and promotional emails" IsChecked="True" />
+                        <controls:CheckBox>
+                            <TextBlock Text="I accept the terms and conditions of use for this application and agree to the privacy policy."
+                                       TextWrapping="Wrap" />
+                        </controls:CheckBox>
+                        <controls:CheckBox IsChecked="True">
+                            <TextBlock Text="Subscribe to newsletter and promotional emails" TextWrapping="Wrap" />
+                        </controls:CheckBox>
                     </controls:StackPanel>
                 </controls:StackPanel>
             </controls:Card>

--- a/src/CrissCross.Avalonia.UI.Gallery/Views/Pages/ControlCatalogPageView.axaml
+++ b/src/CrissCross.Avalonia.UI.Gallery/Views/Pages/ControlCatalogPageView.axaml
@@ -10,8 +10,29 @@
             <controls:TextBlock FontSize="32" FontWeight="Bold" Text="Control &amp; host catalog" />
             <controls:TextBlock
                 Opacity="0.75"
-                Text="This data-driven index makes composed and application-hosted control families discoverable without placing invalid window, dialog, or virtualization topology inside a nested page."
-                TextWrapping="Wrap" />
+                TextWrapping="Wrap">
+                <controls:TextBlock.Text>
+                    This index keeps composed and application-hosted controls discoverable without nesting invalid window, dialog, or virtualization topology inside the page.
+                </controls:TextBlock.Text>
+            </controls:TextBlock>
+            <controls:Card>
+                <controls:StackPanel Spacing="10">
+                    <controls:TextBlock FontSize="18" FontWeight="Bold" Text="NavigationUserControl host" />
+                    <controls:NavigationUserControl
+                        Height="96"
+                        NavigateBackIsEnabled="False">
+                        <controls:Border
+                            Padding="12"
+                            Background="{DynamicResource SolidBackgroundFillColorSecondaryBrush}"
+                            CornerRadius="6">
+                            <controls:TextBlock
+                                Opacity="0.8"
+                                Text="Navigation host ready"
+                                TextWrapping="Wrap" />
+                        </controls:Border>
+                    </controls:NavigationUserControl>
+                </controls:StackPanel>
+            </controls:Card>
             <controls:Card>
                 <controls:StackPanel Spacing="10">
                     <controls:TextBlock FontSize="18" FontWeight="Bold" Text="Coverage inventory" />

--- a/src/CrissCross.Avalonia.UI.Gallery/Views/Pages/FeaturePlaygroundPageView.axaml
+++ b/src/CrissCross.Avalonia.UI.Gallery/Views/Pages/FeaturePlaygroundPageView.axaml
@@ -39,7 +39,9 @@
                         QueryState="{Binding SearchState}"
                         SearchCommand="{Binding SearchCommand}"
                         Text="{Binding SearchText}" />
-                    <controls:FilterBar ClearAllCommand="{Binding ClearSearchCommand}" QueryState="{Binding SearchState}" />
+                    <controls:FilterBar ClearAllCommand="{Binding ClearFiltersCommand}"
+                                        RemoveFilterCommand="{Binding RemoveFilterCommand}"
+                                        QueryState="{Binding SearchState}" />
                     <controls:DataPager
                         PageRequestCommand="{Binding PageRequestCommand}"
                         PaginationState="{Binding PaginationState}"

--- a/src/CrissCross.Avalonia.UI.Gallery/Views/Pages/HomePageView.axaml
+++ b/src/CrissCross.Avalonia.UI.Gallery/Views/Pages/HomePageView.axaml
@@ -49,7 +49,7 @@
                             FontSize="36"
                             FontWeight="Bold"
                             Foreground="{DynamicResource SystemAccentColorPrimary}"
-                            Text="12" />
+                            Text="15" />
                         <controls:TextBlock
                             HorizontalAlignment="Center"
                             FontSize="14"

--- a/src/CrissCross.Avalonia.UI.Gallery/Views/Pages/IndustrialPageView.axaml
+++ b/src/CrissCross.Avalonia.UI.Gallery/Views/Pages/IndustrialPageView.axaml
@@ -1,0 +1,28 @@
+<UserControl
+    x:Class="CrissCross.Avalonia.UI.Gallery.Views.Pages.IndustrialPageView"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:CrissCross.Avalonia.UI.Controls"
+    xmlns:vm="using:CrissCross.Avalonia.UI.Gallery.ViewModels"
+    x:DataType="vm:IndustrialPageViewModel">
+    <ScrollViewer>
+        <controls:StackPanel Margin="24" Spacing="16">
+            <controls:TextBlock FontSize="32" FontWeight="Bold" Text="Industrial Controls" />
+            <controls:TextBlock
+                Opacity="0.75"
+                Text="Industrial indicators present process values, units, range position, data quality, and alarm state in compact operator-facing panels."
+                TextWrapping="Wrap" />
+
+            <controls:Card>
+                <controls:StackPanel Spacing="12">
+                    <controls:TextBlock FontSize="18" FontWeight="Bold" Text="ProcessValueIndicator" />
+                    <WrapPanel>
+                        <controls:ProcessValueIndicator Margin="0,0,12,12" State="{Binding NormalPressure}" />
+                        <controls:ProcessValueIndicator Margin="0,0,12,12" State="{Binding HighTemperature}" />
+                        <controls:ProcessValueIndicator Margin="0,0,12,12" State="{Binding BadQualityVibration}" />
+                    </WrapPanel>
+                </controls:StackPanel>
+            </controls:Card>
+        </controls:StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/CrissCross.Avalonia.UI.Gallery/Views/Pages/IndustrialPageView.axaml.cs
+++ b/src/CrissCross.Avalonia.UI.Gallery/Views/Pages/IndustrialPageView.axaml.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using CrissCross.Avalonia.UI.Gallery.ViewModels;
+using ReactiveUI;
+using ReactiveUI.Avalonia;
+using Splat;
+
+namespace CrissCross.Avalonia.UI.Gallery.Views.Pages;
+
+/// <summary>Industrial process controls gallery page.</summary>
+public partial class IndustrialPageView : ReactiveUserControl<IndustrialPageViewModel>
+{
+    /// <summary>Initializes a new instance of the <see cref="IndustrialPageView"/> class.</summary>
+    public IndustrialPageView()
+    {
+        InitializeComponent();
+        _ = this.WhenActivated(
+            (ActivationDisposable _) => ViewModel ??= AppLocator.Current.GetService<IndustrialPageViewModel>());
+    }
+}

--- a/src/CrissCross.Avalonia.UI.Gallery/Views/Pages/SliderPageView.axaml
+++ b/src/CrissCross.Avalonia.UI.Gallery/Views/Pages/SliderPageView.axaml
@@ -47,7 +47,7 @@
                     <controls:TextBlock Text="Sliders can have custom minimum and maximum values." Opacity="0.7" />
                     <controls:StackPanel Spacing="16" MaxWidth="400" HorizontalAlignment="Left">
                         <controls:StackPanel>
-                            <controls:TextBlock Text="Temperature (0°C to 40°C)" FontSize="12" Margin="0,0,0,4" />
+                            <controls:TextBlock Text="Temperature (0Â°C to 40Â°C)" FontSize="12" Margin="0,0,0,4" />
                             <controls:Slider Value="22" Minimum="0" Maximum="40" />
                         </controls:StackPanel>
                         <controls:StackPanel>

--- a/src/CrissCross.Avalonia.UI/Appearance/ApplicationThemeManager.cs
+++ b/src/CrissCross.Avalonia.UI/Appearance/ApplicationThemeManager.cs
@@ -24,6 +24,9 @@ public static class ApplicationThemeManager
     /// <summary>Event triggered when the application's theme is changed.</summary>
     public static event EventHandler<ThemeChangedEventArgs>? Changed;
 
+    /// <summary>Gets the Avalonia high contrast theme variant.</summary>
+    public static ThemeVariant HighContrastThemeVariant { get; } = new("HighContrast", ThemeVariant.Dark);
+
     /// <summary>Gets the IsHighContrast value.</summary>
     /// <returns><see langword="true"/> if application uses high contrast theme.</returns>
     public static bool IsHighContrast => _cachedApplicationTheme == ApplicationTheme.HighContrast;
@@ -71,6 +74,7 @@ public static class ApplicationThemeManager
             {
                 ApplicationTheme.Dark => ThemeVariant.Dark,
                 ApplicationTheme.Light => ThemeVariant.Light,
+                ApplicationTheme.HighContrast => HighContrastThemeVariant,
                 _ => ThemeVariant.Default,
             };
         }
@@ -140,6 +144,12 @@ public static class ApplicationThemeManager
         }
 
         var actualTheme = Application.Current.ActualThemeVariant;
+        if (actualTheme == HighContrastThemeVariant)
+        {
+            _cachedApplicationTheme = ApplicationTheme.HighContrast;
+            return;
+        }
+
         _cachedApplicationTheme = actualTheme == ThemeVariant.Dark ? ApplicationTheme.Dark : ApplicationTheme.Light;
     }
 }

--- a/src/CrissCross.Avalonia.UI/Controls/AutoSuggestBox/AutoSuggestBox.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/AutoSuggestBox/AutoSuggestBox.cs
@@ -11,8 +11,4 @@ namespace CrissCross.Avalonia.UI.Controls;
 #endif
 
 /// <summary>Represents a text control that makes suggestions to users as they enter text.</summary>
-public class AutoSuggestBox : global::Avalonia.Controls.AutoCompleteBox
-{
-    /// <inheritdoc/>
-    protected override Type StyleKeyOverride => typeof(global::Avalonia.Controls.AutoCompleteBox);
-}
+public class AutoSuggestBox : global::Avalonia.Controls.AutoCompleteBox;

--- a/src/CrissCross.Avalonia.UI/Controls/BreadcrumbBar/BreadcrumbBar.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/BreadcrumbBar/BreadcrumbBar.cs
@@ -67,6 +67,9 @@ public class BreadcrumbBar : ItemsControl, IUseHostedNavigation
         set => SetValue(CommandProperty, value);
     }
 
+    /// <inheritdoc />
+    protected override Type StyleKeyOverride => typeof(BreadcrumbBar);
+
     /// <summary>Setups the navigation.</summary>
     /// <param name="hostName">Name of the host.</param>
     public void SetupNavigation(string hostName) => _hostName = hostName;

--- a/src/CrissCross.Avalonia.UI/Controls/ChipGroup/ChipGroup.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/ChipGroup/ChipGroup.cs
@@ -66,18 +66,22 @@ public class ChipGroup : ItemsControl
     }
 
     /// <inheritdoc />
+    protected override Type StyleKeyOverride => typeof(ChipGroup);
+
+    /// <inheritdoc />
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         ArgumentNullException.ThrowIfNull(change);
 
         base.OnPropertyChanged(change);
 
-        if (change.Property != GroupStateProperty || change.GetNewValue<ChipGroupState?>() is not { } state)
+        if (change.Property != GroupStateProperty)
         {
             return;
         }
 
-        SelectionMode = state.SelectionMode;
-        ItemsSource = state.Chips;
+        var state = change.GetNewValue<ChipGroupState?>();
+        SelectionMode = state?.SelectionMode ?? default;
+        ItemsSource = state?.Chips;
     }
 }

--- a/src/CrissCross.Avalonia.UI/Controls/ContextMenu/ContextMenu.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/ContextMenu/ContextMenu.cs
@@ -9,7 +9,4 @@ namespace CrissCross.Avalonia.UI.Controls;
 #endif
 
 /// <summary>Represents the ContextMenu type.</summary>
-public class ContextMenu : global::Avalonia.Controls.ContextMenu
-{
-    // Inherits all functionality from Avalonia ContextMenu
-}
+public class ContextMenu : global::Avalonia.Controls.ContextMenu;

--- a/src/CrissCross.Avalonia.UI/Controls/DatePicker/DatePicker.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/DatePicker/DatePicker.cs
@@ -11,8 +11,4 @@ namespace CrissCross.Avalonia.UI.Controls;
 #endif
 
 /// <summary>Represents a control that allows the user to select a date.</summary>
-public class DatePicker : global::Avalonia.Controls.DatePicker
-{
-    /// <inheritdoc/>
-    protected override Type StyleKeyOverride => typeof(global::Avalonia.Controls.DatePicker);
-}
+public class DatePicker : global::Avalonia.Controls.DatePicker;

--- a/src/CrissCross.Avalonia.UI/Controls/DropDownButton/DropDownButton.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/DropDownButton/DropDownButton.cs
@@ -11,8 +11,4 @@ namespace CrissCross.Avalonia.UI.Controls;
 #endif
 
 /// <summary>Represents a button with a drop-down list.</summary>
-public class DropDownButton : global::Avalonia.Controls.DropDownButton
-{
-    /// <inheritdoc/>
-    protected override Type StyleKeyOverride => typeof(global::Avalonia.Controls.DropDownButton);
-}
+public class DropDownButton : global::Avalonia.Controls.DropDownButton;

--- a/src/CrissCross.Avalonia.UI/Controls/DynamicScrollBar/DynamicScrollBar.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/DynamicScrollBar/DynamicScrollBar.cs
@@ -9,7 +9,4 @@ namespace CrissCross.Avalonia.UI.Controls;
 #endif
 
 /// <summary>Represents a dynamic scrollbar control with custom styling.</summary>
-public class DynamicScrollBar : global::Avalonia.Controls.Primitives.ScrollBar
-{
-    // Inherits from Avalonia ScrollBar with dynamic features
-}
+public class DynamicScrollBar : global::Avalonia.Controls.Primitives.ScrollBar;

--- a/src/CrissCross.Avalonia.UI/Controls/DynamicScrollViewer/DynamicScrollViewer.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/DynamicScrollViewer/DynamicScrollViewer.cs
@@ -9,7 +9,4 @@ namespace CrissCross.Avalonia.UI.Controls;
 #endif
 
 /// <summary>Represents a scroll viewer with dynamic scrollbar visibility.</summary>
-public class DynamicScrollViewer : global::Avalonia.Controls.ScrollViewer
-{
-    // Inherits from Avalonia ScrollViewer with dynamic features
-}
+public class DynamicScrollViewer : global::Avalonia.Controls.ScrollViewer;

--- a/src/CrissCross.Avalonia.UI/Controls/Expander/Expander.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/Expander/Expander.cs
@@ -15,7 +15,7 @@ public class Expander : global::Avalonia.Controls.Expander
 {
     /// <summary>Property for <see cref="CornerRadius"/>.</summary>
     public static new readonly StyledProperty<CornerRadius> CornerRadiusProperty =
-        AvaloniaProperty.Register<Expander, CornerRadius>(nameof(CornerRadius));
+        global::Avalonia.Controls.Expander.CornerRadiusProperty;
 
     /// <summary>Gets or sets the corner radius.</summary>
     public new CornerRadius CornerRadius

--- a/src/CrissCross.Avalonia.UI/Controls/FilterBar/FilterBar.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/FilterBar/FilterBar.cs
@@ -53,17 +53,20 @@ public class FilterBar : ItemsControl
     }
 
     /// <inheritdoc />
+    protected override Type StyleKeyOverride => typeof(FilterBar);
+
+    /// <inheritdoc />
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         ArgumentNullException.ThrowIfNull(change);
 
         base.OnPropertyChanged(change);
 
-        if (change.Property != QueryStateProperty || change.GetNewValue<SearchQueryState?>() is not { } state)
+        if (change.Property != QueryStateProperty)
         {
             return;
         }
 
-        ItemsSource = state.ActiveFilters;
+        ItemsSource = change.GetNewValue<SearchQueryState?>()?.ActiveFilters;
     }
 }

--- a/src/CrissCross.Avalonia.UI/Controls/GifImage/GifImage.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/GifImage/GifImage.cs
@@ -20,7 +20,7 @@ public class GifImage : global::Avalonia.Controls.Image
 
     /// <summary>Property for <see cref="StretchDirection"/>.</summary>
     public static new readonly StyledProperty<StretchDirection> StretchDirectionProperty =
-        AvaloniaProperty.Register<GifImage, StretchDirection>(nameof(StretchDirection), StretchDirection.Both);
+        global::Avalonia.Controls.Image.StretchDirectionProperty;
 
     /// <summary>Property for <see cref="SourceUri"/>.</summary>
     public static readonly StyledProperty<Uri?> SourceUriProperty =

--- a/src/CrissCross.Avalonia.UI/Controls/IconElement/IconElement.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/IconElement/IconElement.cs
@@ -4,6 +4,7 @@
 
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Documents;
 using Avalonia.Media;
 
 #if REACTIVELIST_REACTIVE
@@ -16,9 +17,8 @@ namespace CrissCross.Avalonia.UI.Controls;
 public class IconElement : Control
 {
     /// <summary>Property for <see cref="Foreground"/>.</summary>
-    public static readonly StyledProperty<IBrush?> ForegroundProperty = AvaloniaProperty.Register<IconElement, IBrush?>(
-        nameof(Foreground),
-        defaultValue: Brushes.Black);
+    public static readonly StyledProperty<IBrush?> ForegroundProperty =
+        TextElement.ForegroundProperty.AddOwner<IconElement>();
 
     /// <summary>Provides the IconElement member.</summary>
     static IconElement()

--- a/src/CrissCross.Avalonia.UI/Controls/ItemsControl/ItemsControl.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/ItemsControl/ItemsControl.cs
@@ -9,7 +9,4 @@ namespace CrissCross.Avalonia.UI.Controls;
 #endif
 
 /// <summary>Represents a control that can be used to present a collection of items.</summary>
-public class ItemsControl : global::Avalonia.Controls.ItemsControl
-{
-    // Inherits all functionality from Avalonia ItemsControl
-}
+public class ItemsControl : global::Avalonia.Controls.ItemsControl;

--- a/src/CrissCross.Avalonia.UI/Controls/ListBox/ListBox.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/ListBox/ListBox.cs
@@ -9,7 +9,4 @@ namespace CrissCross.Avalonia.UI.Controls;
 #endif
 
 /// <summary>Contains a list of selectable items.</summary>
-public class ListBox : global::Avalonia.Controls.ListBox
-{
-    // Inherits all functionality from Avalonia ListBox
-}
+public class ListBox : global::Avalonia.Controls.ListBox;

--- a/src/CrissCross.Avalonia.UI/Controls/Menu/Menu.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/Menu/Menu.cs
@@ -9,7 +9,4 @@ namespace CrissCross.Avalonia.UI.Controls;
 #endif
 
 /// <summary>Represents a menu control that displays a list of items.</summary>
-public class Menu : global::Avalonia.Controls.Menu
-{
-    // Inherits all functionality from Avalonia Menu
-}
+public class Menu : global::Avalonia.Controls.Menu;

--- a/src/CrissCross.Avalonia.UI/Controls/MenuItem/MenuItem.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/MenuItem/MenuItem.cs
@@ -14,8 +14,7 @@ namespace CrissCross.Avalonia.UI.Controls;
 public class MenuItem : global::Avalonia.Controls.MenuItem
 {
     /// <summary>Property for <see cref="Icon"/>.</summary>
-    public static new readonly StyledProperty<object?> IconProperty = AvaloniaProperty.Register<MenuItem, object?>(
-        nameof(Icon));
+    public static new readonly StyledProperty<object?> IconProperty = global::Avalonia.Controls.MenuItem.IconProperty;
 
     /// <summary>Gets or sets the icon.</summary>
     public new object? Icon

--- a/src/CrissCross.Avalonia.UI/Controls/MessageBoxAsync/MessageBoxAsync.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/MessageBoxAsync/MessageBoxAsync.cs
@@ -56,31 +56,16 @@ public static class MessageBoxAsync
     /// <param name="buttons">The buttons value.</param>
     private static void ConfigureButtons(MessageBox messageBox, MessageBoxButton buttons)
     {
-        switch (buttons)
+        var (primaryButtonText, secondaryButtonText, closeButtonText) = buttons switch
         {
-            case MessageBoxButton.Primary:
-                {
-                    messageBox.PrimaryButtonText = "OK";
-                    messageBox.SecondaryButtonText = string.Empty;
-                    messageBox.CloseButtonText = string.Empty;
-                    break;
-                }
+            MessageBoxButton.Primary => ("OK", string.Empty, string.Empty),
+            MessageBoxButton.Secondary => (string.Empty, "Cancel", string.Empty),
+            MessageBoxButton.Close => (string.Empty, string.Empty, "Close"),
+            _ => (string.Empty, string.Empty, string.Empty),
+        };
 
-            case MessageBoxButton.Secondary:
-                {
-                    messageBox.PrimaryButtonText = string.Empty;
-                    messageBox.SecondaryButtonText = "Cancel";
-                    messageBox.CloseButtonText = string.Empty;
-                    break;
-                }
-
-            case MessageBoxButton.Close:
-                {
-                    messageBox.PrimaryButtonText = string.Empty;
-                    messageBox.SecondaryButtonText = string.Empty;
-                    messageBox.CloseButtonText = "Close";
-                    break;
-                }
-        }
+        messageBox.PrimaryButtonText = primaryButtonText;
+        messageBox.SecondaryButtonText = secondaryButtonText;
+        messageBox.CloseButtonText = closeButtonText;
     }
 }

--- a/src/CrissCross.Avalonia.UI/Controls/NavigationUserControl/NavigationUserControl.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/NavigationUserControl/NavigationUserControl.cs
@@ -2,7 +2,17 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Layout;
+
+#if REACTIVELIST_REACTIVE
+using CoreViewModelRoutedViewHost = CrissCross.Reactive.Avalonia.ViewModelRoutedViewHost;
+#else
+using CoreViewModelRoutedViewHost = CrissCross.Avalonia.ViewModelRoutedViewHost;
+#endif
 
 #if REACTIVELIST_REACTIVE
 namespace CrissCross.Reactive.Avalonia.UI.Controls;
@@ -10,8 +20,294 @@ namespace CrissCross.Reactive.Avalonia.UI.Controls;
 namespace CrissCross.Avalonia.UI.Controls;
 #endif
 
-/// <summary>User control wrapper for navigation functionality.</summary>
-public class NavigationUserControl : UserControl
+/// <summary>Hosts a routed Avalonia view-model navigation frame inside a UI user control.</summary>
+/// <seealso cref="UserControl" />
+/// <seealso cref="ISetNavigation" />
+/// <seealso cref="IUseNavigation" />
+/// <seealso cref="IActivatableView" />
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
+public class NavigationUserControl : UserControl, ISetNavigation, IUseNavigation, IActivatableView, IDisposable
 {
-    // Inherits all functionality from UserControl
+    /// <summary>Identifies the XAML-addressable view-model property shared by all navigation control types.</summary>
+    public static readonly StyledProperty<object?> ViewModelProperty =
+        AvaloniaProperty.Register<NavigationUserControl, object?>(nameof(ViewModel));
+
+    /// <summary>The navigate back is enabled property.</summary>
+    public static readonly StyledProperty<bool?> NavigateBackIsEnabledProperty = AvaloniaProperty.Register<
+        NavigationUserControl,
+        bool?
+    >(nameof(NavigateBackIsEnabled), defaultValue: true);
+
+    /// <summary>The navigation frame property.</summary>
+    public static readonly StyledProperty<CoreViewModelRoutedViewHost?> NavigationFrameProperty =
+        AvaloniaProperty.Register<NavigationUserControl, CoreViewModelRoutedViewHost?>(nameof(NavigationFrame));
+
+    /// <summary>Stores the navigation Host Name value.</summary>
+    private string? _navigationHostName;
+
+    /// <summary>Stores a value indicating whether this control is restoring its own content host.</summary>
+    private bool _isUpdatingContent;
+
+    /// <summary>Stores a value indicating whether this control has already disposed its navigation host.</summary>
+    private bool _disposedValue;
+
+    /// <summary>Initializes static members of the <see cref="NavigationUserControl"/> class.</summary>
+    static NavigationUserControl() =>
+        _ = NavigationFrameProperty.Changed.Subscribe(
+            static (e) =>
+            {
+                if (
+                    e.Sender is not NavigationUserControl navigationControl
+                    || e.NewValue.Value is not CoreViewModelRoutedViewHost host)
+                {
+                    return;
+                }
+
+                navigationControl.ConfigureNavigationHost(host, nameof(NavigationUserControl));
+            });
+
+    /// <summary>Gets an observable indicating whether the host can navigate back.</summary>
+    public IObservable<bool?>? CanNavigateBack => NavigationFrame?.CanNavigateBackObservable;
+
+    /// <summary>Gets or sets the stable routed navigation host name.</summary>
+    public string? HostName
+    {
+        get => _navigationHostName ?? Name;
+        set
+        {
+            _navigationHostName = string.IsNullOrWhiteSpace(value) ? null : value;
+            if (NavigationFrame is not { } host)
+            {
+                return;
+            }
+
+            ConfigureNavigationHost(host, nameof(NavigationUserControl));
+        }
+    }
+
+    /// <summary>Gets or sets a value indicating whether back navigation is enabled.</summary>
+    public bool? NavigateBackIsEnabled
+    {
+        get => GetValue(NavigateBackIsEnabledProperty);
+        set => SetValue(NavigateBackIsEnabledProperty, value);
+    }
+
+    /// <summary>Gets or sets the view model exposed to XAML and strongly typed navigation controls.</summary>
+    public object? ViewModel
+    {
+        get => GetValue(ViewModelProperty);
+        set => SetValue(ViewModelProperty, value);
+    }
+
+    /// <summary>Gets the composed routed navigation frame.</summary>
+    public CoreViewModelRoutedViewHost? NavigationFrame
+    {
+        get => GetValue(NavigationFrameProperty);
+        private set => SetValue(NavigationFrameProperty, value);
+    }
+
+    /// <inheritdoc/>
+    string? ISetNavigation.Name => HostName;
+
+    /// <inheritdoc/>
+    string? IUseNavigation.Name => HostName;
+
+    /// <summary>Gets a debugger-friendly textual representation of this instance.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private string DebuggerDisplay => ToString() ?? GetType().Name;
+
+    /// <summary>Disposes the composed navigation frame and unregisters its navigation host aliases.</summary>
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Called when the control finishes initialization.</summary>
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        EnsureHost();
+    }
+
+    /// <inheritdoc/>
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        EnsureHost();
+    }
+
+    /// <inheritdoc/>
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        if (change.Property == NavigateBackIsEnabledProperty && NavigationFrame is { } host)
+        {
+            host.NavigateBackIsEnabled = NavigateBackIsEnabled;
+            return;
+        }
+
+        if (change.Property == NameProperty)
+        {
+            HandleNameChanged();
+            return;
+        }
+
+        if (change.Property != ContentProperty)
+        {
+            return;
+        }
+
+        HandleContentChanged(change.NewValue);
+    }
+
+    /// <summary>Releases managed resources.</summary>
+    /// <param name="disposing">Whether managed resources should be disposed.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposedValue)
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            var frame = NavigationFrame;
+            NavigationFrame = null;
+            if (ReferenceEquals(Content, frame))
+            {
+                Content = null;
+            }
+
+            frame?.Dispose();
+        }
+
+        _disposedValue = true;
+    }
+
+    /// <summary>Ensures the composed navigation frame exists and owns the visible content.</summary>
+    private void EnsureHost()
+    {
+        if (_disposedValue)
+        {
+            return;
+        }
+
+        NavigationFrame ??= CreateNavigationFrame();
+        MoveConsumerContentIntoNavigationFrame(NavigationFrame);
+        ConfigureNavigationHost(NavigationFrame, nameof(NavigationUserControl));
+    }
+
+    /// <summary>Creates a routed navigation frame using the current control state.</summary>
+    /// <returns>The created navigation frame.</returns>
+    private CoreViewModelRoutedViewHost CreateNavigationFrame()
+    {
+        var hostName = ResolveNavigationHostName(nameof(NavigationUserControl));
+        _navigationHostName = hostName;
+        return new()
+        {
+            Name = hostName,
+            HostName = hostName,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalAlignment = VerticalAlignment.Stretch,
+            NavigateBackIsEnabled = NavigateBackIsEnabled,
+        };
+    }
+
+    /// <summary>Moves content supplied by consumers into the composed navigation frame.</summary>
+    /// <param name="host">The composed navigation host.</param>
+    private void MoveConsumerContentIntoNavigationFrame(CoreViewModelRoutedViewHost host)
+    {
+        if (ReferenceEquals(Content, host))
+        {
+            return;
+        }
+
+        var consumerContent = Content;
+        _isUpdatingContent = true;
+        try
+        {
+            if (consumerContent is not null)
+            {
+                Content = null;
+            }
+
+            if (consumerContent is not null && host.Content is null)
+            {
+                host.Content = consumerContent;
+            }
+
+            Content = host;
+        }
+        finally
+        {
+            _isUpdatingContent = false;
+        }
+    }
+
+    /// <summary>Handles content set after the navigation frame has been created.</summary>
+    /// <param name="newValue">The new content value.</param>
+    private void HandleContentChanged(object? newValue)
+    {
+        if (_isUpdatingContent || NavigationFrame is not { } host || ReferenceEquals(newValue, host))
+        {
+            return;
+        }
+
+        _isUpdatingContent = true;
+        try
+        {
+            Content = null;
+            host.Content = newValue;
+            Content = host;
+        }
+        finally
+        {
+            _isUpdatingContent = false;
+        }
+    }
+
+    /// <summary>Handles updates to the Avalonia control name.</summary>
+    private void HandleNameChanged()
+    {
+        if (string.IsNullOrWhiteSpace(Name) || !string.IsNullOrWhiteSpace(_navigationHostName))
+        {
+            return;
+        }
+
+        _navigationHostName = Name;
+        if (NavigationFrame is not { } host)
+        {
+            return;
+        }
+
+        ConfigureNavigationHost(host, nameof(NavigationUserControl));
+    }
+
+    /// <summary>Configures and registers the composed navigation host.</summary>
+    /// <param name="host">The navigation host.</param>
+    /// <param name="fallbackPrefix">The fallback host-name prefix.</param>
+    private void ConfigureNavigationHost(CoreViewModelRoutedViewHost host, string fallbackPrefix)
+    {
+        var hostName = ResolveNavigationHostName(fallbackPrefix);
+        _navigationHostName = hostName;
+        host.HostName = hostName;
+
+        this.SetMainNavigationHost(host);
+    }
+
+    /// <summary>Resolves a stable navigation host name for this control.</summary>
+    /// <param name="fallbackPrefix">The fallback host-name prefix.</param>
+    /// <returns>The resolved host name.</returns>
+    private string ResolveNavigationHostName(string fallbackPrefix)
+    {
+        if (!string.IsNullOrWhiteSpace(_navigationHostName))
+        {
+            return _navigationHostName!;
+        }
+
+        return !string.IsNullOrWhiteSpace(Name)
+            ? Name!
+            : $"__crisscross_navhost_{fallbackPrefix}_{RuntimeHelpers.GetHashCode(this):X8}";
+    }
 }

--- a/src/CrissCross.Avalonia.UI/Controls/NavigationUserControl/NavigationUserControl{TViewModel}.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/NavigationUserControl/NavigationUserControl{TViewModel}.cs
@@ -1,0 +1,45 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Avalonia;
+using ReactiveUI;
+using Splat;
+
+#if REACTIVELIST_REACTIVE
+namespace CrissCross.Reactive.Avalonia.UI.Controls;
+#else
+namespace CrissCross.Avalonia.UI.Controls;
+#endif
+
+/// <summary>A navigation user control with a strongly typed view model.</summary>
+/// <typeparam name="TViewModel">The view model type.</typeparam>
+/// <seealso cref="NavigationUserControl" />
+/// <seealso cref="IViewFor&lt;TViewModel&gt;" />
+public class NavigationUserControl<TViewModel> : NavigationUserControl, IViewFor<TViewModel>
+    where TViewModel : class, IRxObject, new()
+{
+    /// <summary>Gets the binding root view model.</summary>
+    public TViewModel? BindingRoot => ViewModel;
+
+    /// <inheritdoc/>
+    public new TViewModel? ViewModel
+    {
+        get => (TViewModel?)base.ViewModel;
+        set => base.ViewModel = value;
+    }
+
+    /// <inheritdoc/>
+    object? IViewFor.ViewModel
+    {
+        get => ViewModel;
+        set => ViewModel = (TViewModel?)value;
+    }
+
+    /// <inheritdoc/>
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        ViewModel ??= AppLocator.Current.GetService<TViewModel>() ?? new();
+    }
+}

--- a/src/CrissCross.Avalonia.UI/Controls/NavigationView/NavigationView.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/NavigationView/NavigationView.cs
@@ -115,11 +115,9 @@ public partial class NavigationView : TemplatedControl, INavigationView
     public bool Navigate(string pageIdOrTargetTag) => Navigate(pageIdOrTargetTag, null);
 
     /// <inheritdoc />
-    public virtual bool Navigate(string pageIdOrTargetTag, object? dataContext) => !_pageIdOrTargetTagNavigationViewsDictionary.TryGetValue(
-            pageIdOrTargetTag,
-            out var navigationViewItem)
-        ? false
-        : NavigateInternal(navigationViewItem, dataContext);
+    public virtual bool Navigate(string pageIdOrTargetTag, object? dataContext) =>
+        _pageIdOrTargetTagNavigationViewsDictionary.TryGetValue(pageIdOrTargetTag, out var navigationViewItem)
+        && NavigateInternal(navigationViewItem, dataContext);
 
     /// <inheritdoc/>
     public bool NavigateWithHierarchy(Type pageType) => NavigateWithHierarchy(pageType, null);

--- a/src/CrissCross.Avalonia.UI/Controls/PasswordBox/PasswordBox.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/PasswordBox/PasswordBox.cs
@@ -183,23 +183,16 @@ public class PasswordBox : TextBox
             $"INFO: {typeof(PasswordBox)} button clicked with param: {parameter}",
             "CrissCross.Avalonia.UI.PasswordBox");
 
-        switch (parameter)
+        if (parameter == "reveal")
         {
-            case "reveal":
-            {
-                IsPasswordRevealed = !IsPasswordRevealed;
-                RevealPassword = IsPasswordRevealed;
-                _ = Focus();
-                CaretIndex = (Text ?? string.Empty).Length;
-                break;
-            }
-
-            default:
-            {
-                base.OnTemplateButtonClick(parameter);
-                break;
-            }
+            IsPasswordRevealed = !IsPasswordRevealed;
+            RevealPassword = IsPasswordRevealed;
+            _ = Focus();
+            CaretIndex = (Text ?? string.Empty).Length;
+            return;
         }
+
+        base.OnTemplateButtonClick(parameter);
     }
 
     /// <summary>Provides the UpdateTextContents member.</summary>
@@ -304,45 +297,35 @@ public class PasswordBox : TextBox
                 isDeleted = true;
             }
 
-            switch (newCharacters.Length)
+            if (newCharacters.Length > 1)
             {
-                case > 1:
-                {
-                    var index = _currentText.IndexOf(newCharacters[0]);
+                var index = _currentText.IndexOf(newCharacters[0]);
 
-                    _newPasswordValue =
-                        index > _newPasswordValue.Length - 1
-                            ? _newPasswordValue + newCharacters
-                            : _newPasswordValue.Insert(index, newCharacters);
-                    break;
-                }
-
-                case 1:
+                _newPasswordValue =
+                    index > _newPasswordValue.Length - 1
+                        ? _newPasswordValue + newCharacters
+                        : _newPasswordValue.Insert(index, newCharacters);
+            }
+            else if (newCharacters.Length == 1)
+            {
+                for (var i = 0; i < _currentText.Length; i++)
                 {
-                    for (var i = 0; i < _currentText.Length; i++)
+                    if (_currentText[i] == passwordChar)
                     {
-                        if (_currentText[i] == passwordChar)
-                        {
-                            continue;
-                        }
-
-                        UpdatePasswordWithInputCharacter(i, _currentText[i].ToString());
-                        break;
+                        continue;
                     }
 
+                    UpdatePasswordWithInputCharacter(i, _currentText[i].ToString());
                     break;
                 }
-
-                case 0 when !isDeleted:
+            }
+            else if (!isDeleted)
+            {
+                // The input is a PasswordChar, which is to be inserted at the designated position.
+                var insertIndex = selectionIndex - 1;
+                if (insertIndex >= 0)
                 {
-                    // The input is a PasswordChar, which is to be inserted at the designated position.
-                    var insertIndex = selectionIndex - 1;
-                    if (insertIndex >= 0)
-                    {
-                        UpdatePasswordWithInputCharacter(insertIndex, passwordChar.ToString());
-                    }
-
-                    break;
+                    UpdatePasswordWithInputCharacter(insertIndex, passwordChar.ToString());
                 }
             }
 

--- a/src/CrissCross.Avalonia.UI/Controls/ProcessValueIndicator/ProcessValueIndicator.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/ProcessValueIndicator/ProcessValueIndicator.cs
@@ -1,0 +1,167 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Avalonia;
+using Avalonia.Controls.Primitives;
+#if REACTIVELIST_REACTIVE
+using ProcessValueState = global::CrissCross.Reactive.ProcessValueState;
+using ProcessValueStatus = global::CrissCross.Reactive.ProcessValueStatus;
+#else
+using ProcessValueState = global::CrissCross.ProcessValueState;
+using ProcessValueStatus = global::CrissCross.ProcessValueStatus;
+#endif
+
+#if REACTIVELIST_REACTIVE
+namespace CrissCross.Reactive.Avalonia.UI.Controls;
+#else
+namespace CrissCross.Avalonia.UI.Controls;
+#endif
+
+/// <summary>Displays an industrial process value with range, quality, and alarm state.</summary>
+public class ProcessValueIndicator : TemplatedControl
+{
+    /// <summary>Property for <see cref="State"/>.</summary>
+    public static readonly StyledProperty<ProcessValueState?> StateProperty =
+        AvaloniaProperty.Register<ProcessValueIndicator, ProcessValueState?>(nameof(State));
+
+    /// <summary>Property for <see cref="Label"/>.</summary>
+    public static readonly DirectProperty<ProcessValueIndicator, string> LabelProperty =
+        AvaloniaProperty.RegisterDirect<ProcessValueIndicator, string>(
+            nameof(Label),
+            static x => x.Label);
+
+    /// <summary>Property for <see cref="DisplayText"/>.</summary>
+    public static readonly DirectProperty<ProcessValueIndicator, string> DisplayTextProperty =
+        AvaloniaProperty.RegisterDirect<ProcessValueIndicator, string>(
+            nameof(DisplayText),
+            static x => x.DisplayText);
+
+    /// <summary>Property for <see cref="StatusText"/>.</summary>
+    public static readonly DirectProperty<ProcessValueIndicator, string> StatusTextProperty =
+        AvaloniaProperty.RegisterDirect<ProcessValueIndicator, string>(
+            nameof(StatusText),
+            static x => x.StatusText);
+
+    /// <summary>Property for <see cref="Percentage"/>.</summary>
+    public static readonly DirectProperty<ProcessValueIndicator, double> PercentageProperty =
+        AvaloniaProperty.RegisterDirect<ProcessValueIndicator, double>(
+            nameof(Percentage),
+            static x => x.Percentage);
+
+    /// <summary>Property for <see cref="NormalizedValue"/>.</summary>
+    public static readonly DirectProperty<ProcessValueIndicator, double> NormalizedValueProperty =
+        AvaloniaProperty.RegisterDirect<ProcessValueIndicator, double>(
+            nameof(NormalizedValue),
+            static x => x.NormalizedValue);
+
+    /// <summary>Property for <see cref="HasValidValue"/>.</summary>
+    public static readonly DirectProperty<ProcessValueIndicator, bool> HasValidValueProperty =
+        AvaloniaProperty.RegisterDirect<ProcessValueIndicator, bool>(
+            nameof(HasValidValue),
+            static x => x.HasValidValue);
+
+    /// <summary>Property for <see cref="IsAlarm"/>.</summary>
+    public static readonly DirectProperty<ProcessValueIndicator, bool> IsAlarmProperty =
+        AvaloniaProperty.RegisterDirect<ProcessValueIndicator, bool>(
+            nameof(IsAlarm),
+            static x => x.IsAlarm);
+
+    /// <summary>Property for <see cref="Status"/>.</summary>
+    public static readonly DirectProperty<ProcessValueIndicator, ProcessValueStatus> StatusProperty =
+        AvaloniaProperty.RegisterDirect<ProcessValueIndicator, ProcessValueStatus>(
+            nameof(Status),
+            static x => x.Status);
+
+    /// <summary>The fallback process-value snapshot.</summary>
+    private static readonly ProcessValueState EmptyState = new("Process value", null, string.Empty, 0D, 100D);
+
+    /// <summary>Provides the <see cref="ProcessValueIndicator"/> member.</summary>
+    static ProcessValueIndicator() =>
+        _ = StateProperty.Changed.AddClassHandler<ProcessValueIndicator>(static (x, _) => x.UpdateProjectedState());
+
+    /// <summary>Gets or sets the immutable process-value snapshot displayed by the indicator.</summary>
+    public ProcessValueState? State
+    {
+        get => GetValue(StateProperty);
+        set => SetValue(StateProperty, value);
+    }
+
+    /// <summary>Gets the projected measurement label.</summary>
+    public string Label
+    {
+        get;
+        private set => SetAndRaise(LabelProperty, ref field, value);
+    } = EmptyState.Label;
+
+    /// <summary>Gets the projected value and unit display text.</summary>
+    public string DisplayText
+    {
+        get;
+        private set => SetAndRaise(DisplayTextProperty, ref field, value);
+    } = EmptyState.DisplayText;
+
+    /// <summary>Gets the projected status text.</summary>
+    public string StatusText
+    {
+        get;
+        private set => SetAndRaise(StatusTextProperty, ref field, value);
+    } = EmptyState.StatusText;
+
+    /// <summary>Gets the projected range-bar percentage from zero to one hundred.</summary>
+    public double Percentage
+    {
+        get;
+        private set => SetAndRaise(PercentageProperty, ref field, value);
+    } = EmptyState.Percentage;
+
+    /// <summary>Gets the projected normalized value from zero to one.</summary>
+    public double NormalizedValue
+    {
+        get;
+        private set => SetAndRaise(NormalizedValueProperty, ref field, value);
+    } = EmptyState.NormalizedValue;
+
+    /// <summary>Gets a value indicating whether the snapshot has a valid measurement value.</summary>
+    public bool HasValidValue
+    {
+        get;
+        private set => SetAndRaise(HasValidValueProperty, ref field, value);
+    } = EmptyState.HasValidValue;
+
+    /// <summary>Gets a value indicating whether the snapshot is in a low or high alarm state.</summary>
+    public bool IsAlarm
+    {
+        get;
+        private set => SetAndRaise(IsAlarmProperty, ref field, value);
+    } = EmptyState.IsAlarm;
+
+    /// <summary>Gets the projected process-value status.</summary>
+    public ProcessValueStatus Status
+    {
+        get;
+        private set => SetAndRaise(StatusProperty, ref field, value);
+    } = EmptyState.Status;
+
+    /// <inheritdoc/>
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        UpdateProjectedState();
+    }
+
+    /// <summary>Refreshes the public projection from the current immutable state snapshot.</summary>
+    private void UpdateProjectedState()
+    {
+        var state = State ?? EmptyState;
+
+        Label = state.Label;
+        DisplayText = state.DisplayText;
+        StatusText = state.StatusText;
+        Percentage = state.Percentage;
+        NormalizedValue = state.NormalizedValue;
+        HasValidValue = state.HasValidValue;
+        IsAlarm = state.IsAlarm;
+        Status = state.Status;
+    }
+}

--- a/src/CrissCross.Avalonia.UI/Controls/RadioButton/RadioButton.axaml
+++ b/src/CrissCross.Avalonia.UI/Controls/RadioButton/RadioButton.axaml
@@ -45,7 +45,7 @@
                                  Height="{StaticResource RadioButtonCheckGlyphSize}"
                                  Fill="{DynamicResource RadioButtonCheckGlyphFill}"
                                  Opacity="0"
-                                 Stroke="{DynamicResource CircleElevationBorderBrush}" />
+                                 Stroke="{DynamicResource ControlElevationBorderBrush}" />
                     </Grid>
                     <ContentPresenter Grid.Column="1"
                                       Margin="{TemplateBinding Padding}"
@@ -96,7 +96,7 @@
                                  Height="{StaticResource RadioButtonCheckGlyphSize}"
                                  Fill="{DynamicResource RadioButtonCheckGlyphFill}"
                                  Opacity="0"
-                                 Stroke="{DynamicResource CircleElevationBorderBrush}" />
+                                 Stroke="{DynamicResource ControlElevationBorderBrush}" />
                     </Grid>
                     <ContentPresenter Grid.Column="1"
                                       Margin="{TemplateBinding Padding}"

--- a/src/CrissCross.Avalonia.UI/Controls/RichTextBox/Html/HtmlContentParser.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/RichTextBox/Html/HtmlContentParser.cs
@@ -80,33 +80,33 @@ internal static class HtmlContentParser
     /// <param name="writer">The writer value.</param>
     private static void ProcessNode(INode node, in FormattingContext context, SegmentWriter writer)
     {
-        switch (node)
+        if (node is IComment)
         {
-            case IComment:
-                return;
-            case IText textNode:
-            {
-                writer.AppendText(NormalizeWhitespace(textNode.Data), context);
-                return;
-            }
+            return;
+        }
 
-            case IHtmlBreakRowElement:
-            {
-                writer.AppendLineBreak();
-                return;
-            }
+        if (node is IText textNode)
+        {
+            writer.AppendText(NormalizeWhitespace(textNode.Data), context);
+            return;
+        }
 
-            case IHtmlImageElement imageElement:
-            {
-                var imageAlignmentContext = context.WithImageAlignment(ParseAlignment(imageElement));
-                var imageSource = imageElement.GetAttribute("src") ?? imageElement.Source ?? string.Empty;
-                writer.AppendImage(
-                    imageSource,
-                    imageAlignmentContext.ImageAlignment,
-                    ParseLengthAttribute(imageElement, "width"),
-                    ParseLengthAttribute(imageElement, "height"));
-                return;
-            }
+        if (node is IHtmlBreakRowElement)
+        {
+            writer.AppendLineBreak();
+            return;
+        }
+
+        if (node is IHtmlImageElement imageElement)
+        {
+            var imageAlignmentContext = context.WithImageAlignment(ParseAlignment(imageElement));
+            var imageSource = imageElement.GetAttribute("src") ?? imageElement.Source ?? string.Empty;
+            writer.AppendImage(
+                imageSource,
+                imageAlignmentContext.ImageAlignment,
+                ParseLengthAttribute(imageElement, "width"),
+                ParseLengthAttribute(imageElement, "height"));
+            return;
         }
 
         if (node is not IElement element)
@@ -119,6 +119,15 @@ internal static class HtmlContentParser
             return;
         }
 
+        ProcessElement(element, context, writer);
+    }
+
+    /// <summary>Writes an element and its children with inherited formatting.</summary>
+    /// <param name="element">The element to render.</param>
+    /// <param name="context">The inherited formatting.</param>
+    /// <param name="writer">The segment destination.</param>
+    private static void ProcessElement(IElement element, in FormattingContext context, SegmentWriter writer)
+    {
         var scopedContext = context.WithElement(element);
 
         if (element is IHtmlListItemElement)

--- a/src/CrissCross.Avalonia.UI/Controls/RichTextBox/RichTextBox.Clipboard.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/RichTextBox/RichTextBox.Clipboard.cs
@@ -122,7 +122,8 @@ public partial class RichTextBox
     /// <summary>Inserts a dropped image source when drag/drop, image policy, and edit state allow it.</summary>
     /// <param name="imageSource">The image file URI/path or data URI.</param>
     /// <returns><see langword="true"/> when an image was inserted.</returns>
-    public bool TryDropImage(string? imageSource) => imageSource is null ? false : TryInsertImage(imageSource, requireDragDrop: true);
+    public bool TryDropImage(string? imageSource) =>
+        imageSource is not null && TryInsertImage(imageSource, requireDragDrop: true);
 
     /// <summary>Undoes the last action.</summary>
     public void Undo() => UndoCommand.Execute(null);

--- a/src/CrissCross.Avalonia.UI/Controls/RichTextBox/RichTextBox.Rendering.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/RichTextBox/RichTextBox.Rendering.cs
@@ -311,7 +311,7 @@ public partial class RichTextBox
 
         using var reader = new StreamReader(readStream, Encoding.UTF8, true);
         var text = await reader.ReadToEndAsync().ConfigureAwait(true);
-        return Encoding.UTF8.GetByteCount(text) > MaxDroppedTextFileBytes ? false : TryDropText(text);
+        return Encoding.UTF8.GetByteCount(text) <= MaxDroppedTextFileBytes && TryDropText(text);
     }
 
     /// <summary>Provides the MoveSelectionToDropPoint member.</summary>

--- a/src/CrissCross.Avalonia.UI/Controls/ScrollBar/ScrollBar.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/ScrollBar/ScrollBar.cs
@@ -9,7 +9,4 @@ namespace CrissCross.Avalonia.UI.Controls;
 #endif
 
 /// <summary>Represents a scrollbar control (wrapper for Avalonia ScrollBar).</summary>
-public class ScrollBar : global::Avalonia.Controls.Primitives.ScrollBar
-{
-    // Inherits all functionality from Avalonia ScrollBar
-}
+public class ScrollBar : global::Avalonia.Controls.Primitives.ScrollBar;

--- a/src/CrissCross.Avalonia.UI/Controls/Separator/Separator.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/Separator/Separator.cs
@@ -9,7 +9,4 @@ namespace CrissCross.Avalonia.UI.Controls;
 #endif
 
 /// <summary>Represents a separator control for dividing UI elements.</summary>
-public class Separator : global::Avalonia.Controls.Separator
-{
-    // Inherits all functionality from Avalonia Separator
-}
+public class Separator : global::Avalonia.Controls.Separator;

--- a/src/CrissCross.Avalonia.UI/Controls/SplitButton/SplitButton.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/SplitButton/SplitButton.cs
@@ -11,8 +11,4 @@ namespace CrissCross.Avalonia.UI.Controls;
 #endif
 
 /// <summary>Represents a button with two parts that can be invoked separately.</summary>
-public class SplitButton : global::Avalonia.Controls.SplitButton
-{
-    /// <inheritdoc/>
-    protected override Type StyleKeyOverride => typeof(global::Avalonia.Controls.SplitButton);
-}
+public class SplitButton : global::Avalonia.Controls.SplitButton;

--- a/src/CrissCross.Avalonia.UI/Controls/Stepper/Stepper.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/Stepper/Stepper.cs
@@ -95,6 +95,9 @@ public class Stepper : ItemsControl
     /// <summary>Gets the command that requests a specific step key or descriptor.</summary>
     public ICommand JumpToStepCommand { get; }
 
+    /// <inheritdoc />
+    protected override Type StyleKeyOverride => typeof(Stepper);
+
     /// <summary>Requests navigation to the specified step key.</summary>
     /// <param name="stepKey">The stable step key.</param>
     public void RequestStep(string? stepKey)
@@ -134,13 +137,14 @@ public class Stepper : ItemsControl
 
         base.OnPropertyChanged(change);
 
-        if (change.Property != StateProperty || change.GetNewValue<StepperState?>() is not { } state)
+        if (change.Property != StateProperty)
         {
             return;
         }
 
-        CurrentKey = state.CurrentKey;
-        ItemsSource = state.Steps;
+        var state = change.GetNewValue<StepperState?>();
+        CurrentKey = state?.CurrentKey;
+        ItemsSource = state?.Steps;
     }
 
     /// <summary>Provides the RequestPreviousStep member.</summary>

--- a/src/CrissCross.Avalonia.UI/Controls/SymbolRegular.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/SymbolRegular.cs
@@ -9,10 +9,6 @@ namespace CrissCross.Avalonia.UI.Controls;
 #endif
 
 /// <summary>Represents Fluent System Icons regular symbols.</summary>
-[System.Diagnostics.CodeAnalysis.SuppressMessage(
-    "Design",
-    "CA1069:Enums values should not be duplicated",
-    Justification = "By design for mirroring purposes.")]
 public enum SymbolRegular
 {
     /// <summary>Empty symbol.</summary>

--- a/src/CrissCross.Avalonia.UI/Controls/TabControl/TabControl.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/TabControl/TabControl.cs
@@ -9,7 +9,4 @@ namespace CrissCross.Avalonia.UI.Controls;
 #endif
 
 /// <summary>Represents a control that contains multiple items that share the same space on the screen.</summary>
-public class TabControl : global::Avalonia.Controls.TabControl
-{
-    // Inherits all functionality from Avalonia TabControl
-}
+public class TabControl : global::Avalonia.Controls.TabControl;

--- a/src/CrissCross.Avalonia.UI/Controls/ToggleButton/ToggleButton.axaml
+++ b/src/CrissCross.Avalonia.UI/Controls/ToggleButton/ToggleButton.axaml
@@ -7,8 +7,8 @@
     <Thickness x:Key="ToggleButtonIconMargin">0,0,8,0</Thickness>
 
     <Style x:Key="DefaultToggleButtonStyle" Selector="ToggleButton">
-        <Setter Property="Background" Value="{DynamicResource ToggleButtonBackground}" />
-        <Setter Property="Foreground" Value="{DynamicResource ToggleButtonForeground}" />
+        <Setter Property="Background" Value="{DynamicResource ButtonBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource ButtonForeground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
         <Setter Property="BorderThickness" Value="{StaticResource ToggleButtonBorderThemeThickness}" />
         <Setter Property="Padding" Value="{StaticResource ToggleButtonPadding}" />
@@ -16,7 +16,7 @@
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="CornerRadius" Value="4" />
         <Setter Property="Template">
             <ControlTemplate>
                 <Border x:Name="ContentBorder"
@@ -43,8 +43,8 @@
     </Style>
 
     <Style x:Key="DefaultuiToggleButtonStyle" Selector="controls|ToggleButton">
-        <Setter Property="Background" Value="{DynamicResource ToggleButtonBackground}" />
-        <Setter Property="Foreground" Value="{DynamicResource ToggleButtonForeground}" />
+        <Setter Property="Background" Value="{DynamicResource ButtonBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource ButtonForeground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ControlElevationBorderBrush}" />
         <Setter Property="BorderThickness" Value="{StaticResource ToggleButtonBorderThemeThickness}" />
         <Setter Property="Padding" Value="{StaticResource ToggleButtonPadding}" />
@@ -52,7 +52,7 @@
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="CornerRadius" Value="4" />
         <Setter Property="Template">
             <ControlTemplate>
                 <Border x:Name="ContentBorder"

--- a/src/CrissCross.Avalonia.UI/Controls/ValidationSummary/ValidationSummary.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/ValidationSummary/ValidationSummary.cs
@@ -41,6 +41,9 @@ public class ValidationSummary : ItemsControl
     }
 
     /// <inheritdoc />
+    protected override Type StyleKeyOverride => typeof(ValidationSummary);
+
+    /// <inheritdoc />
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         ArgumentNullException.ThrowIfNull(change);

--- a/src/CrissCross.Avalonia.UI/Controls/Window/Window.cs
+++ b/src/CrissCross.Avalonia.UI/Controls/Window/Window.cs
@@ -9,4 +9,8 @@ namespace CrissCross.Avalonia.UI.Controls;
 #endif
 
 /// <summary>Window member.</summary>
-public class Window : global::Avalonia.Controls.Window;
+public class Window : global::Avalonia.Controls.Window
+{
+    /// <inheritdoc />
+    protected override Type StyleKeyOverride => GetType();
+}

--- a/src/CrissCross.Avalonia.UI/Converters/BoolToInvertedBoolConverter.cs
+++ b/src/CrissCross.Avalonia.UI/Converters/BoolToInvertedBoolConverter.cs
@@ -18,7 +18,8 @@ public class BoolToInvertedBoolConverter : IValueConverter
     public static BoolToInvertedBoolConverter Instance { get; } = new();
 
     /// <inheritdoc/>
-    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => value is bool boolValue ? !boolValue : false;
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is bool boolValue && !boolValue;
 
     /// <inheritdoc/>
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>

--- a/src/CrissCross.Avalonia.UI/Converters/EnumToBoolConverter.cs
+++ b/src/CrissCross.Avalonia.UI/Converters/EnumToBoolConverter.cs
@@ -19,7 +19,8 @@ public class EnumToBoolConverter : IValueConverter
     public static EnumToBoolConverter Instance { get; } = new();
 
     /// <inheritdoc/>
-    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => value is null || parameter is null ? false : value.Equals(parameter);
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is not null && parameter is not null && value.Equals(parameter);
 
     /// <inheritdoc/>
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => value is true && parameter is not null ? parameter : BindingOperations.DoNothing;

--- a/src/CrissCross.Avalonia.UI/Converters/FirstCommandConverter.cs
+++ b/src/CrissCross.Avalonia.UI/Converters/FirstCommandConverter.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Windows.Input;
+using Avalonia.Data.Converters;
+
+#if REACTIVELIST_REACTIVE
+namespace CrissCross.Reactive.Avalonia.UI.Converters;
+#else
+namespace CrissCross.Avalonia.UI.Converters;
+#endif
+
+/// <summary>Selects the first command supplied by a control or its model.</summary>
+public sealed class FirstCommandConverter : IMultiValueConverter
+{
+    /// <summary>Gets the shared converter instance.</summary>
+    public static FirstCommandConverter Instance { get; } = new();
+
+    /// <inheritdoc />
+    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        foreach (var value in values)
+        {
+            if (value is ICommand command)
+            {
+                return command;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/CrissCross.Avalonia.UI/CrissCross.Avalonia.UI.csproj
+++ b/src/CrissCross.Avalonia.UI/CrissCross.Avalonia.UI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(CrissCrossAvaloniaTargetFrameworks);</TargetFrameworks>
@@ -22,7 +22,6 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EnablePackageValidation>true</EnablePackageValidation>
     <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
-    <NoWarn>$(NoWarn);CA1812</NoWarn>
   </PropertyGroup>
 
   <!-- Release specific optimizations -->

--- a/src/CrissCross.Avalonia.UI/Resources/FluentTheme.axaml
+++ b/src/CrissCross.Avalonia.UI/Resources/FluentTheme.axaml
@@ -1,5 +1,6 @@
 <Styles xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:appearance="clr-namespace:CrissCross.Avalonia.UI.Appearance">
     <Styles.Resources>
         <ResourceDictionary>
             <ResourceDictionary.ThemeDictionaries>
@@ -11,6 +12,11 @@
                 <ResourceDictionary x:Key="Light">
                     <ResourceDictionary.MergedDictionaries>
                         <ResourceInclude Source="/Resources/Theme/Light.axaml" />
+                    </ResourceDictionary.MergedDictionaries>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="{x:Static appearance:ApplicationThemeManager.HighContrastThemeVariant}">
+                    <ResourceDictionary.MergedDictionaries>
+                        <ResourceInclude Source="/Resources/Theme/HighContrast.axaml" />
                     </ResourceDictionary.MergedDictionaries>
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>

--- a/src/CrissCross.Avalonia.UI/Resources/Theme/Dark.axaml
+++ b/src/CrissCross.Avalonia.UI/Resources/Theme/Dark.axaml
@@ -1,6 +1,8 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
+    <x:Double x:Key="DisabledTextControlOpacity">0.5</x:Double>
+
     <!-- Application Background -->
     <Color x:Key="ApplicationBackgroundColor">#FF202020</Color>
     <SolidColorBrush x:Key="ApplicationBackgroundBrush" Color="{StaticResource ApplicationBackgroundColor}" />
@@ -253,6 +255,8 @@
     <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{StaticResource TextFillColorSecondary}" />
     <SolidColorBrush x:Key="ButtonForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+    <SolidColorBrush x:Key="ButtonBorderBrush" Color="{StaticResource ControlStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="{StaticResource ControlStrokeColorSecondary}" />
     <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="{StaticResource ControlStrokeColorDefault}" />
     <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="{StaticResource ControlStrokeColorDefault}" />
 

--- a/src/CrissCross.Avalonia.UI/Resources/Theme/HighContrast.axaml
+++ b/src/CrissCross.Avalonia.UI/Resources/Theme/HighContrast.axaml
@@ -1,0 +1,401 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <x:Double x:Key="DisabledTextControlOpacity">1</x:Double>
+
+    <!-- Application Background -->
+    <Color x:Key="ApplicationBackgroundColor">#FF000000</Color>
+    <SolidColorBrush x:Key="ApplicationBackgroundBrush" Color="{StaticResource ApplicationBackgroundColor}" />
+
+    <Color x:Key="KeyboardFocusBorderColor">#FFFFFFFF</Color>
+    <SolidColorBrush x:Key="KeyboardFocusBorderColorBrush" Color="{StaticResource KeyboardFocusBorderColor}" />
+
+    <!-- Text Fill Colors -->
+    <Color x:Key="TextFillColorPrimary">#FFFFFFFF</Color>
+    <Color x:Key="TextFillColorSecondary">#FFFFFFFF</Color>
+    <Color x:Key="TextFillColorTertiary">#FFFFFFFF</Color>
+    <Color x:Key="TextFillColorDisabled">#FF808080</Color>
+    <Color x:Key="TextPlaceholderColor">#FF808080</Color>
+    <Color x:Key="TextFillColorInverse">#FF000000</Color>
+
+    <Color x:Key="AccentTextFillColorDisabled">#FF808080</Color>
+    <Color x:Key="TextOnAccentFillColorSelectedText">#FF000000</Color>
+    <Color x:Key="TextOnAccentFillColorPrimary">#FF000000</Color>
+    <Color x:Key="TextOnAccentFillColorSecondary">#FF000000</Color>
+    <Color x:Key="TextOnAccentFillColorDisabled">#FF808080</Color>
+
+    <!-- Control Fill Colors -->
+    <Color x:Key="ControlFillColorDefault">#FF000000</Color>
+    <Color x:Key="ControlFillColorSecondary">#FF000000</Color>
+    <Color x:Key="ControlFillColorTertiary">#FF000000</Color>
+    <Color x:Key="ControlFillColorDisabled">#FF000000</Color>
+    <Color x:Key="ControlFillColorTransparent">#00FFFFFF</Color>
+    <Color x:Key="ControlFillColorInputActive">#FF000000</Color>
+
+    <Color x:Key="ControlStrongFillColorDefault">#FFFFFFFF</Color>
+    <Color x:Key="ControlStrongFillColorDisabled">#FF808080</Color>
+
+    <Color x:Key="ControlSolidFillColorDefault">#FF000000</Color>
+
+    <!-- Subtle Fill Colors -->
+    <Color x:Key="SubtleFillColorTransparent">#00FFFFFF</Color>
+    <Color x:Key="SubtleFillColorSecondary">#FF000000</Color>
+    <Color x:Key="SubtleFillColorTertiary">#FF000000</Color>
+    <Color x:Key="SubtleFillColorDisabled">#00FFFFFF</Color>
+
+    <!-- Control Alt Fill Colors -->
+    <Color x:Key="ControlAltFillColorTransparent">#00FFFFFF</Color>
+    <Color x:Key="ControlAltFillColorSecondary">#FF000000</Color>
+    <Color x:Key="ControlAltFillColorTertiary">#FF000000</Color>
+    <Color x:Key="ControlAltFillColorQuarternary">#FF000000</Color>
+    <Color x:Key="ControlAltFillColorDisabled">#FF000000</Color>
+
+    <!-- Control On Image Fill Colors -->
+    <Color x:Key="ControlOnImageFillColorDefault">#FF000000</Color>
+    <Color x:Key="ControlOnImageFillColorSecondary">#FF000000</Color>
+    <Color x:Key="ControlOnImageFillColorTertiary">#FF000000</Color>
+    <Color x:Key="ControlOnImageFillColorDisabled">#FF000000</Color>
+
+    <Color x:Key="AccentFillColorDisabled">#FF000000</Color>
+
+    <!-- Control Stroke Colors -->
+    <Color x:Key="ControlStrokeColorDefault">#FFFFFFFF</Color>
+    <Color x:Key="ControlStrokeColorSecondary">#FFFFFFFF</Color>
+    <Color x:Key="ControlStrokeColorTertiary">#FFFFFFFF</Color>
+    <Color x:Key="ControlStrokeColorOnAccentDefault">#FFFFFFFF</Color>
+    <Color x:Key="ControlStrokeColorOnAccentSecondary">#FFFFFFFF</Color>
+    <Color x:Key="ControlStrokeColorOnAccentTertiary">#FFFFFFFF</Color>
+    <Color x:Key="ControlStrokeColorOnAccentDisabled">#FF808080</Color>
+
+    <Color x:Key="ControlStrokeColorForStrongFillWhenOnImage">#FFFFFFFF</Color>
+
+    <!-- Card Stroke Colors -->
+    <Color x:Key="CardStrokeColorDefault">#FFFFFFFF</Color>
+    <Color x:Key="CardStrokeColorDefaultSolid">#FFFFFFFF</Color>
+
+    <Color x:Key="ControlStrongStrokeColorDefault">#FFFFFFFF</Color>
+    <Color x:Key="ControlStrongStrokeColorDisabled">#FF808080</Color>
+
+    <!-- Surface Stroke Colors -->
+    <Color x:Key="SurfaceStrokeColorDefault">#FFFFFFFF</Color>
+    <Color x:Key="SurfaceStrokeColorFlyout">#FFFFFFFF</Color>
+    <Color x:Key="SurfaceStrokeColorInverse">#FFFFFFFF</Color>
+
+    <Color x:Key="DividerStrokeColorDefault">#FFFFFFFF</Color>
+
+    <!-- Focus Stroke Colors -->
+    <Color x:Key="FocusStrokeColorOuter">#FFFFFF</Color>
+    <Color x:Key="FocusStrokeColorInner">#FF000000</Color>
+
+    <!-- Card Background Colors -->
+    <Color x:Key="CardBackgroundFillColorDefault">#FF000000</Color>
+    <Color x:Key="CardBackgroundFillColorSecondary">#FF000000</Color>
+
+    <Color x:Key="SmokeFillColorDefault">#FF000000</Color>
+
+    <!-- Layer Fill Colors -->
+    <Color x:Key="LayerFillColorDefault">#FF000000</Color>
+    <Color x:Key="LayerFillColorAlt">#FF000000</Color>
+    <Color x:Key="LayerOnAcrylicFillColorDefault">#FF000000</Color>
+    <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#FF000000</Color>
+
+    <Color x:Key="AcrylicBackgroundFillColorDefault">#FF000000</Color>
+
+    <!-- Layer On Mica Base Alt Colors -->
+    <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#FF000000</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#FF000000</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#FF000000</Color>
+    <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#FF000000</Color>
+
+    <!-- Solid Background Colors -->
+    <Color x:Key="SolidBackgroundFillColorBase">#FF000000</Color>
+    <Color x:Key="SolidBackgroundFillColorSecondary">#FF000000</Color>
+    <Color x:Key="SolidBackgroundFillColorTertiary">#FF000000</Color>
+    <Color x:Key="SolidBackgroundFillColorQuarternary">#FF000000</Color>
+    <Color x:Key="SolidBackgroundFillColorTransparent">#00000000</Color>
+    <Color x:Key="SolidBackgroundFillColorBaseAlt">#FF000000</Color>
+
+    <!-- System Fill Colors -->
+    <Color x:Key="SystemFillColorAttention">#FFFFFF00</Color>
+    <Color x:Key="SystemFillColorInformational">#FFFFFFFF</Color>
+    <Color x:Key="SystemFillColorSuccess">#FF00FF00</Color>
+    <Color x:Key="SystemFillColorCaution">#FFFFFF00</Color>
+    <Color x:Key="SystemFillColorCritical">#FFFF4040</Color>
+    <Color x:Key="SystemFillColorNeutral">#FFFFFFFF</Color>
+    <Color x:Key="SystemFillColorSolidNeutral">#FFFFFFFF</Color>
+    <Color x:Key="SystemFillColorAttentionBackground">#FF000000</Color>
+    <Color x:Key="SystemFillColorSuccessBackground">#FF000000</Color>
+    <Color x:Key="SystemFillColorCautionBackground">#FF000000</Color>
+    <Color x:Key="SystemFillColorCriticalBackground">#FF000000</Color>
+    <Color x:Key="SystemFillColorNeutralBackground">#FF000000</Color>
+    <Color x:Key="SystemFillColorSolidAttentionBackground">#FF000000</Color>
+    <Color x:Key="SystemFillColorSolidNeutralBackground">#FF000000</Color>
+
+    <!-- System Accent Colors (default blue) -->
+    <Color x:Key="SystemAccentColor">#FFFFFF00</Color>
+    <Color x:Key="SystemAccentColorPrimary">#FFFFFF00</Color>
+    <Color x:Key="SystemAccentColorSecondary">#FFFFFFFF</Color>
+    <Color x:Key="SystemAccentColorTertiary">#FFC0C000</Color>
+
+    <!-- ========== BRUSHES ========== -->
+
+    <!-- Text Fill Brushes -->
+    <SolidColorBrush x:Key="TextFillColorPrimaryBrush" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="{StaticResource TextFillColorSecondary}" />
+    <SolidColorBrush x:Key="TextFillColorTertiaryBrush" Color="{StaticResource TextFillColorTertiary}" />
+    <SolidColorBrush x:Key="TextFillColorDisabledBrush" Color="{StaticResource TextFillColorDisabled}" />
+    <SolidColorBrush x:Key="TextPlaceholderColorBrush" Color="{StaticResource TextPlaceholderColor}" />
+    <SolidColorBrush x:Key="TextFillColorInverseBrush" Color="{StaticResource TextFillColorInverse}" />
+
+    <SolidColorBrush x:Key="AccentTextFillColorDisabledBrush" Color="{StaticResource AccentTextFillColorDisabled}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorSelectedTextBrush" Color="{StaticResource TextOnAccentFillColorSelectedText}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorPrimaryBrush" Color="{StaticResource TextOnAccentFillColorPrimary}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorSecondaryBrush" Color="{StaticResource TextOnAccentFillColorSecondary}" />
+    <SolidColorBrush x:Key="TextOnAccentFillColorDisabledBrush" Color="{StaticResource TextOnAccentFillColorDisabled}" />
+
+    <!-- Control Fill Brushes -->
+    <SolidColorBrush x:Key="ControlFillColorDefaultBrush" Color="{StaticResource ControlFillColorDefault}" />
+    <SolidColorBrush x:Key="ControlFillColorSecondaryBrush" Color="{StaticResource ControlFillColorSecondary}" />
+    <SolidColorBrush x:Key="ControlFillColorTertiaryBrush" Color="{StaticResource ControlFillColorTertiary}" />
+    <SolidColorBrush x:Key="ControlFillColorDisabledBrush" Color="{StaticResource ControlFillColorDisabled}" />
+    <SolidColorBrush x:Key="ControlFillColorTransparentBrush" Color="{StaticResource ControlFillColorTransparent}" />
+    <SolidColorBrush x:Key="ControlFillColorInputActiveBrush" Color="{StaticResource ControlFillColorInputActive}" />
+
+    <SolidColorBrush x:Key="ControlStrongFillColorDefaultBrush" Color="{StaticResource ControlStrongFillColorDefault}" />
+    <SolidColorBrush x:Key="ControlStrongFillColorDisabledBrush" Color="{StaticResource ControlStrongFillColorDisabled}" />
+    <SolidColorBrush x:Key="ControlSolidFillColorDefaultBrush" Color="{StaticResource ControlSolidFillColorDefault}" />
+
+    <!-- Subtle Fill Brushes -->
+    <SolidColorBrush x:Key="SubtleFillColorTransparentBrush" Color="{StaticResource SubtleFillColorTransparent}" />
+    <SolidColorBrush x:Key="SubtleFillColorSecondaryBrush" Color="{StaticResource SubtleFillColorSecondary}" />
+    <SolidColorBrush x:Key="SubtleFillColorTertiaryBrush" Color="{StaticResource SubtleFillColorTertiary}" />
+    <SolidColorBrush x:Key="SubtleFillColorDisabledBrush" Color="{StaticResource SubtleFillColorDisabled}" />
+
+    <!-- Control Alt Fill Brushes -->
+    <SolidColorBrush x:Key="ControlAltFillColorTransparentBrush" Color="{StaticResource ControlAltFillColorTransparent}" />
+    <SolidColorBrush x:Key="ControlAltFillColorSecondaryBrush" Color="{StaticResource ControlAltFillColorSecondary}" />
+    <SolidColorBrush x:Key="ControlAltFillColorTertiaryBrush" Color="{StaticResource ControlAltFillColorTertiary}" />
+    <SolidColorBrush x:Key="ControlAltFillColorQuarternaryBrush" Color="{StaticResource ControlAltFillColorQuarternary}" />
+    <SolidColorBrush x:Key="ControlAltFillColorDisabledBrush" Color="{StaticResource ControlAltFillColorDisabled}" />
+
+    <!-- Accent Fill Brushes -->
+    <SolidColorBrush x:Key="AccentFillColorDisabledBrush" Color="{StaticResource AccentFillColorDisabled}" />
+
+    <!-- Control Stroke Brushes -->
+    <SolidColorBrush x:Key="ControlStrokeColorDefaultBrush" Color="{StaticResource ControlStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ControlStrokeColorSecondaryBrush" Color="{StaticResource ControlStrokeColorSecondary}" />
+    <SolidColorBrush x:Key="ControlStrokeColorTertiaryBrush" Color="{StaticResource ControlStrokeColorTertiary}" />
+    <SolidColorBrush x:Key="ControlStrokeColorOnAccentDefaultBrush" Color="{StaticResource ControlStrokeColorOnAccentDefault}" />
+    <SolidColorBrush x:Key="ControlStrokeColorOnAccentSecondaryBrush" Color="{StaticResource ControlStrokeColorOnAccentSecondary}" />
+    <SolidColorBrush x:Key="ControlStrokeColorOnAccentTertiaryBrush" Color="{StaticResource ControlStrokeColorOnAccentTertiary}" />
+    <SolidColorBrush x:Key="ControlStrokeColorOnAccentDisabledBrush" Color="{StaticResource ControlStrokeColorOnAccentDisabled}" />
+
+    <!-- Card Stroke Brushes -->
+    <SolidColorBrush x:Key="CardStrokeColorDefaultBrush" Color="{StaticResource CardStrokeColorDefault}" />
+    <SolidColorBrush x:Key="CardStrokeColorDefaultSolidBrush" Color="{StaticResource CardStrokeColorDefaultSolid}" />
+
+    <SolidColorBrush x:Key="ControlStrongStrokeColorDefaultBrush" Color="{StaticResource ControlStrongStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ControlStrongStrokeColorDisabledBrush" Color="{StaticResource ControlStrongStrokeColorDisabled}" />
+
+    <!-- Surface Stroke Brushes -->
+    <SolidColorBrush x:Key="SurfaceStrokeColorDefaultBrush" Color="{StaticResource SurfaceStrokeColorDefault}" />
+    <SolidColorBrush x:Key="SurfaceStrokeColorFlyoutBrush" Color="{StaticResource SurfaceStrokeColorFlyout}" />
+    <SolidColorBrush x:Key="SurfaceStrokeColorInverseBrush" Color="{StaticResource SurfaceStrokeColorInverse}" />
+
+    <SolidColorBrush x:Key="DividerStrokeColorDefaultBrush" Color="{StaticResource DividerStrokeColorDefault}" />
+
+    <!-- Focus Stroke Brushes -->
+    <SolidColorBrush x:Key="FocusStrokeColorOuterBrush" Color="{StaticResource FocusStrokeColorOuter}" />
+    <SolidColorBrush x:Key="FocusStrokeColorInnerBrush" Color="{StaticResource FocusStrokeColorInner}" />
+
+    <!-- Card Background Brushes -->
+    <SolidColorBrush x:Key="CardBackgroundFillColorDefaultBrush" Color="{StaticResource CardBackgroundFillColorDefault}" />
+    <SolidColorBrush x:Key="CardBackgroundFillColorSecondaryBrush" Color="{StaticResource CardBackgroundFillColorSecondary}" />
+
+    <SolidColorBrush x:Key="SmokeFillColorDefaultBrush" Color="{StaticResource SmokeFillColorDefault}" />
+
+    <!-- Layer Fill Brushes -->
+    <SolidColorBrush x:Key="LayerFillColorDefaultBrush" Color="{StaticResource LayerFillColorDefault}" />
+    <SolidColorBrush x:Key="LayerFillColorAltBrush" Color="{StaticResource LayerFillColorAlt}" />
+    <SolidColorBrush x:Key="LayerOnAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnAcrylicFillColorDefault}" />
+
+    <!-- Solid Background Brushes -->
+    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource SolidBackgroundFillColorBase}" />
+    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource SolidBackgroundFillColorSecondary}" />
+    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{StaticResource SolidBackgroundFillColorTertiary}" />
+    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{StaticResource SolidBackgroundFillColorQuarternary}" />
+    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseAltBrush" Color="{StaticResource SolidBackgroundFillColorBaseAlt}" />
+
+    <!-- System Fill Brushes -->
+    <SolidColorBrush x:Key="SystemFillColorSuccessBrush" Color="{StaticResource SystemFillColorSuccess}" />
+    <SolidColorBrush x:Key="SystemFillColorCautionBrush" Color="{StaticResource SystemFillColorCaution}" />
+    <SolidColorBrush x:Key="SystemFillColorCriticalBrush" Color="{StaticResource SystemFillColorCritical}" />
+    <SolidColorBrush x:Key="SystemFillColorNeutralBrush" Color="{StaticResource SystemFillColorNeutral}" />
+    <SolidColorBrush x:Key="SystemFillColorSolidNeutralBrush" Color="{StaticResource SystemFillColorSolidNeutral}" />
+    <SolidColorBrush x:Key="SystemFillColorAttentionBackgroundBrush" Color="{StaticResource SystemFillColorAttentionBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorSuccessBackgroundBrush" Color="{StaticResource SystemFillColorSuccessBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorCautionBackgroundBrush" Color="{StaticResource SystemFillColorCautionBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorCriticalBackgroundBrush" Color="{StaticResource SystemFillColorCriticalBackground}" />
+    <SolidColorBrush x:Key="SystemFillColorNeutralBackgroundBrush" Color="{StaticResource SystemFillColorNeutralBackground}" />
+
+    <!-- ========== CONTROL-SPECIFIC BRUSHES ========== -->
+
+    <!-- Button -->
+    <SolidColorBrush x:Key="AccentButtonBackground" Color="{StaticResource SystemAccentColorPrimary}" />
+    <SolidColorBrush x:Key="AccentButtonBackgroundPointerOver" Color="{StaticResource SystemAccentColorSecondary}" />
+    <SolidColorBrush x:Key="AccentButtonBackgroundPressed" Color="{StaticResource SystemAccentColorTertiary}" />
+    <SolidColorBrush x:Key="AccentButtonForeground" Color="{StaticResource TextOnAccentFillColorPrimary}" />
+    <SolidColorBrush x:Key="AccentButtonForegroundPointerOver" Color="{StaticResource TextOnAccentFillColorPrimary}" />
+    <SolidColorBrush x:Key="AccentButtonForegroundPressed" Color="{StaticResource TextOnAccentFillColorSecondary}" />
+    <SolidColorBrush x:Key="ButtonBackground" Color="{StaticResource ControlFillColorDefault}" />
+    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{StaticResource ControlFillColorSecondary}" />
+    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="{StaticResource ControlFillColorTertiary}" />
+    <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="{StaticResource ControlFillColorDisabled}" />
+    <SolidColorBrush x:Key="ButtonForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{StaticResource TextFillColorSecondary}" />
+    <SolidColorBrush x:Key="ButtonForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+    <SolidColorBrush x:Key="ButtonBorderBrush" Color="{StaticResource ControlStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="{StaticResource ControlStrokeColorSecondary}" />
+    <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="{StaticResource ControlStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="{StaticResource ControlStrokeColorDefault}" />
+
+    <!-- CheckBox -->
+    <SolidColorBrush x:Key="CheckBoxBackground" Color="{StaticResource ControlAltFillColorSecondary}" />
+    <SolidColorBrush x:Key="CheckBoxForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="CheckBoxBorderBrush" Color="{StaticResource ControlStrongStrokeColorDefault}" />
+    <SolidColorBrush x:Key="CheckBoxCheckGlyphForeground" Color="{StaticResource TextOnAccentFillColorPrimary}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBackgroundFillChecked" Color="{StaticResource SystemAccentColorPrimary}" />
+    <SolidColorBrush x:Key="CheckBoxCheckBackgroundFillCheckedPointerOver" Color="{StaticResource SystemAccentColorSecondary}" />
+
+    <!-- RadioButton -->
+    <SolidColorBrush x:Key="RadioButtonForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="RadioButtonForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseCheckedStroke" Color="{StaticResource SystemAccentColorPrimary}" />
+    <SolidColorBrush x:Key="RadioButtonCheckGlyphFill" Color="{StaticResource TextOnAccentFillColorPrimary}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseFill" Color="{StaticResource ControlAltFillColorSecondary}" />
+    <SolidColorBrush x:Key="RadioButtonOuterEllipseStroke" Color="{StaticResource ControlStrongStrokeColorDefault}" />
+
+    <!-- ToggleSwitch -->
+    <SolidColorBrush x:Key="ToggleSwitchContentForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOff" Color="{StaticResource ControlStrongStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ToggleSwitchStrokeOn" Color="{StaticResource SystemAccentColorPrimary}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOn" Color="{StaticResource SystemAccentColorPrimary}" />
+    <SolidColorBrush x:Key="ToggleSwitchFillOff" Color="{StaticResource ControlAltFillColorSecondary}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOff" Color="{StaticResource TextFillColorSecondary}" />
+    <SolidColorBrush x:Key="ToggleSwitchKnobFillOn" Color="{StaticResource TextOnAccentFillColorPrimary}" />
+
+    <!-- ProgressBar -->
+    <SolidColorBrush x:Key="ProgressBarForeground" Color="{StaticResource SystemAccentColorPrimary}" />
+    <SolidColorBrush x:Key="ProgressBarBackground" Color="{StaticResource ControlStrongStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ProgressBarBorderBrush" Color="{StaticResource ControlStrokeColorDefault}" />
+
+    <!-- ProgressRing -->
+    <SolidColorBrush x:Key="ProgressRingForegroundThemeBrush" Color="{StaticResource SystemAccentColorPrimary}" />
+    <SolidColorBrush x:Key="ProgressRingBackgroundThemeBrush" Color="{StaticResource ControlFillColorTransparent}" />
+
+    <!-- Slider -->
+    <SolidColorBrush x:Key="SliderTrackFill" Color="{StaticResource ControlStrongFillColorDefault}" />
+    <SolidColorBrush x:Key="SliderThumbBackground" Color="{StaticResource SystemAccentColorPrimary}" />
+    <SolidColorBrush x:Key="SliderThumbBackgroundPointerOver" Color="{StaticResource SystemAccentColorSecondary}" />
+    <SolidColorBrush x:Key="SliderOuterThumbBackground" Color="{StaticResource ControlSolidFillColorDefault}" />
+
+    <!-- TextBox -->
+    <SolidColorBrush x:Key="TextControlBackground" Color="{StaticResource ControlFillColorDefault}" />
+    <SolidColorBrush x:Key="TextControlBackgroundPointerOver" Color="{StaticResource ControlFillColorSecondary}" />
+    <SolidColorBrush x:Key="TextControlBackgroundFocused" Color="{StaticResource ControlFillColorInputActive}" />
+    <SolidColorBrush x:Key="TextControlBackgroundDisabled" Color="{StaticResource ControlFillColorDisabled}" />
+    <SolidColorBrush x:Key="TextControlForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="TextControlForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+    <SolidColorBrush x:Key="TextControlBorderBrush" Color="{StaticResource ControlStrokeColorDefault}" />
+    <SolidColorBrush x:Key="TextControlBorderBrushPointerOver" Color="{StaticResource ControlStrokeColorSecondary}" />
+    <SolidColorBrush x:Key="TextControlBorderBrushFocused" Color="{StaticResource SystemAccentColorPrimary}" />
+    <SolidColorBrush x:Key="TextControlFocusedBorderBrush" Color="{StaticResource SystemAccentColorPrimary}" />
+    <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="{StaticResource TextFillColorSecondary}" />
+
+    <!-- ComboBox -->
+    <SolidColorBrush x:Key="ComboBoxBackground" Color="{StaticResource ControlFillColorDefault}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundFocused" Color="{StaticResource ControlFillColorDefault}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundPointerOver" Color="{StaticResource ControlFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxBackgroundDisabled" Color="{StaticResource ControlFillColorDisabled}" />
+    <SolidColorBrush x:Key="ComboBoxForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="ComboBoxForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrush" Color="{StaticResource ControlStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrushPointerOver" Color="{StaticResource ControlStrokeColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrushDisabled" Color="{StaticResource ControlStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ComboBoxBorderBrushFocused" Color="{StaticResource SystemAccentColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxPlaceholderForeground" Color="{StaticResource TextFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownGlyphForeground" Color="{StaticResource TextFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
+    <SolidColorBrush x:Key="ComboBoxDropDownBorderBrush" Color="{StaticResource SurfaceStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ComboBoxItemBackgroundSelected" Color="{StaticResource SubtleFillColorSecondary}" />
+    <SolidColorBrush x:Key="ComboBoxItemForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="ComboBoxItemForegroundSelected" Color="{StaticResource TextFillColorPrimary}" />
+
+    <!-- ContentDialog -->
+    <SolidColorBrush x:Key="ContentDialogSmokeFill" Color="{StaticResource SmokeFillColorDefault}" />
+    <SolidColorBrush x:Key="ContentDialogBackground" Color="{StaticResource SolidBackgroundFillColorBase}" />
+    <SolidColorBrush x:Key="ContentDialogTopOverlay" Color="{StaticResource LayerFillColorAlt}" />
+    <SolidColorBrush x:Key="ContentDialogBorderBrush" Color="{StaticResource SurfaceStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ContentDialogSeparatorBorderBrush" Color="{StaticResource CardStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ContentDialogForeground" Color="{StaticResource TextFillColorPrimary}" />
+
+    <!-- NavigationView -->
+    <SolidColorBrush x:Key="NavigationViewItemForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOver" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundPressed" Color="{StaticResource TextFillColorSecondary}" />
+    <SolidColorBrush x:Key="NavigationViewSelectionIndicatorForeground" Color="{StaticResource SystemAccentColorPrimary}" />
+    <SolidColorBrush x:Key="NavigationViewDefaultPaneBackground" Color="{StaticResource LayerFillColorDefault}" />
+    <SolidColorBrush x:Key="NavigationViewItemSeparatorForeground" Color="{StaticResource DividerStrokeColorDefault}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackground" Color="{StaticResource SubtleFillColorTransparent}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundSelected" Color="{StaticResource SubtleFillColorSecondary}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundPressed" Color="{StaticResource SubtleFillColorTertiary}" />
+    <SolidColorBrush x:Key="NavigationViewItemBorderBrush" Color="{StaticResource SubtleFillColorTransparent}" />
+    <SolidColorBrush x:Key="NavigationViewContentBackground" Color="{StaticResource LayerFillColorDefault}" />
+    <SolidColorBrush x:Key="NavigationViewContentGridBorderBrush" Color="{StaticResource CardStrokeColorDefault}" />
+    <SolidColorBrush x:Key="NavigationViewItemBackgroundSelectedLeftFluent" Color="{StaticResource ControlFillColorDefault}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundLeftFluent" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="NavigationViewItemForegroundPointerOverLeftFluent" Color="{StaticResource TextFillColorPrimary}" />
+
+    <!-- Card -->
+    <SolidColorBrush x:Key="CardBackground" Color="{StaticResource CardBackgroundFillColorDefault}" />
+    <SolidColorBrush x:Key="CardBackgroundPointerOver" Color="{StaticResource ControlFillColorSecondary}" />
+    <SolidColorBrush x:Key="CardBackgroundPressed" Color="{StaticResource ControlFillColorTertiary}" />
+    <SolidColorBrush x:Key="CardBackgroundDisabled" Color="{StaticResource ControlFillColorDisabled}" />
+    <SolidColorBrush x:Key="CardForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="CardBorderBrush" Color="{StaticResource CardStrokeColorDefault}" />
+
+    <!-- Window -->
+    <SolidColorBrush x:Key="WindowBackground" Color="{StaticResource ApplicationBackgroundColor}" />
+    <SolidColorBrush x:Key="WindowForeground" Color="{StaticResource TextFillColorPrimary}" />
+
+    <!-- Flyout -->
+    <SolidColorBrush x:Key="FlyoutBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
+    <SolidColorBrush x:Key="FlyoutBorderBrush" Color="{StaticResource SurfaceStrokeColorFlyout}" />
+
+    <!-- InfoBar -->
+    <SolidColorBrush x:Key="InfoBarBorderBrush" Color="{StaticResource CardStrokeColorDefault}" />
+    <SolidColorBrush x:Key="InfoBarTitleForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="InfoBarErrorSeverityBackgroundBrush" Color="{StaticResource SystemFillColorCriticalBackground}" />
+    <SolidColorBrush x:Key="InfoBarWarningSeverityBackgroundBrush" Color="{StaticResource SystemFillColorCautionBackground}" />
+    <SolidColorBrush x:Key="InfoBarSuccessSeverityBackgroundBrush" Color="{StaticResource SystemFillColorSuccessBackground}" />
+    <SolidColorBrush x:Key="InfoBarInformationalSeverityBackgroundBrush" Color="{StaticResource SystemFillColorAttentionBackground}" />
+
+    <!-- Snackbar -->
+    <SolidColorBrush x:Key="SnackBarBackground" Color="{StaticResource AcrylicBackgroundFillColorDefault}" />
+    <SolidColorBrush x:Key="SnackBarForeground" Color="{StaticResource TextFillColorPrimary}" />
+    <SolidColorBrush x:Key="SnackBarBorderBrush" Color="{StaticResource SurfaceStrokeColorFlyout}" />
+
+    <!-- Elevation Border Brushes -->
+    <LinearGradientBrush x:Key="ControlElevationBorderBrush" StartPoint="0%,0%" EndPoint="0%,100%">
+        <GradientStop Offset="0.33" Color="{StaticResource ControlStrokeColorSecondary}" />
+        <GradientStop Offset="1.0" Color="{StaticResource ControlStrokeColorDefault}" />
+    </LinearGradientBrush>
+
+    <LinearGradientBrush x:Key="AccentControlElevationBorderBrush" StartPoint="0%,100%" EndPoint="0%,0%">
+        <GradientStop Offset="0.33" Color="{StaticResource ControlStrokeColorOnAccentSecondary}" />
+        <GradientStop Offset="1.0" Color="{StaticResource ControlStrokeColorOnAccentDefault}" />
+    </LinearGradientBrush>
+
+</ResourceDictionary>

--- a/src/CrissCross.Avalonia.UI/Resources/Theme/Light.axaml
+++ b/src/CrissCross.Avalonia.UI/Resources/Theme/Light.axaml
@@ -1,6 +1,8 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
+    <x:Double x:Key="DisabledTextControlOpacity">0.5</x:Double>
+
     <!-- Application Background -->
     <Color x:Key="ApplicationBackgroundColor">#FFF3F3F3</Color>
     <SolidColorBrush x:Key="ApplicationBackgroundBrush" Color="{StaticResource ApplicationBackgroundColor}" />
@@ -253,6 +255,8 @@
     <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{StaticResource TextFillColorPrimary}" />
     <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{StaticResource TextFillColorSecondary}" />
     <SolidColorBrush x:Key="ButtonForegroundDisabled" Color="{StaticResource TextFillColorDisabled}" />
+    <SolidColorBrush x:Key="ButtonBorderBrush" Color="{StaticResource ControlStrokeColorDefault}" />
+    <SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="{StaticResource ControlStrokeColorSecondary}" />
     <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="{StaticResource ControlStrokeColorDefault}" />
     <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="{StaticResource ControlStrokeColorDefault}" />
 

--- a/src/CrissCross.Avalonia.UI/Themes/AppBarButton.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/AppBarButton.axaml
@@ -87,8 +87,8 @@
     </Style>
 
     <Style Selector="controls|AppBarButton:pressed /template/ Ellipse#PART_IconBorder">
-        <Setter Property="Fill" Value="{DynamicResource SystemAccentColorPrimaryBrush}" />
-        <Setter Property="Stroke" Value="{DynamicResource SystemAccentColorSecondaryBrush}" />
+        <Setter Property="Fill" Value="{DynamicResource AccentButtonBackground}" />
+        <Setter Property="Stroke" Value="{DynamicResource ControlStrokeColorOnAccentSecondaryBrush}" />
     </Style>
 
     <Style Selector="controls|AppBarButton:pressed /template/ Path#PART_IconPath">
@@ -113,7 +113,7 @@
     </Style>
 
     <Style Selector="controls|AppBarButton:focus-visible /template/ Ellipse#PART_IconBorder">
-        <Setter Property="Stroke" Value="{DynamicResource SystemAccentColorPrimaryBrush}" />
+        <Setter Property="Stroke" Value="{DynamicResource AccentButtonBackground}" />
         <Setter Property="StrokeThickness" Value="2" />
     </Style>
 </Styles>

--- a/src/CrissCross.Avalonia.UI/Themes/AutoSuggestBox.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/AutoSuggestBox.axaml
@@ -3,7 +3,8 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross AutoSuggestBox Style -->
-    <Style Selector="controls|AutoSuggestBox">
+    <Style Selector=":is(controls|AutoSuggestBox)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type AutoCompleteBox}}" />
         <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
         <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorderBrush}" />
@@ -19,18 +20,18 @@
     </Style>
     
     <!-- Focus state -->
-    <Style Selector="controls|AutoSuggestBox:focus-within">
+    <Style Selector=":is(controls|AutoSuggestBox):focus-within">
         <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
     </Style>
     
     <!-- Pointer over state -->
-    <Style Selector="controls|AutoSuggestBox:pointerover">
+    <Style Selector=":is(controls|AutoSuggestBox):pointerover">
         <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushPointerOver}" />
     </Style>
     
     <!-- Disabled state -->
-    <Style Selector="controls|AutoSuggestBox:disabled">
-        <Setter Property="Opacity" Value="0.5" />
+    <Style Selector=":is(controls|AutoSuggestBox):disabled">
+        <Setter Property="Opacity" Value="{DynamicResource DisabledTextControlOpacity}" />
     </Style>
     
 </Styles>

--- a/src/CrissCross.Avalonia.UI/Themes/BezelToggleButton.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/BezelToggleButton.axaml
@@ -4,9 +4,9 @@
     
     <!-- CrissCross BezelToggleButton Style - A toggle button with a beveled/raised 3D appearance -->
     <Style Selector="controls|BezelToggleButton">
-        <Setter Property="Background" Value="{DynamicResource ToggleButtonBackground}" />
-        <Setter Property="Foreground" Value="{DynamicResource ToggleButtonForeground}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ToggleButtonBorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ButtonBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource ButtonForeground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Padding" Value="16,8" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />

--- a/src/CrissCross.Avalonia.UI/Themes/BreadcrumbBar.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/BreadcrumbBar.axaml
@@ -4,6 +4,11 @@
     
     <!-- CrissCross BreadcrumbBar Style -->
     <Style Selector="controls|BreadcrumbBar">
+        <Setter Property="Template">
+            <ControlTemplate>
+                <ItemsPresenter Name="PART_ItemsPresenter" ItemsPanel="{TemplateBinding ItemsPanel}" />
+            </ControlTemplate>
+        </Setter>
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="ItemsPanel">

--- a/src/CrissCross.Avalonia.UI/Themes/Button.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/Button.axaml
@@ -3,7 +3,14 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross Button Style -->
-    <Style Selector="controls|Button">
+    <Style Selector=":is(controls|Button)">
+        <Setter Property="Appearance" Value="Secondary" />
+        <Setter Property="MouseOverBackground" Value="{DynamicResource ButtonBackgroundPointerOver}" />
+        <Setter Property="MouseOverBorderBrush" Value="{DynamicResource ButtonBorderBrushPointerOver}" />
+        <Setter Property="MouseOverForeground" Value="{DynamicResource ButtonForegroundPointerOver}" />
+        <Setter Property="PressedBackground" Value="{DynamicResource ButtonBackgroundPressed}" />
+        <Setter Property="PressedBorderBrush" Value="{DynamicResource ButtonBorderBrushPressed}" />
+        <Setter Property="PressedForeground" Value="{DynamicResource ButtonForegroundPressed}" />
         <Setter Property="Background" Value="{DynamicResource ButtonBackground}" />
         <Setter Property="Foreground" Value="{DynamicResource ButtonForeground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrush}" />
@@ -26,14 +33,16 @@
                                           Content="{TemplateBinding Icon}"
                                           IsVisible="{Binding Icon, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static ObjectConverters.IsNotNull}}"
                                           Margin="0,0,8,0"
-                                          VerticalAlignment="Center" />
+                                          VerticalAlignment="Center"
+                                          TextElement.Foreground="{TemplateBinding Foreground}" />
                         <!-- Content -->
                         <ContentPresenter Name="PART_ContentPresenter"
                                           Grid.Column="1"
                                           Content="{TemplateBinding Content}"
                                           ContentTemplate="{TemplateBinding ContentTemplate}"
                                           HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          TextElement.Foreground="{TemplateBinding Foreground}" />
                     </Grid>
                 </Border>
             </ControlTemplate>
@@ -41,7 +50,7 @@
     </Style>
     
     <!-- Button without icon - single column layout -->
-    <Style Selector="controls|Button[Icon={x:Null}]">
+    <Style Selector=":is(controls|Button)[Icon={x:Null}]">
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Name="RootBorder"
@@ -54,27 +63,111 @@
                                       Content="{TemplateBinding Content}"
                                       ContentTemplate="{TemplateBinding ContentTemplate}"
                                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      TextElement.Foreground="{TemplateBinding Foreground}" />
                 </Border>
             </ControlTemplate>
         </Setter>
     </Style>
     
+    <Style Selector=":is(controls|Button)[Appearance=Primary]">
+        <Setter Property="Background" Value="{DynamicResource AccentButtonBackground}" />
+        <Setter Property="MouseOverBackground" Value="{DynamicResource AccentButtonBackgroundPointerOver}" />
+        <Setter Property="PressedBackground" Value="{DynamicResource AccentButtonBackgroundPressed}" />
+        <Setter Property="Foreground" Value="{DynamicResource AccentButtonForeground}" />
+        <Setter Property="MouseOverForeground" Value="{DynamicResource AccentButtonForeground}" />
+        <Setter Property="PressedForeground" Value="{DynamicResource AccentButtonForeground}" />
+    </Style>
+
+    <Style Selector=":is(controls|Button)[Appearance=Info]">
+        <Setter Property="Background" Value="{DynamicResource SystemFillColorAttention}" />
+        <Setter Property="MouseOverBackground" Value="{DynamicResource SystemFillColorAttention}" />
+        <Setter Property="PressedBackground" Value="{DynamicResource SystemFillColorAttention}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}" />
+        <Setter Property="MouseOverForeground" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}" />
+        <Setter Property="PressedForeground" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}" />
+    </Style>
+
+    <Style Selector=":is(controls|Button)[Appearance=Danger]">
+        <Setter Property="Background" Value="{DynamicResource SystemFillColorCriticalBrush}" />
+        <Setter Property="MouseOverBackground" Value="{DynamicResource SystemFillColorCriticalBrush}" />
+        <Setter Property="PressedBackground" Value="{DynamicResource SystemFillColorCriticalBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}" />
+        <Setter Property="MouseOverForeground" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}" />
+        <Setter Property="PressedForeground" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}" />
+    </Style>
+
+    <Style Selector=":is(controls|Button)[Appearance=Success]">
+        <Setter Property="Background" Value="{DynamicResource SystemFillColorSuccessBrush}" />
+        <Setter Property="MouseOverBackground" Value="{DynamicResource SystemFillColorSuccessBrush}" />
+        <Setter Property="PressedBackground" Value="{DynamicResource SystemFillColorSuccessBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}" />
+        <Setter Property="MouseOverForeground" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}" />
+        <Setter Property="PressedForeground" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}" />
+    </Style>
+
+    <Style Selector=":is(controls|Button)[Appearance=Caution]">
+        <Setter Property="Background" Value="{DynamicResource SystemFillColorCautionBrush}" />
+        <Setter Property="MouseOverBackground" Value="{DynamicResource SystemFillColorCautionBrush}" />
+        <Setter Property="PressedBackground" Value="{DynamicResource SystemFillColorCautionBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}" />
+        <Setter Property="MouseOverForeground" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}" />
+        <Setter Property="PressedForeground" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}" />
+    </Style>
+
+    <Style Selector=":is(controls|Button)[Appearance=Dark]">
+        <Setter Property="Background" Value="Black" />
+        <Setter Property="MouseOverBackground" Value="Black" />
+        <Setter Property="PressedBackground" Value="Black" />
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="MouseOverForeground" Value="White" />
+        <Setter Property="PressedForeground" Value="White" />
+    </Style>
+
+    <Style Selector=":is(controls|Button)[Appearance=Light]">
+        <Setter Property="Background" Value="White" />
+        <Setter Property="MouseOverBackground" Value="White" />
+        <Setter Property="PressedBackground" Value="White" />
+        <Setter Property="Foreground" Value="Black" />
+        <Setter Property="MouseOverForeground" Value="Black" />
+        <Setter Property="PressedForeground" Value="Black" />
+    </Style>
+
+    <Style Selector=":is(controls|Button)[Appearance=Transparent]">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="MouseOverBackground" Value="Transparent" />
+        <Setter Property="PressedBackground" Value="Transparent" />
+        <Setter Property="Foreground" Value="{DynamicResource ButtonForeground}" />
+        <Setter Property="MouseOverForeground" Value="{DynamicResource ButtonForeground}" />
+        <Setter Property="PressedForeground" Value="{DynamicResource ButtonForeground}" />
+    </Style>
+
+    <Style Selector=":is(controls|Button):pointerover:not(:disabled)">
+        <Setter Property="Foreground" Value="{Binding MouseOverForeground, RelativeSource={RelativeSource Self}}" />
+    </Style>
+
+    <Style Selector=":is(controls|Button):pressed:not(:disabled)">
+        <Setter Property="Foreground" Value="{Binding PressedForeground, RelativeSource={RelativeSource Self}}" />
+    </Style>
+
     <!-- PointerOver State -->
-    <Style Selector="controls|Button:pointerover /template/ Border#RootBorder">
-        <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPointerOver}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPointerOver}" />
+    <Style Selector=":is(controls|Button):pointerover:not(:disabled) /template/ Border#RootBorder">
+        <Setter Property="Background" Value="{Binding MouseOverBackground, RelativeSource={RelativeSource TemplatedParent}}" />
+        <Setter Property="BorderBrush" Value="{Binding MouseOverBorderBrush, RelativeSource={RelativeSource TemplatedParent}}" />
     </Style>
     
     <!-- Pressed State -->
-    <Style Selector="controls|Button:pressed /template/ Border#RootBorder">
-        <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPressed}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPressed}" />
+    <Style Selector=":is(controls|Button):pressed:not(:disabled) /template/ Border#RootBorder">
+        <Setter Property="Background" Value="{Binding PressedBackground, RelativeSource={RelativeSource TemplatedParent}}" />
+        <Setter Property="BorderBrush" Value="{Binding PressedBorderBrush, RelativeSource={RelativeSource TemplatedParent}}" />
     </Style>
     
     <!-- Disabled State -->
-    <Style Selector="controls|Button:disabled">
-        <Setter Property="Opacity" Value="0.5" />
+    <Style Selector=":is(controls|Button):disabled">
+        <Setter Property="Opacity" Value="{DynamicResource DisabledTextControlOpacity}" />
+        <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
+        <Setter Property="Background" Value="{DynamicResource ButtonBackgroundDisabled}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushDisabled}" />
     </Style>
     
 </Styles>

--- a/src/CrissCross.Avalonia.UI/Themes/Calendar.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/Calendar.axaml
@@ -6,8 +6,8 @@
     <!-- Inherits from Avalonia.Controls.Calendar, provide template for the derived control -->
     <Style Selector="controls|Calendar">
         <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
-        <Setter Property="Background" Value="{DynamicResource FlyoutPresenterBackground}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource FlyoutBorderThemeBrush}" />
+        <Setter Property="Background" Value="{DynamicResource FlyoutBackground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource FlyoutBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Template">
             <ControlTemplate>
@@ -24,8 +24,8 @@
     <!-- CalendarItem styling - ensure text colors work in dark mode -->
     <Style Selector="controls|Calendar CalendarItem">
         <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
-        <Setter Property="Background" Value="{DynamicResource FlyoutPresenterBackground}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource FlyoutBorderThemeBrush}" />
+        <Setter Property="Background" Value="{DynamicResource FlyoutBackground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource FlyoutBorderBrush}" />
     </Style>
     
     <!-- Style all TextBlocks inside CalendarItem -->
@@ -64,11 +64,11 @@
     </Style>
     
     <Style Selector="controls|Calendar CalendarDayButton:pointerover">
-        <Setter Property="Background" Value="{DynamicResource ListViewItemBackgroundPointerOver}" />
+        <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondaryBrush}" />
     </Style>
     
     <Style Selector="controls|Calendar CalendarDayButton:pressed">
-        <Setter Property="Background" Value="{DynamicResource ListViewItemBackgroundPressed}" />
+        <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiaryBrush}" />
     </Style>
     
     <Style Selector="controls|Calendar CalendarDayButton:selected">
@@ -129,11 +129,11 @@
     </Style>
     
     <Style Selector="controls|Calendar CalendarButton:pointerover">
-        <Setter Property="Background" Value="{DynamicResource ListViewItemBackgroundPointerOver}" />
+        <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondaryBrush}" />
     </Style>
     
     <Style Selector="controls|Calendar CalendarButton:pressed">
-        <Setter Property="Background" Value="{DynamicResource ListViewItemBackgroundPressed}" />
+        <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiaryBrush}" />
     </Style>
     
     <Style Selector="controls|Calendar CalendarButton:selected">
@@ -156,11 +156,11 @@
     </Style>
     
     <Style Selector="controls|Calendar CalendarItem Button:pointerover">
-        <Setter Property="Background" Value="{DynamicResource ListViewItemBackgroundPointerOver}" />
+        <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondaryBrush}" />
     </Style>
     
     <Style Selector="controls|Calendar CalendarItem Button:pressed">
-        <Setter Property="Background" Value="{DynamicResource ListViewItemBackgroundPressed}" />
+        <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiaryBrush}" />
     </Style>
     
     <!-- Day name headers (Mon, Tue, etc.) -->

--- a/src/CrissCross.Avalonia.UI/Themes/CheckBox.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/CheckBox.axaml
@@ -4,9 +4,9 @@
     
     <!-- CrissCross CheckBox Style -->
     <Style Selector="controls|CheckBox">
-        <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
-        <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ControlAltFillColorSecondaryBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ControlStrongStrokeColorDefaultBrush}" />
         <Setter Property="Padding" Value="8,0,0,0" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
@@ -35,7 +35,7 @@
                                       Height="12"
                                       Data="M1.5,5.5 L4.5,8.5 L10.5,2.5"
                                       Fill="Transparent"
-                                      Stroke="White"
+                                      Stroke="{DynamicResource CheckBoxCheckGlyphForeground}"
                                       StrokeThickness="2"
                                       Stretch="Uniform"
                                       HorizontalAlignment="Center"
@@ -45,7 +45,7 @@
                                 <Rectangle Name="IndeterminateMark"
                                            Width="8"
                                            Height="8"
-                                           Fill="White"
+                                           Fill="{DynamicResource CheckBoxCheckGlyphForeground}"
                                            HorizontalAlignment="Center"
                                            VerticalAlignment="Center"
                                            IsVisible="False" />
@@ -58,22 +58,17 @@
                                           Margin="{TemplateBinding Padding}"
                                           HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          TextElement.Foreground="{Binding Foreground, RelativeSource={RelativeSource TemplatedParent}}" />
+                                          TextElement.Foreground="{TemplateBinding Foreground}" />
                     </Grid>
                 </Border>
             </ControlTemplate>
         </Setter>
     </Style>
     
-    <!-- Set foreground for content text -->
-    <Style Selector="controls|CheckBox /template/ ContentPresenter#ContentPresenter">
-        <Setter Property="TextBlock.Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
-    </Style>
-    
     <!-- Unchecked state -->
     <Style Selector="controls|CheckBox:unchecked /template/ Border#CheckBorder">
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseMediumHighBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ControlStrongStrokeColorDefaultBrush}" />
     </Style>
     
     <!-- Checked State -->
@@ -108,7 +103,8 @@
     
     <!-- Disabled State -->
     <Style Selector="controls|CheckBox:disabled">
-        <Setter Property="Opacity" Value="0.5" />
+        <Setter Property="Opacity" Value="{DynamicResource DisabledTextControlOpacity}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextFillColorDisabledBrush}" />
     </Style>
     
 </Styles>

--- a/src/CrissCross.Avalonia.UI/Themes/CheckBoxModern.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/CheckBoxModern.axaml
@@ -32,14 +32,14 @@
                                 <PathIcon x:Name="CheckGlyph"
                                           Width="12"
                                           Height="12"
-                                          Foreground="White"
+                                          Foreground="{DynamicResource AccentButtonForeground}"
                                           Data="M 1,5 L 4,8 L 9,2"
                                           IsVisible="False" />
                                 <!-- Indeterminate mark -->
                                 <Border x:Name="IndeterminateGlyph"
                                         Width="10"
                                         Height="10"
-                                        Background="White"
+                                        Background="{DynamicResource AccentButtonForeground}"
                                         CornerRadius="2"
                                         IsVisible="False" />
                             </Panel>
@@ -62,7 +62,7 @@
     
     <!-- Set foreground for content text -->
     <Style Selector="controls|CheckBoxModern /template/ ContentPresenter#ContentPresenter">
-        <Setter Property="TextBlock.Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+        <Setter Property="TextBlock.Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
     </Style>
     
     <!-- Checked state -->
@@ -87,7 +87,7 @@
     
     <!-- Disabled state -->
     <Style Selector="controls|CheckBoxModern:disabled">
-        <Setter Property="Opacity" Value="0.5" />
+        <Setter Property="Opacity" Value="{DynamicResource DisabledTextControlOpacity}" />
     </Style>
     
     <!-- Pointer over state -->

--- a/src/CrissCross.Avalonia.UI/Themes/Chip.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/Chip.axaml
@@ -21,6 +21,7 @@
                                 CommandParameter="{Binding Model, RelativeSource={RelativeSource TemplatedParent}}"
                                 Content="{TemplateBinding Text}" />
                         <Button MinWidth="24"
+                                IsVisible="{TemplateBinding IsRemovable}"
                                 Command="{Binding RemoveCommand, RelativeSource={RelativeSource TemplatedParent}}"
                                 CommandParameter="{Binding Model, RelativeSource={RelativeSource TemplatedParent}}"
                                 Content="×" />

--- a/src/CrissCross.Avalonia.UI/Themes/ChipGroup.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/ChipGroup.axaml
@@ -1,18 +1,37 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:converters="clr-namespace:CrissCross.Avalonia.UI.Converters;assembly=CrissCross.Avalonia.UI"
         xmlns:core="clr-namespace:CrissCross;assembly=CrissCross"
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
 
     <Style Selector="controls|ChipGroup">
+        <Setter Property="ItemsPanel">
+            <ItemsPanelTemplate>
+                <WrapPanel />
+            </ItemsPanelTemplate>
+        </Setter>
         <Setter Property="ItemTemplate">
             <DataTemplate x:DataType="core:ChipModel">
                 <controls:Chip Margin="0,0,6,6"
-                               Model="{Binding}" />
+                               Model="{Binding}">
+                    <controls:Chip.SelectCommand>
+                        <MultiBinding Converter="{x:Static converters:FirstCommandConverter.Instance}">
+                            <Binding Path="$parent[controls:ChipGroup].SelectChipCommand" />
+                            <Binding Path="SelectCommand" />
+                        </MultiBinding>
+                    </controls:Chip.SelectCommand>
+                    <controls:Chip.RemoveCommand>
+                        <MultiBinding Converter="{x:Static converters:FirstCommandConverter.Instance}">
+                            <Binding Path="$parent[controls:ChipGroup].RemoveChipCommand" />
+                            <Binding Path="RemoveCommand" />
+                        </MultiBinding>
+                    </controls:Chip.RemoveCommand>
+                </controls:Chip>
             </DataTemplate>
         </Setter>
         <Setter Property="Template">
             <ControlTemplate>
-                <ItemsPresenter />
+                <ItemsPresenter Name="PART_ItemsPresenter" ItemsPanel="{TemplateBinding ItemsPanel}" />
             </ControlTemplate>
         </Setter>
     </Style>

--- a/src/CrissCross.Avalonia.UI/Themes/ComboBox.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/ComboBox.axaml
@@ -113,7 +113,7 @@
         <Setter Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
         <Setter Property="Foreground" Value="{DynamicResource ComboBoxForegroundDisabled}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
-        <Setter Property="Opacity" Value="0.5" />
+        <Setter Property="Opacity" Value="{DynamicResource DisabledTextControlOpacity}" />
     </Style>
     
 </Styles>

--- a/src/CrissCross.Avalonia.UI/Themes/ContextMenu.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/ContextMenu.axaml
@@ -3,9 +3,10 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross ContextMenu Style -->
-    <Style Selector="controls|ContextMenu">
-        <Setter Property="Background" Value="{DynamicResource MenuFlyoutPresenterBackground}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource MenuFlyoutPresenterBorderBrush}" />
+    <Style Selector=":is(controls|ContextMenu)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type ContextMenu}}" />
+        <Setter Property="Background" Value="{DynamicResource FlyoutBackground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource FlyoutBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="8" />
         <Setter Property="Padding" Value="4" />

--- a/src/CrissCross.Avalonia.UI/Themes/DataFilterPanel.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/DataFilterPanel.axaml
@@ -8,7 +8,7 @@
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Padding="12"
-                        BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                        BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
                         BorderThickness="1"
                         CornerRadius="6">
                     <StackPanel>

--- a/src/CrissCross.Avalonia.UI/Themes/DatePicker.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/DatePicker.axaml
@@ -3,7 +3,8 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross DatePicker Style -->
-    <Style Selector="controls|DatePicker">
+    <Style Selector=":is(controls|DatePicker)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type DatePicker}}" />
         <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
         <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorderBrush}" />
@@ -15,17 +16,17 @@
     </Style>
     
     <!-- PointerOver State -->
-    <Style Selector="controls|DatePicker:pointerover">
+    <Style Selector=":is(controls|DatePicker):pointerover">
         <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushPointerOver}" />
     </Style>
     
     <!-- Pressed State -->
-    <Style Selector="controls|DatePicker:pressed">
+    <Style Selector=":is(controls|DatePicker):pressed">
         <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
     </Style>
     
     <!-- Disabled State -->
-    <Style Selector="controls|DatePicker:disabled">
+    <Style Selector=":is(controls|DatePicker):disabled">
         <Setter Property="Opacity" Value="0.5" />
     </Style>
     

--- a/src/CrissCross.Avalonia.UI/Themes/DropDownButton.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/DropDownButton.axaml
@@ -3,7 +3,8 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross DropDownButton Style -->
-    <Style Selector="controls|DropDownButton">
+    <Style Selector=":is(controls|DropDownButton)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type DropDownButton}}" />
         <Setter Property="Background" Value="{DynamicResource ButtonBackground}" />
         <Setter Property="Foreground" Value="{DynamicResource ButtonForeground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrush}" />
@@ -15,20 +16,20 @@
     </Style>
     
     <!-- PointerOver State -->
-    <Style Selector="controls|DropDownButton:pointerover">
+    <Style Selector=":is(controls|DropDownButton):pointerover">
         <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPointerOver}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPointerOver}" />
     </Style>
     
     <!-- Pressed State -->
-    <Style Selector="controls|DropDownButton:pressed">
+    <Style Selector=":is(controls|DropDownButton):pressed">
         <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPressed}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPressed}" />
     </Style>
     
     <!-- Disabled State -->
-    <Style Selector="controls|DropDownButton:disabled">
-        <Setter Property="Opacity" Value="0.5" />
+    <Style Selector=":is(controls|DropDownButton):disabled">
+        <Setter Property="Opacity" Value="{DynamicResource DisabledTextControlOpacity}" />
     </Style>
     
 </Styles>

--- a/src/CrissCross.Avalonia.UI/Themes/DynamicScrollBar.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/DynamicScrollBar.axaml
@@ -1,9 +1,11 @@
 <Styles xmlns="https://github.com/avaloniaui"
+        xmlns:primitives="clr-namespace:Avalonia.Controls.Primitives;assembly=Avalonia.Controls"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross DynamicScrollBar Style -->
-    <Style Selector="controls|DynamicScrollBar">
+    <Style Selector=":is(controls|DynamicScrollBar)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type primitives:ScrollBar}}" />
         <Setter Property="Background" Value="Transparent" />
     </Style>
     

--- a/src/CrissCross.Avalonia.UI/Themes/DynamicScrollViewer.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/DynamicScrollViewer.axaml
@@ -3,7 +3,8 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross DynamicScrollViewer Style -->
-    <Style Selector="controls|DynamicScrollViewer">
+    <Style Selector=":is(controls|DynamicScrollViewer)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type ScrollViewer}}" />
         <Setter Property="Background" Value="Transparent" />
     </Style>
     

--- a/src/CrissCross.Avalonia.UI/Themes/EmptyState.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/EmptyState.axaml
@@ -34,11 +34,11 @@
                         <Button MinWidth="96"
                                 Command="{Binding Model.PrimaryActionCommand, RelativeSource={RelativeSource TemplatedParent}}"
                                 Content="{Binding Model.PrimaryActionText, RelativeSource={RelativeSource TemplatedParent}}"
-                                IsVisible="{Binding Model.HasPrimaryAction, RelativeSource={RelativeSource TemplatedParent}}" />
+                                IsVisible="{Binding Model.HasPrimaryAction, RelativeSource={RelativeSource TemplatedParent}, FallbackValue=False, TargetNullValue=False}" />
                         <Button MinWidth="96"
                                 Command="{Binding Model.SecondaryActionCommand, RelativeSource={RelativeSource TemplatedParent}}"
                                 Content="{Binding Model.SecondaryActionText, RelativeSource={RelativeSource TemplatedParent}}"
-                                IsVisible="{Binding Model.HasSecondaryAction, RelativeSource={RelativeSource TemplatedParent}}" />
+                                IsVisible="{Binding Model.HasSecondaryAction, RelativeSource={RelativeSource TemplatedParent}, FallbackValue=False, TargetNullValue=False}" />
                     </StackPanel>
                 </StackPanel>
             </ControlTemplate>

--- a/src/CrissCross.Avalonia.UI/Themes/Expander.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/Expander.axaml
@@ -3,9 +3,10 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross Expander Style -->
-    <Style Selector="controls|Expander">
-        <Setter Property="Background" Value="{DynamicResource ExpanderBackground}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ExpanderHeaderBorderBrush}" />
+    <Style Selector=":is(controls|Expander)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type Expander}}" />
+        <Setter Property="Background" Value="{DynamicResource CardBackground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="4" />
         <Setter Property="Padding" Value="16" />

--- a/src/CrissCross.Avalonia.UI/Themes/FilterBar.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/FilterBar.axaml
@@ -4,17 +4,25 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
 
     <Style Selector="controls|FilterBar">
+        <Setter Property="ItemsPanel">
+            <ItemsPanelTemplate>
+                <WrapPanel />
+            </ItemsPanelTemplate>
+        </Setter>
         <Setter Property="ItemTemplate">
             <DataTemplate x:DataType="core:FilterToken">
                 <Border Margin="0,0,6,6"
                         Padding="10,4"
-                        Background="#14000000"
+                        Background="{DynamicResource SubtleFillColorSecondaryBrush}"
                         CornerRadius="12">
                     <StackPanel Orientation="Horizontal"
                                 Spacing="6">
                         <TextBlock VerticalAlignment="Center"
                                    Text="{Binding DisplayText}" />
                         <Button MinWidth="24"
+                                Command="{Binding $parent[controls:FilterBar].RemoveFilterCommand}"
+                                CommandParameter="{Binding}"
+                                IsVisible="{Binding IsRemovable}"
                                 Content="×" />
                     </StackPanel>
                 </Border>
@@ -28,7 +36,7 @@
                             Margin="8,0,0,6"
                             Command="{Binding ClearAllCommand, RelativeSource={RelativeSource TemplatedParent}}"
                             Content="Clear" />
-                    <ItemsPresenter />
+                    <ItemsPresenter Name="PART_ItemsPresenter" ItemsPanel="{TemplateBinding ItemsPanel}" />
                 </DockPanel>
             </ControlTemplate>
         </Setter>

--- a/src/CrissCross.Avalonia.UI/Themes/FluentNavigationWindow.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/FluentNavigationWindow.axaml
@@ -6,7 +6,6 @@
     <Style Selector="controls|FluentNavigationWindow">
         <Setter Property="Background" Value="{DynamicResource ApplicationBackgroundColor}" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimary}" />
-        <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
         <Setter Property="FontSize" Value="14" />
     </Style>
     

--- a/src/CrissCross.Avalonia.UI/Themes/FluentWindow.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/FluentWindow.axaml
@@ -6,7 +6,6 @@
     <Style Selector="controls|FluentWindow">
         <Setter Property="Background" Value="{DynamicResource ApplicationBackgroundColor}" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimary}" />
-        <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
         <Setter Property="FontSize" Value="14" />
     </Style>
     

--- a/src/CrissCross.Avalonia.UI/Themes/GelButton.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/GelButton.axaml
@@ -5,7 +5,9 @@
     <!-- CrissCross GelButton Style - A button with a gel/glass-like appearance -->
     <Style Selector="controls|GelButton">
         <Setter Property="Background" Value="{DynamicResource SystemAccentColor}" />
-        <Setter Property="Foreground" Value="White" />
+        <Setter Property="Foreground" Value="{DynamicResource AccentButtonForeground}" />
+        <Setter Property="MouseOverForeground" Value="{DynamicResource AccentButtonForeground}" />
+        <Setter Property="PressedForeground" Value="{DynamicResource AccentButtonForeground}" />
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Padding" Value="16,8" />
@@ -145,7 +147,7 @@
     
     <!-- Disabled state -->
     <Style Selector="controls|GelButton:disabled">
-        <Setter Property="Opacity" Value="0.5" />
+        <Setter Property="Opacity" Value="{DynamicResource DisabledTextControlOpacity}" />
     </Style>
     
     <Style Selector="controls|GelButton:disabled /template/ Border#Base">

--- a/src/CrissCross.Avalonia.UI/Themes/GelRepeatButton.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/GelRepeatButton.axaml
@@ -5,7 +5,7 @@
     <!-- CrissCross GelRepeatButton Style - A repeat button with a gel/glass-like appearance -->
     <Style Selector="controls|GelRepeatButton">
         <Setter Property="Background" Value="{DynamicResource SystemAccentColor}" />
-        <Setter Property="Foreground" Value="White" />
+        <Setter Property="Foreground" Value="{DynamicResource AccentButtonForeground}" />
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Padding" Value="16,8" />
@@ -141,7 +141,7 @@
     
     <!-- Disabled state -->
     <Style Selector="controls|GelRepeatButton:disabled">
-        <Setter Property="Opacity" Value="0.5" />
+        <Setter Property="Opacity" Value="{DynamicResource DisabledTextControlOpacity}" />
     </Style>
     
 </Styles>

--- a/src/CrissCross.Avalonia.UI/Themes/GelToggleButton.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/GelToggleButton.axaml
@@ -5,7 +5,7 @@
     <!-- CrissCross GelToggleButton Style - A toggle button with a gel/glass-like appearance -->
     <Style Selector="controls|GelToggleButton">
         <Setter Property="Background" Value="{DynamicResource SystemAccentColor}" />
-        <Setter Property="Foreground" Value="White" />
+        <Setter Property="Foreground" Value="{DynamicResource AccentButtonForeground}" />
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Padding" Value="16,8" />
@@ -158,7 +158,7 @@
     
     <!-- Disabled state -->
     <Style Selector="controls|GelToggleButton:disabled">
-        <Setter Property="Opacity" Value="0.5" />
+        <Setter Property="Opacity" Value="{DynamicResource DisabledTextControlOpacity}" />
     </Style>
     
 </Styles>

--- a/src/CrissCross.Avalonia.UI/Themes/GifImage.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/GifImage.axaml
@@ -3,7 +3,7 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross GifImage Style -->
-    <Style Selector="controls|GifImage">
+    <Style Selector=":is(controls|GifImage)">
         <Setter Property="Stretch" Value="Uniform" />
     </Style>
     

--- a/src/CrissCross.Avalonia.UI/Themes/HexColorTextBox.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/HexColorTextBox.axaml
@@ -4,9 +4,9 @@
     
     <!-- CrissCross HexColorTextBox Style -->
     <Style Selector="controls|HexColorTextBox">
-        <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}" />
-        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+        <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource TextFillColorSecondaryBrush}" />
         <Setter Property="SelectionBrush" Value="{DynamicResource SystemAccentColor}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Padding" Value="8,6" />
@@ -31,7 +31,7 @@
                                 Height="24"
                                 Margin="6,0,0,0"
                                 CornerRadius="4"
-                                BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                BorderBrush="{DynamicResource TextFillColorSecondaryBrush}"
                                 BorderThickness="1"
                                 ClipToBounds="True"
                                 VerticalAlignment="Center">
@@ -75,12 +75,12 @@
                         <Panel Grid.Column="1" Margin="8,0,8,0">
                             <TextBlock Name="PART_Watermark"
                                        Text="{TemplateBinding Watermark}"
-                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                       Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                        VerticalAlignment="Center"
                                        IsVisible="False" />
                             <TextPresenter Name="PART_TextPresenter"
                                            Text="{TemplateBinding Text, Mode=TwoWay}"
-                                           CaretBrush="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                                           CaretBrush="{DynamicResource TextFillColorPrimaryBrush}"
                                            CaretIndex="{TemplateBinding CaretIndex}"
                                            SelectionStart="{TemplateBinding SelectionStart}"
                                            SelectionEnd="{TemplateBinding SelectionEnd}"
@@ -108,7 +108,7 @@
     
     <!-- Pointer over state -->
     <Style Selector="controls|HexColorTextBox:pointerover">
-        <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource TextFillColorPrimaryBrush}" />
     </Style>
     
     <!-- Disabled state -->

--- a/src/CrissCross.Avalonia.UI/Themes/Image.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/Image.axaml
@@ -3,7 +3,7 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross Image Style -->
-    <Style Selector="controls|Image">
+    <Style Selector=":is(controls|Image)">
         <Setter Property="Stretch" Value="Uniform" />
     </Style>
     

--- a/src/CrissCross.Avalonia.UI/Themes/Index.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/Index.axaml
@@ -66,6 +66,7 @@
     <StyleInclude Source="avares://CrissCross.Avalonia.UI/Themes/ProgressBar.axaml" />
     <StyleInclude Source="avares://CrissCross.Avalonia.UI/Themes/ProgressRing.axaml" />
     <StyleInclude Source="avares://CrissCross.Avalonia.UI/Themes/CircularGauge.axaml" />
+    <StyleInclude Source="avares://CrissCross.Avalonia.UI/Themes/ProcessValueIndicator.axaml" />
 
     <!-- Rating Controls -->
     <StyleInclude Source="avares://CrissCross.Avalonia.UI/Themes/RatingControl.axaml" />

--- a/src/CrissCross.Avalonia.UI/Themes/ItemsControl.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/ItemsControl.axaml
@@ -3,7 +3,8 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross ItemsControl Style -->
-    <Style Selector="controls|ItemsControl">
+    <Style Selector=":is(controls|ItemsControl)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type ItemsControl}}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimary}" />
     </Style>

--- a/src/CrissCross.Avalonia.UI/Themes/Label.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/Label.axaml
@@ -3,7 +3,7 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross Label Style -->
-    <Style Selector="controls|Label">
+    <Style Selector=":is(controls|Label)">
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimary}" />
         <Setter Property="FontSize" Value="14" />
     </Style>

--- a/src/CrissCross.Avalonia.UI/Themes/ListBox.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/ListBox.axaml
@@ -3,7 +3,8 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross ListBox Style -->
-    <Style Selector="controls|ListBox">
+    <Style Selector=":is(controls|ListBox)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type ListBox}}" />
         <Setter Property="Background" Value="{DynamicResource ControlFillColorDefault}" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimary}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ControlStrokeColorDefault}" />
@@ -13,21 +14,21 @@
     </Style>
     
     <!-- ListBox Item Style -->
-    <Style Selector="controls|ListBox ListBoxItem">
+    <Style Selector=":is(controls|ListBox) ListBoxItem">
         <Setter Property="Padding" Value="12,8" />
         <Setter Property="Margin" Value="2" />
         <Setter Property="CornerRadius" Value="4" />
     </Style>
     
-    <Style Selector="controls|ListBox ListBoxItem:pointerover">
+    <Style Selector=":is(controls|ListBox) ListBoxItem:pointerover">
         <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondary}" />
     </Style>
     
-    <Style Selector="controls|ListBox ListBoxItem:selected">
+    <Style Selector=":is(controls|ListBox) ListBoxItem:selected">
         <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiary}" />
     </Style>
     
-    <Style Selector="controls|ListBox ListBoxItem:selected:pointerover">
+    <Style Selector=":is(controls|ListBox) ListBoxItem:selected:pointerover">
         <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiary}" />
     </Style>
     

--- a/src/CrissCross.Avalonia.UI/Themes/ListView.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/ListView.axaml
@@ -3,7 +3,8 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross ListView Style -->
-    <Style Selector="controls|ListView">
+    <Style Selector=":is(controls|ListView)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type ListBox}}" />
         <Setter Property="Background" Value="{DynamicResource ControlFillColorDefault}" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimary}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ControlStrokeColorDefault}" />
@@ -13,17 +14,17 @@
     </Style>
     
     <!-- ListView Item Style -->
-    <Style Selector="controls|ListView ListBoxItem">
+    <Style Selector=":is(controls|ListView) ListBoxItem">
         <Setter Property="Padding" Value="12,8" />
         <Setter Property="Margin" Value="2" />
         <Setter Property="CornerRadius" Value="4" />
     </Style>
     
-    <Style Selector="controls|ListView ListBoxItem:pointerover">
+    <Style Selector=":is(controls|ListView) ListBoxItem:pointerover">
         <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondary}" />
     </Style>
     
-    <Style Selector="controls|ListView ListBoxItem:selected">
+    <Style Selector=":is(controls|ListView) ListBoxItem:selected">
         <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiary}" />
     </Style>
     

--- a/src/CrissCross.Avalonia.UI/Themes/Menu.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/Menu.axaml
@@ -3,8 +3,9 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross Menu Style -->
-    <Style Selector="controls|Menu">
-        <Setter Property="Background" Value="{DynamicResource MenuBarBackground}" />
+    <Style Selector=":is(controls|Menu)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type Menu}}" />
+        <Setter Property="Background" Value="{DynamicResource ControlFillColorDefaultBrush}" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimary}" />
         <Setter Property="Padding" Value="4" />
     </Style>

--- a/src/CrissCross.Avalonia.UI/Themes/MenuItem.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/MenuItem.axaml
@@ -3,22 +3,23 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross MenuItem Style -->
-    <Style Selector="controls|MenuItem">
+    <Style Selector=":is(controls|MenuItem)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type MenuItem}}" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimary}" />
         <Setter Property="Padding" Value="12,8" />
         <Setter Property="CornerRadius" Value="4" />
     </Style>
     
-    <Style Selector="controls|MenuItem:pointerover">
+    <Style Selector=":is(controls|MenuItem):pointerover">
         <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondary}" />
     </Style>
     
-    <Style Selector="controls|MenuItem:pressed">
+    <Style Selector=":is(controls|MenuItem):pressed">
         <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiary}" />
     </Style>
     
-    <Style Selector="controls|MenuItem:disabled">
-        <Setter Property="Opacity" Value="0.5" />
+    <Style Selector=":is(controls|MenuItem):disabled">
+        <Setter Property="Opacity" Value="{DynamicResource DisabledTextControlOpacity}" />
     </Style>
     
 </Styles>

--- a/src/CrissCross.Avalonia.UI/Themes/PasswordBox.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/PasswordBox.axaml
@@ -7,7 +7,7 @@
         <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
         <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorderBrush}" />
-        <Setter Property="SelectionBrush" Value="{DynamicResource TextControlSelectionHighlightColor}" />
+        <Setter Property="SelectionBrush" Value="{DynamicResource AccentButtonBackground}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="4" />
         <Setter Property="Padding" Value="10,6" />
@@ -101,7 +101,7 @@
     
     <!-- Disabled State -->
     <Style Selector="controls|PasswordBox:disabled">
-        <Setter Property="Opacity" Value="0.5" />
+        <Setter Property="Opacity" Value="{DynamicResource DisabledTextControlOpacity}" />
     </Style>
     
 </Styles>

--- a/src/CrissCross.Avalonia.UI/Themes/ProcessValueIndicator.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/ProcessValueIndicator.axaml
@@ -1,0 +1,44 @@
+<Styles xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
+    <Style Selector="controls|ProcessValueIndicator">
+        <Setter Property="Background" Value="{DynamicResource CardBackgroundFillColorSecondaryBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+        <Setter Property="Padding" Value="12" />
+        <Setter Property="MinWidth" Value="220" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding CornerRadius}"
+                        Padding="{TemplateBinding Padding}">
+                    <StackPanel Spacing="6">
+                        <TextBlock FontSize="14" FontWeight="Bold" Text="{TemplateBinding Label}" TextTrimming="CharacterEllipsis" />
+                        <TextBlock FontSize="22" FontWeight="Bold" Text="{TemplateBinding DisplayText}" TextTrimming="CharacterEllipsis" />
+                        <ProgressBar x:Name="PART_RangeBar" Height="8" Minimum="0" Maximum="100"
+                                     Background="{DynamicResource SystemFillColorNeutralBackgroundBrush}"
+                                     Foreground="{DynamicResource SystemFillColorSuccessBrush}" Value="{TemplateBinding Percentage}" />
+                        <TextBlock x:Name="PART_StatusText" FontSize="14" Foreground="{DynamicResource SystemFillColorSuccessBrush}"
+                                   Text="{TemplateBinding StatusText}" TextTrimming="CharacterEllipsis" />
+                    </StackPanel>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+    <Style Selector="controls|ProcessValueIndicator[IsAlarm=True] /template/ ProgressBar#PART_RangeBar">
+        <Setter Property="Foreground" Value="{DynamicResource SystemFillColorCriticalBrush}" />
+    </Style>
+    <Style Selector="controls|ProcessValueIndicator[IsAlarm=True] /template/ TextBlock#PART_StatusText">
+        <Setter Property="Foreground" Value="{DynamicResource SystemFillColorCriticalBrush}" />
+    </Style>
+    <Style Selector="controls|ProcessValueIndicator[Status=BadQuality] /template/ ProgressBar#PART_RangeBar">
+        <Setter Property="Foreground" Value="{DynamicResource SystemFillColorCautionBrush}" />
+    </Style>
+    <Style Selector="controls|ProcessValueIndicator[Status=BadQuality] /template/ TextBlock#PART_StatusText">
+        <Setter Property="Foreground" Value="{DynamicResource SystemFillColorCautionBrush}" />
+    </Style>
+    <Style Selector="controls|ProcessValueIndicator[Status=InvalidConfiguration] /template/ ProgressBar#PART_RangeBar">
+        <Setter Property="Foreground" Value="{DynamicResource SystemFillColorNeutralBrush}" />
+    </Style>
+    <Style Selector="controls|ProcessValueIndicator[Status=InvalidConfiguration] /template/ TextBlock#PART_StatusText">
+        <Setter Property="Foreground" Value="{DynamicResource SystemFillColorNeutralBrush}" />
+    </Style>
+</Styles>

--- a/src/CrissCross.Avalonia.UI/Themes/PropertyGridLite.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/PropertyGridLite.axaml
@@ -8,7 +8,7 @@
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Padding="12"
-                        BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                        BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
                         BorderThickness="1"
                         CornerRadius="6">
                     <StackPanel>

--- a/src/CrissCross.Avalonia.UI/Themes/RadioButton.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/RadioButton.axaml
@@ -4,7 +4,7 @@
     
     <!-- CrissCross RadioButton Style -->
     <Style Selector="controls|RadioButton">
-        <Setter Property="Foreground" Value="{DynamicResource RadioButtonForeground}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
         <Setter Property="Background" Value="{DynamicResource RadioButtonOuterEllipseFill}" />
         <Setter Property="BorderBrush" Value="{DynamicResource RadioButtonOuterEllipseStroke}" />
         <Setter Property="Padding" Value="8,0,0,0" />
@@ -25,7 +25,7 @@
                         <Ellipse Name="CheckGlyph"
                                  Width="10"
                                  Height="10"
-                                 Fill="{DynamicResource RadioButtonCheckGlyphFill}"
+                                 Fill="{DynamicResource RadioButtonOuterEllipseCheckedStroke}"
                                  IsVisible="False" />
                     </Grid>
                     <ContentPresenter Name="ContentPresenter"
@@ -34,7 +34,8 @@
                                       ContentTemplate="{TemplateBinding ContentTemplate}"
                                       Margin="{TemplateBinding Padding}"
                                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      TextElement.Foreground="{TemplateBinding Foreground}" />
                 </Grid>
             </ControlTemplate>
         </Setter>
@@ -42,8 +43,8 @@
     
     <!-- Checked State -->
     <Style Selector="controls|RadioButton:checked /template/ Ellipse#OuterEllipse">
-        <Setter Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseFillChecked}" />
-        <Setter Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseStrokeChecked}" />
+        <Setter Property="Fill" Value="{DynamicResource ControlAltFillColorTransparentBrush}" />
+        <Setter Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseCheckedStroke}" />
     </Style>
     
     <Style Selector="controls|RadioButton:checked /template/ Ellipse#CheckGlyph">
@@ -52,12 +53,22 @@
     
     <!-- PointerOver State -->
     <Style Selector="controls|RadioButton:pointerover /template/ Ellipse#OuterEllipse">
-        <Setter Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseStrokePointerOver}" />
+        <Setter Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseCheckedStroke}" />
     </Style>
     
     <!-- Disabled State -->
     <Style Selector="controls|RadioButton:disabled">
-        <Setter Property="Opacity" Value="0.5" />
+        <Setter Property="Opacity" Value="{DynamicResource DisabledTextControlOpacity}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextFillColorDisabledBrush}" />
+    </Style>
+
+    <Style Selector="controls|RadioButton:disabled /template/ Ellipse#OuterEllipse">
+        <Setter Property="Fill" Value="{DynamicResource ControlAltFillColorTransparentBrush}" />
+        <Setter Property="Stroke" Value="{DynamicResource ControlStrongStrokeColorDisabledBrush}" />
+    </Style>
+
+    <Style Selector="controls|RadioButton:disabled /template/ Ellipse#CheckGlyph">
+        <Setter Property="Fill" Value="{DynamicResource ControlStrongStrokeColorDisabledBrush}" />
     </Style>
     
 </Styles>

--- a/src/CrissCross.Avalonia.UI/Themes/ScrollBar.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/ScrollBar.axaml
@@ -1,9 +1,11 @@
 <Styles xmlns="https://github.com/avaloniaui"
+        xmlns:primitives="clr-namespace:Avalonia.Controls.Primitives;assembly=Avalonia.Controls"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross ScrollBar Style -->
-    <Style Selector="controls|ScrollBar">
+    <Style Selector=":is(controls|ScrollBar)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type primitives:ScrollBar}}" />
         <Setter Property="Background" Value="Transparent" />
     </Style>
     

--- a/src/CrissCross.Avalonia.UI/Themes/ScrollViewer.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/ScrollViewer.axaml
@@ -3,7 +3,8 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross ScrollViewer Style -->
-    <Style Selector="controls|ScrollViewer">
+    <Style Selector=":is(controls|ScrollViewer)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type ScrollViewer}}" />
         <Setter Property="Background" Value="Transparent" />
     </Style>
     

--- a/src/CrissCross.Avalonia.UI/Themes/SegmentedControl.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/SegmentedControl.axaml
@@ -34,7 +34,7 @@
     </Style>
 
     <Style Selector="controls|SegmentedControl > ListBoxItem:selected">
-        <Setter Property="Background" Value="{DynamicResource AccentFillColorDefaultBrush}" />
+        <Setter Property="Background" Value="{DynamicResource AccentButtonBackground}" />
         <Setter Property="Foreground" Value="{DynamicResource TextOnAccentFillColorPrimaryBrush}" />
     </Style>
 

--- a/src/CrissCross.Avalonia.UI/Themes/Separator.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/Separator.axaml
@@ -3,7 +3,8 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross Separator Style -->
-    <Style Selector="controls|Separator">
+    <Style Selector=":is(controls|Separator)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type Separator}}" />
         <Setter Property="Background" Value="{DynamicResource DividerStrokeColorDefault}" />
         <Setter Property="Height" Value="1" />
         <Setter Property="Margin" Value="0,4" />

--- a/src/CrissCross.Avalonia.UI/Themes/SplitButton.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/SplitButton.axaml
@@ -3,10 +3,11 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross SplitButton Style -->
-    <Style Selector="controls|SplitButton">
-        <Setter Property="Background" Value="{DynamicResource SplitButtonBackground}" />
-        <Setter Property="Foreground" Value="{DynamicResource SplitButtonForeground}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource SplitButtonBorderBrush}" />
+    <Style Selector=":is(controls|SplitButton)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type SplitButton}}" />
+        <Setter Property="Background" Value="{DynamicResource ButtonBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource ButtonForeground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="4" />
         <Setter Property="Padding" Value="12,6" />
@@ -15,13 +16,13 @@
     </Style>
     
     <!-- PointerOver State -->
-    <Style Selector="controls|SplitButton:pointerover">
-        <Setter Property="Background" Value="{DynamicResource SplitButtonBackgroundPointerOver}" />
+    <Style Selector=":is(controls|SplitButton):pointerover">
+        <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPointerOver}" />
     </Style>
     
     <!-- Disabled State -->
-    <Style Selector="controls|SplitButton:disabled">
-        <Setter Property="Opacity" Value="0.5" />
+    <Style Selector=":is(controls|SplitButton):disabled">
+        <Setter Property="Opacity" Value="{DynamicResource DisabledTextControlOpacity}" />
     </Style>
     
 </Styles>

--- a/src/CrissCross.Avalonia.UI/Themes/Stepper.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/Stepper.axaml
@@ -32,23 +32,23 @@
                     <TextBlock Margin="0,0,0,8"
                                Opacity="0.72"
                                Text="{Binding State.ProgressText, RelativeSource={RelativeSource TemplatedParent}}" />
-                    <ItemsPresenter ItemsPanel="{TemplateBinding ItemsPanel}" />
+                    <ItemsPresenter Name="PART_ItemsPresenter" ItemsPanel="{TemplateBinding ItemsPanel}" />
                     <StackPanel Margin="0,8,0,0" Orientation="Horizontal">
                         <Button MinWidth="72"
                                 Margin="0,0,8,0"
                                 Command="{Binding PreviousStepCommand, RelativeSource={RelativeSource TemplatedParent}}"
                                 Content="Previous"
-                                IsEnabled="{Binding State.CanGoPrevious, RelativeSource={RelativeSource TemplatedParent}}" />
+                                IsEnabled="{Binding State.CanGoPrevious, RelativeSource={RelativeSource TemplatedParent}, FallbackValue=False, TargetNullValue=False}" />
                         <Button MinWidth="72"
                                 Margin="0,0,8,0"
                                 Command="{Binding NextStepCommand, RelativeSource={RelativeSource TemplatedParent}}"
                                 Content="Next"
-                                IsEnabled="{Binding State.CanGoNext, RelativeSource={RelativeSource TemplatedParent}}" />
+                                IsEnabled="{Binding State.CanGoNext, RelativeSource={RelativeSource TemplatedParent}, FallbackValue=False, TargetNullValue=False}" />
                         <Button MinWidth="72"
                                 Margin="0,0,8,0"
                                 Command="{Binding FinishCommand, RelativeSource={RelativeSource TemplatedParent}}"
                                 Content="Finish"
-                                IsEnabled="{Binding State.CanFinish, RelativeSource={RelativeSource TemplatedParent}}" />
+                                IsEnabled="{Binding State.CanFinish, RelativeSource={RelativeSource TemplatedParent}, FallbackValue=False, TargetNullValue=False}" />
                         <Button MinWidth="72"
                                 Command="{Binding CancelCommand, RelativeSource={RelativeSource TemplatedParent}}"
                                 Content="Cancel" />

--- a/src/CrissCross.Avalonia.UI/Themes/TabControl.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/TabControl.axaml
@@ -3,23 +3,24 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross TabControl Style -->
-    <Style Selector="controls|TabControl">
+    <Style Selector=":is(controls|TabControl)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type TabControl}}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimary}" />
         <Setter Property="Padding" Value="0" />
     </Style>
     
     <!-- Tab item styling within CrissCross TabControl -->
-    <Style Selector="controls|TabControl TabItem">
+    <Style Selector=":is(controls|TabControl) TabItem">
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondary}" />
         <Setter Property="Padding" Value="12,8" />
     </Style>
     
-    <Style Selector="controls|TabControl TabItem:selected">
+    <Style Selector=":is(controls|TabControl) TabItem:selected">
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimary}" />
     </Style>
     
-    <Style Selector="controls|TabControl TabItem:pointerover">
+    <Style Selector=":is(controls|TabControl) TabItem:pointerover">
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimary}" />
     </Style>
     

--- a/src/CrissCross.Avalonia.UI/Themes/TextBlock.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/TextBlock.axaml
@@ -3,59 +3,59 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross TextBlock Style -->
-    <Style Selector="controls|TextBlock">
+    <Style Selector=":is(controls|TextBlock)">
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimary}" />
         <Setter Property="FontSize" Value="14" />
     </Style>
     
     <!-- Typography variants -->
-    <Style Selector="controls|TextBlock[FontTypography=Caption]">
+    <Style Selector=":is(controls|TextBlock)[FontTypography=Caption]">
         <Setter Property="FontSize" Value="12" />
     </Style>
     
-    <Style Selector="controls|TextBlock[FontTypography=Body]">
+    <Style Selector=":is(controls|TextBlock)[FontTypography=Body]">
         <Setter Property="FontSize" Value="14" />
     </Style>
     
-    <Style Selector="controls|TextBlock[FontTypography=BodyStrong]">
+    <Style Selector=":is(controls|TextBlock)[FontTypography=BodyStrong]">
         <Setter Property="FontSize" Value="14" />
         <Setter Property="FontWeight" Value="SemiBold" />
     </Style>
     
-    <Style Selector="controls|TextBlock[FontTypography=Subtitle]">
+    <Style Selector=":is(controls|TextBlock)[FontTypography=Subtitle]">
         <Setter Property="FontSize" Value="20" />
         <Setter Property="FontWeight" Value="SemiBold" />
     </Style>
     
-    <Style Selector="controls|TextBlock[FontTypography=Title]">
+    <Style Selector=":is(controls|TextBlock)[FontTypography=Title]">
         <Setter Property="FontSize" Value="28" />
         <Setter Property="FontWeight" Value="SemiBold" />
     </Style>
     
-    <Style Selector="controls|TextBlock[FontTypography=TitleLarge]">
+    <Style Selector=":is(controls|TextBlock)[FontTypography=TitleLarge]">
         <Setter Property="FontSize" Value="40" />
         <Setter Property="FontWeight" Value="SemiBold" />
     </Style>
     
-    <Style Selector="controls|TextBlock[FontTypography=Display]">
+    <Style Selector=":is(controls|TextBlock)[FontTypography=Display]">
         <Setter Property="FontSize" Value="68" />
         <Setter Property="FontWeight" Value="SemiBold" />
     </Style>
     
     <!-- Appearance variants -->
-    <Style Selector="controls|TextBlock[Appearance=Primary]">
+    <Style Selector=":is(controls|TextBlock)[Appearance=Primary]">
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimary}" />
     </Style>
     
-    <Style Selector="controls|TextBlock[Appearance=Secondary]">
+    <Style Selector=":is(controls|TextBlock)[Appearance=Secondary]">
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondary}" />
     </Style>
     
-    <Style Selector="controls|TextBlock[Appearance=Tertiary]">
+    <Style Selector=":is(controls|TextBlock)[Appearance=Tertiary]">
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorTertiary}" />
     </Style>
     
-    <Style Selector="controls|TextBlock[Appearance=Disabled]">
+    <Style Selector=":is(controls|TextBlock)[Appearance=Disabled]">
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorDisabled}" />
     </Style>
     

--- a/src/CrissCross.Avalonia.UI/Themes/TextBox.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/TextBox.axaml
@@ -7,7 +7,7 @@
         <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
         <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorderBrush}" />
-        <Setter Property="SelectionBrush" Value="{DynamicResource TextControlSelectionHighlightColor}" />
+        <Setter Property="SelectionBrush" Value="{DynamicResource AccentButtonBackground}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="4" />
         <Setter Property="Padding" Value="10,6" />
@@ -74,7 +74,7 @@
     
     <!-- Disabled State -->
     <Style Selector="controls|TextBox:disabled">
-        <Setter Property="Opacity" Value="0.5" />
+        <Setter Property="Opacity" Value="{DynamicResource DisabledTextControlOpacity}" />
     </Style>
     
 </Styles>

--- a/src/CrissCross.Avalonia.UI/Themes/ThumbRate.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/ThumbRate.axaml
@@ -6,8 +6,8 @@
     <Style Selector="controls|ThumbRate">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="ThumbSize" Value="24" />
-        <Setter Property="SelectedBrush" Value="{DynamicResource AccentFillColorDefaultBrush}" />
-        <Setter Property="UnselectedBrush" Value="{DynamicResource TextFillColorSecondary}" />
+        <Setter Property="SelectedBrush" Value="{DynamicResource AccentButtonBackground}" />
+        <Setter Property="UnselectedBrush" Value="{DynamicResource TextFillColorSecondaryBrush}" />
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Background="{TemplateBinding Background}"

--- a/src/CrissCross.Avalonia.UI/Themes/ToggleButton.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/ToggleButton.axaml
@@ -4,9 +4,9 @@
     
     <!-- CrissCross ToggleButton Style -->
     <Style Selector="controls|ToggleButton">
-        <Setter Property="Background" Value="{DynamicResource ToggleButtonBackground}" />
-        <Setter Property="Foreground" Value="{DynamicResource ToggleButtonForeground}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ToggleButtonBorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ButtonBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource ButtonForeground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="4" />
         <Setter Property="Padding" Value="12,6" />
@@ -33,7 +33,7 @@
     <!-- Checked State -->
     <Style Selector="controls|ToggleButton:checked /template/ Border#RootBorder">
         <Setter Property="Background" Value="{DynamicResource AccentButtonBackground}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource AccentButtonBorderBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource AccentControlElevationBorderBrush}" />
     </Style>
     
     <Style Selector="controls|ToggleButton:checked">
@@ -42,7 +42,7 @@
     
     <!-- PointerOver State -->
     <Style Selector="controls|ToggleButton:pointerover /template/ Border#RootBorder">
-        <Setter Property="Background" Value="{DynamicResource ToggleButtonBackgroundPointerOver}" />
+        <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPointerOver}" />
     </Style>
     
     <!-- Disabled State -->

--- a/src/CrissCross.Avalonia.UI/Themes/ToggleSwitch.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/ToggleSwitch.axaml
@@ -76,7 +76,7 @@
         </Setter>
         
         <!-- Default styling -->
-        <Setter Property="Background" Value="{DynamicResource ToggleSwitchContainerBackground}" />
+        <Setter Property="Background" Value="{DynamicResource ToggleSwitchFillOff}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ToggleSwitchStrokeOff}" />
         <Setter Property="Foreground" Value="{DynamicResource ToggleSwitchContentForeground}" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -108,12 +108,12 @@
     
     <!-- PointerOver state (unchecked) -->
     <Style Selector="controls|ToggleSwitch:pointerover:not(:checked) /template/ Border#SwitchAreaGrid">
-        <Setter Property="Background" Value="{DynamicResource ToggleSwitchContainerBackgroundPointerOver}" />
+        <Setter Property="Background" Value="{DynamicResource ControlAltFillColorTertiaryBrush}" />
     </Style>
     
     <!-- PointerOver state (checked) -->
     <Style Selector="controls|ToggleSwitch:pointerover:checked /template/ Border#SwitchAreaGrid">
-        <Setter Property="Background" Value="{DynamicResource ToggleSwitchFillOnPointerOver}" />
+        <Setter Property="Background" Value="{DynamicResource AccentButtonBackgroundPointerOver}" />
     </Style>
     
 </Styles>

--- a/src/CrissCross.Avalonia.UI/Themes/ToolTip.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/ToolTip.axaml
@@ -6,13 +6,13 @@
     <Style Selector="controls|ToolTip">
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Background="{DynamicResource ToolTipBackground}"
-                        BorderBrush="{DynamicResource ToolTipBorderBrush}"
+                <Border Background="{DynamicResource FlyoutBackground}"
+                        BorderBrush="{DynamicResource FlyoutBorderBrush}"
                         BorderThickness="1"
                         CornerRadius="4"
                         Padding="12,8">
                     <TextBlock Text="{TemplateBinding Text}"
-                               Foreground="{DynamicResource ToolTipForeground}"
+                               Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                                FontSize="12"
                                TextWrapping="Wrap" />
                 </Border>

--- a/src/CrissCross.Avalonia.UI/Themes/TreeView.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/TreeView.axaml
@@ -3,7 +3,8 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross TreeView Style -->
-    <Style Selector="controls|TreeView">
+    <Style Selector=":is(controls|TreeView)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type TreeView}}" />
         <Setter Property="Background" Value="{DynamicResource ControlFillColorDefault}" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimary}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ControlStrokeColorDefault}" />
@@ -13,15 +14,15 @@
     </Style>
     
     <!-- TreeView Item Style -->
-    <Style Selector="controls|TreeView TreeViewItem">
+    <Style Selector=":is(controls|TreeView) TreeViewItem">
         <Setter Property="Padding" Value="8,4" />
     </Style>
     
-    <Style Selector="controls|TreeView TreeViewItem:pointerover">
+    <Style Selector=":is(controls|TreeView) TreeViewItem:pointerover">
         <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondary}" />
     </Style>
     
-    <Style Selector="controls|TreeView TreeViewItem:selected">
+    <Style Selector=":is(controls|TreeView) TreeViewItem:selected">
         <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiary}" />
     </Style>
     

--- a/src/CrissCross.Avalonia.UI/Themes/ValidationSummary.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/ValidationSummary.axaml
@@ -28,7 +28,7 @@
                     <StackPanel>
                         <TextBlock FontWeight="SemiBold"
                                    Text="{Binding SummaryState.SummaryText, RelativeSource={RelativeSource TemplatedParent}}" />
-                        <ItemsPresenter Margin="0,8,0,0" />
+                        <ItemsPresenter Name="PART_ItemsPresenter" ItemsPanel="{TemplateBinding ItemsPanel}" Margin="0,8,0,0" />
                     </StackPanel>
                 </Border>
             </ControlTemplate>

--- a/src/CrissCross.Avalonia.UI/Themes/VirtualizingGridView.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/VirtualizingGridView.axaml
@@ -3,7 +3,8 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross VirtualizingGridView Style -->
-    <Style Selector="controls|VirtualizingGridView">
+    <Style Selector=":is(controls|VirtualizingGridView)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type ListBox}}" />
         <Setter Property="Background" Value="{DynamicResource ControlFillColorDefault}" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimary}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ControlStrokeColorDefault}" />
@@ -18,17 +19,17 @@
     </Style>
     
     <!-- VirtualizingGridView Item Style -->
-    <Style Selector="controls|VirtualizingGridView ListBoxItem">
+    <Style Selector=":is(controls|VirtualizingGridView) ListBoxItem">
         <Setter Property="Padding" Value="8" />
         <Setter Property="Margin" Value="2" />
         <Setter Property="CornerRadius" Value="4" />
     </Style>
     
-    <Style Selector="controls|VirtualizingGridView ListBoxItem:pointerover">
+    <Style Selector=":is(controls|VirtualizingGridView) ListBoxItem:pointerover">
         <Setter Property="Background" Value="{DynamicResource SubtleFillColorSecondary}" />
     </Style>
     
-    <Style Selector="controls|VirtualizingGridView ListBoxItem:selected">
+    <Style Selector=":is(controls|VirtualizingGridView) ListBoxItem:selected">
         <Setter Property="Background" Value="{DynamicResource SubtleFillColorTertiary}" />
     </Style>
     

--- a/src/CrissCross.Avalonia.UI/Themes/VirtualizingItemsControl.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/VirtualizingItemsControl.axaml
@@ -3,7 +3,8 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross VirtualizingItemsControl Style -->
-    <Style Selector="controls|VirtualizingItemsControl">
+    <Style Selector=":is(controls|VirtualizingItemsControl)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type ItemsControl}}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimary}" />
     </Style>

--- a/src/CrissCross.Avalonia.UI/Themes/Window.axaml
+++ b/src/CrissCross.Avalonia.UI/Themes/Window.axaml
@@ -3,10 +3,10 @@
         xmlns:controls="clr-namespace:CrissCross.Avalonia.UI.Controls;assembly=CrissCross.Avalonia.UI">
     
     <!-- CrissCross Window Style -->
-    <Style Selector="controls|Window">
+    <Style Selector=":is(controls|Window)">
+        <Setter Property="Theme" Value="{StaticResource {x:Type Window}}" />
         <Setter Property="Background" Value="{DynamicResource ApplicationBackgroundColor}" />
         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimary}" />
-        <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
         <Setter Property="FontSize" Value="14" />
     </Style>
     

--- a/src/CrissCross.Avalonia.UI/UI-PARITY.md
+++ b/src/CrissCross.Avalonia.UI/UI-PARITY.md
@@ -4,23 +4,27 @@ The Avalonia UI project has a source control-folder match with the WPF UI
 project for every control family except `Symbols`. `Symbols` is a WPF generated
 asset container; Avalonia exposes the equivalent `SymbolRegular` and
 `SymbolFilled` icon definitions directly, while additionally exposing
-`MenuItem` as its own control family.
+`MenuItem` as its own control family. Avalonia also includes the coordinated
+industrial `ProcessValueIndicator` control for process-value readouts.
 
-The themed-control inventory contains 113 Avalonia theme dictionaries across
-117 public control families. The gallery now covers every applicable family:
-60 families are instantiated directly on its interactive pages and the
-remaining 51 are discoverable through the data-driven **Control & Host
-Catalog** page. That page identifies the concrete composed page or top-level
-host required by each family. It deliberately avoids invalid nested window,
-dialog, and virtualisation topology.
+The themed-control inventory contains 114 Avalonia control theme dictionaries
+across 118 public control families. The gallery now covers the applicable
+rendered control families directly or through the data-driven **Control & Host
+Catalog** page. The catalog also marks API-compatibility wrappers whose current
+Avalonia implementation is intentionally thin, including `Frame` and `Page`, so
+those entries are not counted as behavior-parity demonstrations until their
+navigation behavior is implemented. `NavigationUserControl` is now a concrete
+Avalonia UI routed view-model host wrapper with a per-instance generated host
+name when consumers do not supply one.
+It deliberately avoids invalid nested window, dialog, and virtualisation topology.
 
 | Comparison | Before | After |
 | --- | ---: | ---: |
-| Avalonia public control families | 117 | 117 |
-| Directly instantiated gallery families | 60 | 60 |
-| Discoverable catalog or host families | 0 | 51 |
-| Applicable families without a gallery/host example | 51 | 0 |
-| Theme dictionaries covered by an application style include | 113 | 113 |
+| Avalonia public control families | 117 | 118 |
+| Directly instantiated gallery families | 60 | 61 |
+| Discoverable catalog, host, or wrapper families | 0 | 52 |
+| Applicable families without a gallery/host or wrapper entry | 51 | 0 |
+| Theme dictionaries covered by an application style include | 113 | 114 |
 | Inapplicable nested-page families | 6 | 6 |
 
 The catalog records these composed or host-backed families:
@@ -28,14 +32,21 @@ The catalog records these composed or host-backed families:
 `Alarms`, `Anchor`, `AppBar`, `Arc`, `BreadcrumbBar`, `ChipGroup`,
 `ContentDialog`, `ContextMenu`, `DataFilterPanel`, `DataGrid`,
 `DynamicScrollBar`, `DynamicScrollViewer`, `EmptyState`, `Expander`, `Flyout`,
-`Frame`, `Gauges`, `GifImage`, `GridView`, `GroupBox`, `IconElement`,
+`Frame` (wrapper gap tracked separately), `Gauges`, `GifImage`, `GridView`, `GroupBox`, `IconElement`,
 `IconSource`, `Image`, `ItemsControl`, `Label`, `ListBox`, `ListView`,
 `LoadingScreen`, `Menu`, `MessageBox`, `MessageBoxAsync`,
-`NavigationControls`, `NavigationUserControl`, `NavigationView`,
-`NumericPushButton`, `Page`, `PropertyGridLite`, `ScrollBar`, `ScrollViewer`,
-`StatusBar`, `TabControl`, `TabView`, `TitleBar`, `ToolBar`, `ToolTip`,
-`TreeGrid`, `TreeView`, `ValidationSummary`, `VirtualizingGridView`,
-`VirtualizingItemsControl`, and `VirtualizingWrapPanel`.
+`NavigationControls`, `NavigationUserControl` (per-instance routed host), `NavigationView`,
+`NumericPushButton`, `Page` (wrapper gap tracked separately), `ProcessValueIndicator`, `PropertyGridLite`,
+`ScrollBar`, `ScrollViewer`, `StatusBar`, `TabControl`, `TabView`, `TitleBar`,
+`ToolBar`, `ToolTip`, `TreeGrid`, `TreeView`, `ValidationSummary`,
+`VirtualizingGridView`, `VirtualizingItemsControl`, and
+`VirtualizingWrapPanel`.
+
+`NavigationUserControl` now composes the existing Avalonia
+`ViewModelRoutedViewHost`, preserves consumer content inside the frame, and
+registers a stable per-instance navigation host. `Frame` and `Page` remain thin
+Avalonia `UserControl` wrappers retained for API compatibility and are not
+behavior-parity navigation implementations yet.
 
 The six remaining inapplicable families are native window-chrome primitives:
 `AccessText`, `ClientAreaBorder`, `FluentNavigationWindow`, `FluentWindow`,
@@ -44,7 +55,7 @@ they are instead exercised by the application-level gallery window/topology or
 are native text/chrome primitives styled by the loaded theme dictionaries.
 
 Interactive gallery coverage includes custom input, command, picker, feedback,
-card, workflow, BBCode, rich text, progress, and theme controls. It also
-includes `ThemeSwitcher` and runtime light/dark selection, which exercise the
-shared resources in `Resources/Theme/Light.axaml` and
-`Resources/Theme/Dark.axaml`.
+card, workflow, BBCode, rich text, progress, industrial process-value, and
+theme controls. It also includes `ThemeSwitcher` and runtime light/dark
+selection, which exercise the shared resources in
+`Resources/Theme/Light.axaml` and `Resources/Theme/Dark.axaml`.

--- a/src/CrissCross.Avalonia/NavigationUserControl.cs
+++ b/src/CrissCross.Avalonia/NavigationUserControl.cs
@@ -22,6 +22,10 @@ namespace CrissCross.Avalonia;
 /// <seealso cref="IActivatableView" />
 public class NavigationUserControl : UserControl, ISetNavigation, IUseNavigation, IActivatableView
 {
+    /// <summary>Identifies the XAML-addressable view-model property shared by all navigation control types.</summary>
+    public static readonly StyledProperty<object?> ViewModelProperty =
+        AvaloniaProperty.Register<NavigationUserControl, object?>(nameof(ViewModel));
+
     /// <summary>The navigate back is enabled property.</summary>
     public static readonly StyledProperty<bool?> NavigateBackIsEnabledProperty = AvaloniaProperty.Register<
         NavigationUserControl,
@@ -66,6 +70,13 @@ public class NavigationUserControl : UserControl, ISetNavigation, IUseNavigation
     {
         get => GetValue(NavigateBackIsEnabledProperty);
         set => SetValue(NavigateBackIsEnabledProperty, value);
+    }
+
+    /// <summary>Gets or sets the view model exposed to XAML and strongly typed navigation controls.</summary>
+    public object? ViewModel
+    {
+        get => GetValue(ViewModelProperty);
+        set => SetValue(ViewModelProperty, value);
     }
 
     /// <summary>Gets the navigation frame.</summary>

--- a/src/CrissCross.Avalonia/NavigationUserControl{TViewModel}.cs
+++ b/src/CrissCross.Avalonia/NavigationUserControl{TViewModel}.cs
@@ -19,16 +19,6 @@ namespace CrissCross.Avalonia;
 public class NavigationUserControl<TViewModel> : NavigationUserControl, IViewFor<TViewModel>
     where TViewModel : class, IRxObject, new()
 {
-    /// <summary>The view model dependency property.</summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "AvaloniaProperty",
-        "AVP1002",
-        Justification = "Generic avalonia property is expected here.")]
-    public static readonly StyledProperty<TViewModel?> ViewModelProperty = AvaloniaProperty.Register<
-        NavigationUserControl<TViewModel>,
-        TViewModel?
-    >(nameof(ViewModel));
-
     /// <summary>Initializes a new instance of the <see cref="NavigationUserControl{TViewModel}"/> class.</summary>
     public NavigationUserControl() => AttachedToVisualTree += OnAttachedToVisualTree;
 
@@ -36,10 +26,10 @@ public class NavigationUserControl<TViewModel> : NavigationUserControl, IViewFor
     public TViewModel? BindingRoot => ViewModel;
 
     /// <inheritdoc/>
-    public TViewModel? ViewModel
+    public new TViewModel? ViewModel
     {
-        get => GetValue(ViewModelProperty);
-        set => SetValue(ViewModelProperty, value);
+        get => (TViewModel?)base.ViewModel;
+        set => base.ViewModel = value;
     }
 
     /// <inheritdoc/>

--- a/src/CrissCross.Avalonia/NavigationWindow.cs
+++ b/src/CrissCross.Avalonia/NavigationWindow.cs
@@ -23,6 +23,10 @@ namespace CrissCross.Avalonia;
 /// <seealso cref="IActivatableView" />
 public class NavigationWindow : Window, ISetNavigation, IUseNavigation, IActivatableView
 {
+    /// <summary>Identifies the XAML-addressable view-model property shared by all navigation window types.</summary>
+    public static readonly StyledProperty<object?> ViewModelProperty =
+        AvaloniaProperty.Register<NavigationWindow, object?>(nameof(ViewModel));
+
     /// <summary>The navigate back is enabled property.</summary>
     public static readonly StyledProperty<bool?> NavigateBackIsEnabledProperty = AvaloniaProperty.Register<
         NavigationWindow,
@@ -87,6 +91,13 @@ public class NavigationWindow : Window, ISetNavigation, IUseNavigation, IActivat
         set => SetValue(NavigateBackIsEnabledProperty, value);
     }
 
+    /// <summary>Gets or sets the view model exposed to XAML and strongly typed navigation windows.</summary>
+    public object? ViewModel
+    {
+        get => GetValue(ViewModelProperty);
+        set => SetValue(ViewModelProperty, value);
+    }
+
     /// <summary>Gets the navigation frame.</summary>
     /// <value>
     /// The navigation frame.
@@ -128,6 +139,11 @@ public class NavigationWindow : Window, ISetNavigation, IUseNavigation, IActivat
             return;
         }
 
+        if (!string.IsNullOrWhiteSpace(_navigationHostName))
+        {
+            return;
+        }
+
         _navigationHostName = Name;
         if (NavigationFrame is not { } host)
         {
@@ -153,6 +169,13 @@ public class NavigationWindow : Window, ISetNavigation, IUseNavigation, IActivat
         }
 
         return base.RegisterContentPresenter(presenter);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnClosed(EventArgs e)
+    {
+        NavigationFrame?.Dispose();
+        base.OnClosed(e);
     }
 
     /// <summary>Runs the configure Navigation Host operation.</summary>

--- a/src/CrissCross.Avalonia/NavigationWindow{TViewModel}.cs
+++ b/src/CrissCross.Avalonia/NavigationWindow{TViewModel}.cs
@@ -19,16 +19,6 @@ namespace CrissCross.Avalonia;
 public class NavigationWindow<TViewModel> : NavigationWindow, IViewFor<TViewModel>
     where TViewModel : class, IRxObject, new()
 {
-    /// <summary>The view model dependency property.</summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "AvaloniaProperty",
-        "AVP1002",
-        Justification = "Generic avalonia property is expected here.")]
-    public static readonly StyledProperty<TViewModel?> ViewModelProperty = AvaloniaProperty.Register<
-        NavigationWindow<TViewModel>,
-        TViewModel?
-    >(nameof(ViewModel));
-
     /// <summary>Initializes a new instance of the <see cref="NavigationWindow{TViewModel}"/> class.</summary>
     public NavigationWindow() => AttachedToVisualTree += OnAttachedToVisualTree;
 
@@ -36,10 +26,10 @@ public class NavigationWindow<TViewModel> : NavigationWindow, IViewFor<TViewMode
     public TViewModel? BindingRoot => ViewModel;
 
     /// <inheritdoc/>
-    public TViewModel? ViewModel
+    public new TViewModel? ViewModel
     {
-        get => GetValue(ViewModelProperty);
-        set => SetValue(ViewModelProperty, value);
+        get => (TViewModel?)base.ViewModel;
+        set => base.ViewModel = value;
     }
 
     /// <inheritdoc/>

--- a/src/CrissCross.Avalonia/ReactiveTransitioningContentControl.cs
+++ b/src/CrissCross.Avalonia/ReactiveTransitioningContentControl.cs
@@ -5,12 +5,13 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 
 #if REACTIVE_SHIM
-using ReactiveUI.Reactive;
+using UiScheduler = ReactiveUI.Primitives.Reactive.Concurrency.AvaloniaScheduler;
 #else
-using ReactiveUI;
+using UiScheduler = ReactiveUI.Primitives.Concurrency.AvaloniaScheduler;
 #endif
 
 #if REACTIVELIST_REACTIVE
@@ -20,33 +21,28 @@ namespace CrissCross.Avalonia;
 #endif
 
 /// <summary>Displays <see cref="ContentControl.Content" /> according to an <see cref="IDataTemplate" />.</summary>
-/// <seealso cref="ContentControl" />
-/// <seealso cref="IDisposable" />
 public class ReactiveTransitioningContentControl : ContentControl, IDisposable
 {
     /// <summary>The animation timer interval in milliseconds.</summary>
     private const double AnimationIntervalMilliseconds = 10D;
 
-    /// <summary>Stores the opacity Subject value.</summary>
-    private readonly Signal<double> _opacitySubject = new();
+    /// <summary>The number of opacity updates in one transition.</summary>
+    private const int AnimationStepCount = 13;
 
-    /// <summary>Stores the animation Semaphore value.</summary>
-    private readonly SemaphoreSlim _animationSemaphore = new(1);
+    /// <summary>Owns the current transition and cancels it when newer content arrives.</summary>
+    private readonly SerialDisposable _animationSubscription = new();
 
-    /// <summary>Stores the animation Disposable value.</summary>
-    private CompositeDisposable _animationDisposable = [];
-
-    /// <summary>Stores the content Presenter2 value.</summary>
-    private ContentPresenter? _contentPresenter2;
-
-    /// <summary>Stores the content Presenter1 value.</summary>
+    /// <summary>The primary template presenter.</summary>
     private ContentPresenter? _contentPresenter1;
 
-    /// <summary>Stores the current Presenter value.</summary>
-    private int _currentPresenter;
+    /// <summary>The secondary template presenter.</summary>
+    private ContentPresenter? _contentPresenter2;
 
-    /// <summary>Gets a value indicating whether gets a value that indicates whether the object is disposed.</summary>
-    public bool IsDisposed => _animationDisposable.IsDisposed;
+    /// <summary>Identifies the currently visible presenter.</summary>
+    private bool _isPrimaryVisible;
+
+    /// <summary>Gets a value indicating whether this control has been disposed.</summary>
+    public bool IsDisposed => _animationSubscription.IsDisposed;
 
     /// <summary>Releases resources used by this instance.</summary>
     public void Dispose()
@@ -55,181 +51,109 @@ public class ReactiveTransitioningContentControl : ContentControl, IDisposable
         GC.SuppressFinalize(this);
     }
 
-    /// <summary>Releases unmanaged and - optionally - managed resources.</summary>
-    /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release
-    /// only unmanaged resources.</param>
+    /// <summary>Releases the active transition subscription.</summary>
+    /// <param name="disposing">Whether managed resources should be released.</param>
     protected virtual void Dispose(bool disposing)
     {
-        if (IsDisposed || !disposing)
+        if (!disposing)
         {
             return;
         }
 
-        _animationDisposable.Dispose();
-        _opacitySubject.Dispose();
-        _animationSemaphore.Dispose();
+        _animationSubscription.Dispose();
     }
 
-    /// <inheritdoc/>
+    /// <inheritdoc />
     protected override bool RegisterContentPresenter(ContentPresenter presenter)
     {
-        if (
-            base.RegisterContentPresenter(presenter)
-            || presenter is not ContentPresenter p2
-            || p2.Name != "PART_ContentPresenter2")
+        if (base.RegisterContentPresenter(presenter))
+        {
+            _contentPresenter1 = presenter;
+            return true;
+        }
+
+        if (presenter.Name != "PART_ContentPresenter2")
         {
             return false;
         }
 
-        _contentPresenter2 = p2;
-        _contentPresenter2.IsVisible = false;
-        _contentPresenter1 = Presenter;
-        _contentPresenter1!.IsVisible = false;
-        return _contentPresenter1 is not null;
+        _contentPresenter2 = presenter;
+        return true;
     }
 
-    /// <inheritdoc/>
+    /// <inheritdoc />
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        base.OnApplyTemplate(e);
+        UpdateContent(withTransition: false);
+    }
+
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        UpdateContent(withTransition: false);
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        _animationSubscription.Disposable = null;
+        base.OnDetachedFromVisualTree(e);
+    }
+
+    /// <inheritdoc />
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
-        if (change?.Property != ContentProperty)
+        base.OnPropertyChanged(change);
+        if (change.Property != ContentProperty)
         {
-            base.OnPropertyChanged(change!);
             return;
         }
 
-        UpdateContent(true);
-        base.OnPropertyChanged(change!);
+        UpdateContent(withTransition: true);
     }
 
-    /// <summary>Runs the update Content operation.</summary>
-    /// <param name="withTransition">A value indicating whether the content change should animate.</param>
+    /// <summary>Displays the latest content without blocking the UI thread on a preceding animation.</summary>
+    /// <param name="withTransition">Whether the incoming content should fade in.</param>
     private void UpdateContent(bool withTransition)
     {
-        var (from, to, current) = GetPresenters();
-        if (VisualRoot is null || from is null || to is null)
+        if (IsDisposed || VisualRoot is null || _contentPresenter1 is null || _contentPresenter2 is null)
         {
             return;
         }
 
-        try
-        {
-            _animationSemaphore.Wait();
-            to.Content = Content;
-            if (withTransition)
-            {
-                to.Opacity = 0D;
-                to.IsVisible = true;
-                from!.IsVisible = false;
-                AnimateContent();
-            }
-            else
-            {
-                _currentPresenter = current == 1 ? 0 : 1;
-                to.IsVisible = true;
-                from.Content = null;
-                from.IsVisible = false;
-            }
-        }
-        catch
-        {
-            _ = _animationSemaphore.Release();
-        }
-    }
+        _animationSubscription.Disposable = null;
+        var from = _isPrimaryVisible ? _contentPresenter1 : _contentPresenter2;
+        var to = _isPrimaryVisible ? _contentPresenter2 : _contentPresenter1;
+        from.Content = null;
+        from.IsVisible = false;
+        to.Content = null;
+        to.Content = Content;
+        to.Opacity = 1D;
+        to.IsVisible = true;
+        _isPrimaryVisible = !_isPrimaryVisible;
 
-    /// <summary>Runs the animate Content operation.</summary>
-    private void AnimateContent()
-    {
-        // This should be an animation but there is currently an issue with PageTransitions in Avalonia
-        _animationDisposable.Dispose();
-        _animationDisposable = [];
-        var (from, to, current) = GetPresenters();
-        _ = to!.Bind(OpacityProperty, _opacitySubject).DisposeWith(_animationDisposable);
-        var opacity = new AnimationOpacityState(_opacitySubject);
-        _ = Observable
+        if (!withTransition || Content is null)
+        {
+            return;
+        }
+
+        to.Opacity = 0D;
+        var opacity = new AnimationOpacityState(to);
+        _animationSubscription.Disposable = Observable
             .Interval(TimeSpan.FromMilliseconds(AnimationIntervalMilliseconds))
-            .Subscribe(opacity.OnNext)
-            .DisposeWith(_animationDisposable);
-        _ = new ActionDisposable(new AnimationCompletion(this, from!, to!, current).Schedule)
-            .DisposeWith(_animationDisposable);
-        _ = _opacitySubject
-            .Where(static x => x >= 1D)
-            .ObserveOn(RxSchedulers.MainThreadScheduler)
-            .Subscribe(_ =>
-            {
-                if (_animationDisposable.IsDisposed)
-                {
-                    return;
-                }
-
-                _animationDisposable.Dispose();
-            })
-            .DisposeWith(_animationDisposable);
+            .Take(AnimationStepCount)
+            .ObserveOn(UiScheduler.Instance)
+            .Subscribe(opacity.OnNext);
     }
 
-    /// <summary>Gets the current and next content presenters.</summary>
-    /// <returns>The current presenter pair and active index.</returns>
-    private (ContentPresenter? from, ContentPresenter? to, int current) GetPresenters()
+    /// <summary>Updates the opacity of one incoming content presenter.</summary>
+    /// <param name="presenter">The presenter owned by this transition.</param>
+    private sealed class AnimationOpacityState(ContentPresenter presenter)
     {
-        var from = _currentPresenter == 1 ? _contentPresenter1 : _contentPresenter2;
-        var to = _currentPresenter == 1 ? _contentPresenter2 : _contentPresenter1;
-        return (from, to, _currentPresenter);
-    }
-
-    /// <summary>Maintains the opacity for a single active content transition.</summary>
-    /// <param name="opacitySubject">The transition opacity signal.</param>
-    private sealed class AnimationOpacityState(Signal<double> opacitySubject)
-    {
-        /// <summary>The opacity increment applied for each animation tick.</summary>
-        private const double OpacityIncrement = 0.08D;
-
-        /// <summary>Stores the current transition opacity.</summary>
-        private double _opacity;
-
-        /// <summary>Advances the transition opacity for one timer tick.</summary>
-        /// <param name="_">The timer tick value.</param>
-        public void OnNext(long _)
-        {
-            _opacity = Math.Min(_opacity + OpacityIncrement, 1D);
-            opacitySubject.OnNext(_opacity);
-        }
-    }
-
-    /// <summary>Schedules the final UI update for a completed content transition.</summary>
-    /// <param name="control">The control that owns the transition.</param>
-    /// <param name="from">The outgoing content presenter.</param>
-    /// <param name="to">The incoming content presenter.</param>
-    /// <param name="current">The outgoing presenter index.</param>
-    private sealed class AnimationCompletion(
-        ReactiveTransitioningContentControl control,
-        ContentPresenter from,
-        ContentPresenter to,
-        int current)
-    {
-        /// <summary>Schedules completion on the UI scheduler.</summary>
-#if REACTIVE_SHIM
-        public void Schedule() =>
-            _ = RxSchedulers.MainThreadScheduler.Schedule(
-                this,
-                static (_, completion) =>
-                {
-                    completion.Complete();
-                    return Disposable.Empty;
-                });
-#else
-        public void Schedule() =>
-            _ = RxSchedulers.MainThreadScheduler.Schedule(this, static completion => completion.Complete());
-#endif
-
-        /// <summary>Completes the transition on the UI thread.</summary>
-        private void Complete()
-        {
-            to.Opacity = 1D;
-            from.Opacity = 1D;
-            to.IsVisible = true;
-            from.IsVisible = false;
-            from.Content = null;
-            control._currentPresenter = current == 1 ? 0 : 1;
-            _ = control._animationSemaphore.Release();
-        }
+        /// <summary>Advances opacity until the incoming content is fully visible.</summary>
+        /// <param name="tick">The zero-based animation tick.</param>
+        public void OnNext(long tick) => presenter.Opacity = Math.Min((tick + 1D) / AnimationStepCount, 1D);
     }
 }

--- a/src/CrissCross.Avalonia/Themes/ReactiveTransitioningContentControl.axaml
+++ b/src/CrissCross.Avalonia/Themes/ReactiveTransitioningContentControl.axaml
@@ -7,12 +7,12 @@
             <ControlTemplate>
                 <Panel>
                     <ContentPresenter Name="PART_ContentPresenter"
-                                      Content="{TemplateBinding Content}"
                                       ContentTemplate="{TemplateBinding ContentTemplate}"
                                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                       Padding="{TemplateBinding Padding}" />
                     <ContentPresenter Name="PART_ContentPresenter2"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
                                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                       Padding="{TemplateBinding Padding}" />

--- a/src/CrissCross.Avalonia/ViewModelRoutedViewHost.cs
+++ b/src/CrissCross.Avalonia/ViewModelRoutedViewHost.cs
@@ -71,6 +71,12 @@ public class ViewModelRoutedViewHost : ReactiveTransitioningContentControl, IRes
     /// <summary>Stores the to View Model value.</summary>
     private IRxObject? _toViewModel;
 
+    /// <summary>Stores the navigation result subscription.</summary>
+    private IDisposable? _navigationResultSubscription;
+
+    /// <summary>Stores the disposed value.</summary>
+    private bool _disposedValue;
+
     /// <summary>Initializes a new instance of the <see cref="ViewModelRoutedViewHost"/> class.</summary>
     public ViewModelRoutedViewHost()
     {
@@ -317,7 +323,9 @@ public class ViewModelRoutedViewHost : ReactiveTransitioningContentControl, IRes
             return;
         }
 
-        _ = resultNavigating
+        _navigationResultSubscription?.Dispose();
+
+        _navigationResultSubscription = resultNavigating
             .DistinctUntilChanged()
             .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(e => HandleNavigationResult(e, hostName));
@@ -327,15 +335,23 @@ public class ViewModelRoutedViewHost : ReactiveTransitioningContentControl, IRes
     /// <param name="disposing">Whether managed resources should also be released.</param>
     protected override void Dispose(bool disposing)
     {
+        if (_disposedValue)
+        {
+            return;
+        }
+
         base.Dispose(disposing);
         if (!disposing)
         {
             return;
         }
 
+        ViewModelRoutedViewHostMixins.UnregisterNavigationHost(this);
+        _navigationResultSubscription?.Dispose();
         _canNavigateBackSubject.Dispose();
         _currentViewModel.Dispose();
         _navigationViews.Clear();
+        _disposedValue = true;
     }
 
     /// <summary>Refreshes navigation hosts other than the active host.</summary>

--- a/src/CrissCross.MAUI.Reactive/CrissCross.MAUI.Reactive.csproj
+++ b/src/CrissCross.MAUI.Reactive/CrissCross.MAUI.Reactive.csproj
@@ -29,7 +29,6 @@
   <ItemGroup>
     <PackageReference Include="ReactiveUI.Maui.Reactive" />
     <PackageReference Include="Microsoft.Maui.Controls" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>

--- a/src/CrissCross.MAUI.Test/CrissCross.MAUI.Example.csproj
+++ b/src/CrissCross.MAUI.Test/CrissCross.MAUI.Example.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net10.0-android</TargetFrameworks>
@@ -55,7 +55,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
     <PackageReference Include="Microsoft.Maui.Controls" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">

--- a/src/CrissCross.MAUI.Test/ViewModels/ControlsGalleryViewModel.cs
+++ b/src/CrissCross.MAUI.Test/ViewModels/ControlsGalleryViewModel.cs
@@ -7,6 +7,9 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
+using CrissCross.Maui.UI;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls;
 using ReactiveUI;
 
 namespace CrissCross.MAUI.Test;
@@ -90,7 +93,7 @@ public sealed class ControlsGalleryViewModel : RxObject
         _segmentState = new(CreateSegments(), "table");
         _chipGroupState = new(CreateChips(AlarmsChipKey), ChipGroupSelectionMode.Multiple);
         _stepperState = new(CreateSteps(ReviewStepKey), ReviewStepKey, StepperOrientation.Horizontal);
-        _themeState = new(_selectedTheme, ThemeChoice.Dark, supportsHighContrast: true);
+        _themeState = CreateThemeState(_selectedTheme);
 
         RunImportCommand = ReactiveCommand.CreateFromTask(RunImportAsync);
         SearchCommand = ReactiveCommand.CreateFromTask<string>(SearchAsync);
@@ -223,13 +226,12 @@ public sealed class ControlsGalleryViewModel : RxObject
         get => _selectedTheme;
         set
         {
-            if (_selectedTheme == value)
+            if (_selectedTheme != value)
             {
-                return;
+                _ = this.RaiseAndSetIfChanged(ref _selectedTheme, value);
             }
 
-            _ = this.RaiseAndSetIfChanged(ref _selectedTheme, value);
-            ThemeState = new(value, ThemeChoice.Dark, supportsHighContrast: true);
+            ThemeState = CreateThemeState(value);
         }
     }
 
@@ -239,6 +241,15 @@ public sealed class ControlsGalleryViewModel : RxObject
         get => _themeState;
         private set => this.RaiseAndSetIfChanged(ref _themeState, value);
     }
+
+    /// <summary>Gets the normal process-value sample.</summary>
+    public ProcessValueState NormalProcessValue { get; } = new("Reactor temperature", 72.4, "C", 0, 100, 10, 90);
+
+    /// <summary>Gets the alarm process-value sample.</summary>
+    public ProcessValueState AlarmProcessValue { get; } = new("Line pressure", 126.8, "bar", 0, 140, new ProcessValueOptions { HighAlarmLimit = 120 });
+
+    /// <summary>Gets the bad-quality process-value sample.</summary>
+    public ProcessValueState BadQualityProcessValue { get; } = new("Flow transmitter", null, "L/min", 0, 500, new ProcessValueOptions { IsGoodQuality = false });
 
     /// <summary>Gets deterministic platform notes for manual QA.</summary>
     public string PlatformNotes { get; } = GetPlatformNotes();
@@ -298,6 +309,27 @@ public sealed class ControlsGalleryViewModel : RxObject
             ? "iOS: safe-area and touch interaction QA."
             : "MAUI: platform-specific handlers are active for the current device.";
     }
+
+    /// <summary>Creates a theme snapshot using the current MAUI requested theme for System.</summary>
+    /// <param name="choice">The selected theme choice.</param>
+    /// <returns>The theme snapshot.</returns>
+    private static ThemePreferenceState CreateThemeState(ThemeChoice choice) =>
+        new(choice, GetSystemTheme(), supportsHighContrast: true);
+
+    /// <summary>Gets the current MAUI application theme as a shared concrete theme choice.</summary>
+    /// <returns>The current concrete system theme choice.</returns>
+    private static ThemeChoice GetSystemTheme() =>
+        Application.Current?.RequestedTheme == AppTheme.Dark ? ThemeChoice.Dark : ThemeChoice.Light;
+
+    /// <summary>Maps a shared theme choice to the MAUI app theme override.</summary>
+    /// <param name="choice">The selected shared theme choice.</param>
+    /// <returns>The MAUI app theme override.</returns>
+    private static AppTheme ToApplicationTheme(ThemeChoice choice) => choice switch
+    {
+        ThemeChoice.Dark => AppTheme.Dark,
+        ThemeChoice.Light => AppTheme.Light,
+        _ => AppTheme.Unspecified,
+    };
 
     /// <summary>Provides the CreateSearchState member.</summary>
     /// <param name="text">The text value.</param>
@@ -430,5 +462,17 @@ public sealed class ControlsGalleryViewModel : RxObject
 
     /// <summary>Provides the ApplyTheme member.</summary>
     /// <param name="choice">The choice value.</param>
-    private void ApplyTheme(ThemeChoice choice) => SelectedTheme = choice;
+    private void ApplyTheme(ThemeChoice choice)
+    {
+        if (Application.Current is { } application)
+        {
+            application.UserAppTheme = ToApplicationTheme(choice);
+        }
+
+        SelectedTheme = choice;
+        if (Application.Current is { } currentApplication)
+        {
+            _ = currentApplication.Resources.UseCrissCrossMauiUiResources(ThemeState);
+        }
+    }
 }

--- a/src/CrissCross.MAUI.Test/Views/ControlsGalleryView.xaml
+++ b/src/CrissCross.MAUI.Test/Views/ControlsGalleryView.xaml
@@ -61,6 +61,15 @@
 
                 <Frame Padding="16">
                     <VerticalStackLayout Spacing="10">
+                        <Label FontAttributes="Bold" FontSize="18" Text="Industrial process values" />
+                        <mauiui:ProcessValueIndicator State="{Binding NormalProcessValue}" />
+                        <mauiui:ProcessValueIndicator State="{Binding AlarmProcessValue}" />
+                        <mauiui:ProcessValueIndicator State="{Binding BadQualityProcessValue}" />
+                    </VerticalStackLayout>
+                </Frame>
+
+                <Frame Padding="16">
+                    <VerticalStackLayout Spacing="10">
                         <Label FontAttributes="Bold" FontSize="18" Text="Theme and date/time" />
                         <mauiui:ThemeSwitcher ChangeThemeCommand="{Binding ThemeChangedCommand}" ThemeState="{Binding ThemeState}" />
                         <mauiui:DateTimeRangePicker ApplyRangeCommand="{Binding RangeChangedCommand}" Range="{Binding CurrentRange}" />

--- a/src/CrissCross.MAUI/CrissCross.MAUI.csproj
+++ b/src/CrissCross.MAUI/CrissCross.MAUI.csproj
@@ -1,15 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net10.0-ios;net10.0-tvos;net10.0-macos;net10.0-maccatalyst;net10.0-android</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-ios;net10.0-tvos;net10.0-macos;net10.0-maccatalyst;net10.0-android;net11.0;net11.0-ios;net11.0-tvos;net11.0-macos;net11.0-maccatalyst;net11.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0;net11.0-windows10.0.19041.0</TargetFrameworks>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
 
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">23.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' and $(TargetFramework.StartsWith('net11.0'))">24.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' and !$(TargetFramework.StartsWith('net11.0'))">23.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
@@ -20,7 +21,6 @@
   <ItemGroup>
     <PackageReference Include="ReactiveUI.Maui" />
     <PackageReference Include="Microsoft.Maui.Controls" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>

--- a/src/CrissCross.MAUI/NavigationShell.Setup.cs
+++ b/src/CrissCross.MAUI/NavigationShell.Setup.cs
@@ -45,8 +45,8 @@ public partial class NavigationShell
             .FromEventPattern<ShellNavigatedEventArgs>(handler => Navigated += handler, handler => Navigated -= handler)
             .Select(static pattern => pattern.EventArgs);
 
-        _ = navigatingEvent.Subscribe(HandleShellNavigating);
-        _ = navigatedEvent.Subscribe(HandleShellNavigated);
+        _subscriptions.Add(navigatingEvent.Subscribe(HandleShellNavigating));
+        _subscriptions.Add(navigatedEvent.Subscribe(HandleShellNavigated));
     }
 
     /// <summary>Handles a shell navigating event.</summary>
@@ -131,11 +131,11 @@ public partial class NavigationShell
 
     /// <summary>Subscribes to routed navigation requests for this host.</summary>
     private void SubscribeToNavigationRequests() =>
-        _ = ViewModelRoutedViewHostMixins
+        _subscriptions.Add(ViewModelRoutedViewHostMixins
             .ResultNavigating[Name]
             .DistinctUntilChanged()
             .ObserveOn(RxSchedulers.MainThreadScheduler)
-            .Subscribe(HandleNavigationRequest);
+            .Subscribe(HandleNavigationRequest));
 
     /// <summary>Handles a routed navigation request.</summary>
     /// <param name="eventArgs">The navigation event arguments.</param>

--- a/src/CrissCross.MAUI/NavigationShell.cs
+++ b/src/CrissCross.MAUI/NavigationShell.cs
@@ -65,6 +65,9 @@ public partial class NavigationShell
     /// <summary>Stores resolved views in the same order as the view model navigation stack.</summary>
     private readonly List<IViewFor?> _navigationViews = [];
 
+    /// <summary>Stores event and routed navigation subscriptions created by this shell.</summary>
+    private readonly List<IDisposable> _subscriptions = [];
+
     /// <summary>Stores the current View Model value.</summary>
     private readonly Signal<INotifiyRoutableViewModel> _currentViewModel = new();
 
@@ -99,7 +102,7 @@ public partial class NavigationShell
     public NavigationShell()
     {
         ViewLocator = AppLocator.Current.GetService<IViewLocator>();
-        _ = CurrentViewModel
+        _subscriptions.Add(CurrentViewModel
             .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(vm =>
             {
@@ -130,7 +133,7 @@ public partial class NavigationShell
 
                 CanNavigateBack = NavigationStack?.Count > 1;
                 _canNavigateBackSubject.OnNext(CanNavigateBack);
-            });
+            }));
     }
 
     /// <summary>Gets or sets a value indicating whether [navigate back is enabled].</summary>
@@ -359,6 +362,14 @@ public partial class NavigationShell
 
         if (disposing)
         {
+            UnregisterNavigationHost();
+
+            foreach (var subscription in _subscriptions)
+            {
+                subscription.Dispose();
+            }
+
+            _subscriptions.Clear();
             _canNavigateBackSubject.Dispose();
             _currentViewModel.Dispose();
         }
@@ -376,6 +387,35 @@ public partial class NavigationShell
         }
 
         ns.SetMainNavigationHost(ns);
+    }
+
+    /// <summary>Removes shared navigation registrations that still point to this shell.</summary>
+    private void UnregisterNavigationHost()
+    {
+        var hostNames = new List<string>();
+        foreach (var pair in ViewModelRoutedViewHostMixins.NavigationHost)
+        {
+            if (ReferenceEquals(pair.Value, this))
+            {
+                hostNames.Add(pair.Key);
+            }
+        }
+
+        foreach (var hostName in hostNames)
+        {
+            _ = ViewModelRoutedViewHostMixins.NavigationHost.Remove(hostName);
+            if (ViewModelRoutedViewHostMixins.CurrentViewDisposable.Remove(hostName, out var disposable))
+            {
+                disposable.Dispose();
+            }
+
+            if (ViewModelRoutedViewHostMixins.ResultNavigating.Remove(hostName, out var resultNavigating))
+            {
+                resultNavigating.Dispose();
+            }
+
+            _ = ViewModelRoutedViewHostMixins.WhenSetupSubjects.Remove(hostName);
+        }
     }
 
     /// <summary>Runs the goto Page operation.</summary>

--- a/src/CrissCross.Maui.UI.Gallery/App.xaml
+++ b/src/CrissCross.Maui.UI.Gallery/App.xaml
@@ -10,14 +10,14 @@
                 <styles:CrissCrossMauiUi />
             </ResourceDictionary.MergedDictionaries>
             <Style TargetType="ContentPage">
-                <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource CrissCrossSurfaceColorLight}, Dark={StaticResource CrissCrossSurfaceColorDark}}" />
+                <Setter Property="BackgroundColor" Value="{DynamicResource CrissCrossSurfaceColor}" />
             </Style>
             <Style TargetType="Label">
-                <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource CrissCrossTextColorLight}, Dark={StaticResource CrissCrossTextColorDark}}" />
+                <Setter Property="TextColor" Value="{DynamicResource CrissCrossTextColor}" />
             </Style>
             <Style TargetType="Frame">
-                <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource CrissCrossSubtleSurfaceColorLight}, Dark={StaticResource CrissCrossSubtleSurfaceColorDark}}" />
-                <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource CrissCrossBorderColorLight}, Dark={StaticResource CrissCrossBorderColorDark}}" />
+                <Setter Property="BackgroundColor" Value="{DynamicResource CrissCrossSubtleSurfaceColor}" />
+                <Setter Property="BorderColor" Value="{DynamicResource CrissCrossBorderColor}" />
             </Style>
         </ResourceDictionary>
     </Application.Resources>

--- a/src/CrissCross.Maui.UI.Gallery/App.xaml.cs
+++ b/src/CrissCross.Maui.UI.Gallery/App.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using CrissCross.Maui.UI;
+using ReactiveUI.Builder;
 
 namespace CrissCross.Maui.UI.Gallery;
 
@@ -14,6 +15,7 @@ public partial class App : Application
     {
         InitializeComponent();
         _ = Resources.UseCrissCrossMauiUiResources();
+        _ = RxAppBuilder.CreateReactiveUIBuilder().WithMaui().BuildApp();
     }
 
     /// <inheritdoc />

--- a/src/CrissCross.Maui.UI.Gallery/CrissCross.Maui.UI.Gallery.csproj
+++ b/src/CrissCross.Maui.UI.Gallery/CrissCross.Maui.UI.Gallery.csproj
@@ -50,7 +50,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
     <PackageReference Include="Microsoft.Maui.Controls" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
     <PackageReference Include="ReactiveUI" />
   </ItemGroup>
 

--- a/src/CrissCross.Maui.UI.Gallery/GalleryPage.xaml
+++ b/src/CrissCross.Maui.UI.Gallery/GalleryPage.xaml
@@ -10,7 +10,7 @@
     <ScrollView>
         <VerticalStackLayout Padding="24" Spacing="16">
             <Label FontAttributes="Bold" FontSize="28" Text="CrissCross MAUI UI Gallery" />
-            <Label Text="All 27 shared MAUI control projections are instantiated below. Toggle the theme to verify common Light and Dark resources." />
+            <Label Text="All 28 shared MAUI control projections are instantiated below. Toggle the theme to verify common System, Light, Dark, and High Contrast resources." />
 
             <Frame Padding="16">
                 <VerticalStackLayout Spacing="10">
@@ -29,15 +29,9 @@
                 <VerticalStackLayout Spacing="10">
                     <Label FontAttributes="Bold" FontSize="18" Text="Search and data flow" />
                     <mauiui:SearchBox Placeholder="Search controls" SearchState="{Binding SearchState}" SubmitCommand="{Binding SearchCommand}" />
-                    <mauiui:FilterBar ClearFiltersCommand="{Binding ClearSearchCommand}" SearchState="{Binding SearchState}">
-                        <mauiui:FilterBar.Content><Label Text="FilterBar: active filters are projected from SearchQueryState." /></mauiui:FilterBar.Content>
-                    </mauiui:FilterBar>
-                    <mauiui:DataPager PageRequestCommand="{Binding RequestPageCommand}" PaginationState="{Binding PaginationState}" QueryState="{Binding SearchState}" SortKey="name">
-                        <mauiui:DataPager.Content><Label Text="DataPager requests pages through the reactive command." /></mauiui:DataPager.Content>
-                    </mauiui:DataPager>
-                    <mauiui:DataFilterPanel ApplyFiltersCommand="{Binding ApplyFiltersCommand}" FilterPanelState="{Binding FilterPanelState}">
-                        <mauiui:DataFilterPanel.Content><Label Text="DataFilterPanel: descriptor driven, reflection-free filters." /></mauiui:DataFilterPanel.Content>
-                    </mauiui:DataFilterPanel>
+                    <mauiui:FilterBar ClearFiltersCommand="{Binding ClearSearchCommand}" SearchState="{Binding SearchState}" />
+                    <mauiui:DataPager PageRequestCommand="{Binding RequestPageCommand}" PaginationState="{Binding PaginationState}" QueryState="{Binding SearchState}" SortKey="name" />
+                    <mauiui:DataFilterPanel ApplyFiltersCommand="{Binding ApplyFiltersCommand}" FilterPanelState="{Binding FilterPanelState}" />
                 </VerticalStackLayout>
             </Frame>
 
@@ -47,27 +41,29 @@
                     <mauiui:Chip IsSelected="True" Model="{Binding HighlightChip}" Text="Selected chip" />
                     <mauiui:ChipGroup SelectionCommand="{Binding SelectChipCommand}" State="{Binding ChipGroupState}" />
                     <mauiui:SegmentedControl SelectionCommand="{Binding SelectSegmentCommand}" State="{Binding SegmentState}" />
-                    <mauiui:Stepper StepCommand="{Binding SelectStepCommand}" StepperState="{Binding StepperState}">
-                        <mauiui:Stepper.Content><Label Text="Stepper: Connect → Review → Publish." /></mauiui:Stepper.Content>
-                    </mauiui:Stepper>
+                    <mauiui:Stepper StepCommand="{Binding SelectStepCommand}" StepperState="{Binding StepperState}" />
                 </VerticalStackLayout>
             </Frame>
 
             <Frame Padding="16">
                 <VerticalStackLayout Spacing="10">
                     <Label FontAttributes="Bold" FontSize="18" Text="Forms, feedback, and configuration" />
-                    <mauiui:ReactiveFormField FieldState="Invalid"><mauiui:ReactiveFormField.Content><Label Text="ReactiveFormField: invalid input state." /></mauiui:ReactiveFormField.Content></mauiui:ReactiveFormField>
-                    <mauiui:ValidationSummary SummaryState="{Binding ValidationState}"><mauiui:ValidationSummary.Content><Label Text="ValidationSummary: one sample validation message." /></mauiui:ValidationSummary.Content></mauiui:ValidationSummary>
-                    <mauiui:EmptyState Model="{Binding EmptyState}" PrimaryCommand="{Binding RestoreContentCommand}"><mauiui:EmptyState.Content><Label Text="EmptyState: no saved views yet; restore sample content." /></mauiui:EmptyState.Content></mauiui:EmptyState>
-                    <mauiui:PropertyGridLite PropertyGridState="{Binding PropertyGridState}" UpdatePropertyCommand="{Binding UpdatePropertyCommand}"><mauiui:PropertyGridLite.Content><Label Text="PropertyGridLite: descriptor-driven configuration." /></mauiui:PropertyGridLite.Content></mauiui:PropertyGridLite>
+                    <mauiui:ReactiveFormField FieldState="Invalid" Header="Operator name" HelperText="Enter the operator assigned to the shift." IsRequired="True">
+                        <mauiui:ReactiveFormField.Content>
+                            <Entry Text="" />
+                        </mauiui:ReactiveFormField.Content>
+                    </mauiui:ReactiveFormField>
+                    <mauiui:ValidationSummary SummaryState="{Binding ValidationState}" />
+                    <mauiui:EmptyState Model="{Binding EmptyState}" PrimaryCommand="{Binding RestoreContentCommand}" />
+                    <mauiui:PropertyGridLite PropertyGridState="{Binding PropertyGridState}" UpdatePropertyCommand="{Binding UpdatePropertyCommand}" />
                 </VerticalStackLayout>
             </Frame>
 
             <Frame Padding="16">
                 <VerticalStackLayout Spacing="10">
                     <Label FontAttributes="Bold" FontSize="18" Text="Time and theme" />
-                    <mauiui:DateTimeRangePicker ApplyRangeCommand="{Binding ApplyRangeCommand}" Range="{Binding DateRange}"><mauiui:DateTimeRangePicker.Content><Label Text="DateTimeRangePicker: Last four hours." /></mauiui:DateTimeRangePicker.Content></mauiui:DateTimeRangePicker>
-                    <mauiui:ThemeSwitcher ChangeThemeCommand="{Binding SetThemeCommand}" ThemeState="{Binding ThemeState}"><mauiui:ThemeSwitcher.Content><HorizontalStackLayout Spacing="8"><Button Command="{Binding SetThemeCommand}" CommandParameter="Light" Text="Light" /><Button Command="{Binding SetThemeCommand}" CommandParameter="Dark" Text="Dark" /><Label Text="{Binding ThemeDescription}" VerticalOptions="Center" /></HorizontalStackLayout></mauiui:ThemeSwitcher.Content></mauiui:ThemeSwitcher>
+                    <mauiui:DateTimeRangePicker ApplyRangeCommand="{Binding ApplyRangeCommand}" Range="{Binding DateRange}" />
+                    <mauiui:ThemeSwitcher ChangeThemeCommand="{Binding SetThemeCommand}" ThemeState="{Binding ThemeState}" />
                 </VerticalStackLayout>
             </Frame>
 
@@ -98,6 +94,9 @@
             <Frame Padding="16">
                 <VerticalStackLayout Spacing="10">
                     <Label FontAttributes="Bold" FontSize="18" Text="Alarms, colour, and notifications" />
+                    <mauiui:ProcessValueIndicator State="{Binding NormalProcessValue}" />
+                    <mauiui:ProcessValueIndicator State="{Binding AlarmProcessValue}" />
+                    <mauiui:ProcessValueIndicator State="{Binding BadQualityProcessValue}" />
                     <mauiui:AlarmBanner IsActive="True" Message="AlarmBanner: sample alarm actions are reactive commands." Severity="Warning" />
                     <HorizontalStackLayout Spacing="12">
                         <mauiui:CardColor Color="#3B55C9" Subtitle="Accent" Title="Indigo" />

--- a/src/CrissCross.Maui.UI.Gallery/GalleryViewModel.cs
+++ b/src/CrissCross.Maui.UI.Gallery/GalleryViewModel.cs
@@ -4,6 +4,7 @@
 
 using System.Windows.Input;
 using CrissCross;
+using Microsoft.Maui.Controls;
 using ReactiveUI;
 
 namespace CrissCross.Maui.UI.Gallery;
@@ -26,6 +27,30 @@ public sealed class GalleryViewModel : ReactiveObject, IDisposable
     /// <summary>Number of hours represented by the default range sample.</summary>
     private const int DefaultRangeHours = -4;
 
+    /// <summary>Defines the reactor temperature for the industrial example.</summary>
+    private const double ReactorTemperature = 72.4;
+
+    /// <summary>Defines the temperature maximum for the industrial example.</summary>
+    private const double TemperatureMaximum = 100;
+
+    /// <summary>Defines the temperature low alarm for the industrial example.</summary>
+    private const double TemperatureLowAlarm = 10;
+
+    /// <summary>Defines the temperature high alarm for the industrial example.</summary>
+    private const double TemperatureHighAlarm = 90;
+
+    /// <summary>Defines the line pressure for the industrial example.</summary>
+    private const double LinePressure = 126.8;
+
+    /// <summary>Defines the pressure maximum for the industrial example.</summary>
+    private const double PressureMaximum = 140;
+
+    /// <summary>Defines the pressure high alarm for the industrial example.</summary>
+    private const double PressureHighAlarm = 120;
+
+    /// <summary>Defines the flow maximum for the industrial example.</summary>
+    private const double FlowMaximum = 500;
+
     /// <summary>Duration of the deterministic visual QA operation.</summary>
     private static readonly TimeSpan OperationDelay = TimeSpan.FromMilliseconds(350);
 
@@ -40,14 +65,14 @@ public sealed class GalleryViewModel : ReactiveObject, IDisposable
         SearchCommand = ReactiveCommand.Create<string>(Search);
         ClearSearchCommand = ReactiveCommand.Create(() => Search(string.Empty));
         RequestPageCommand = ReactiveCommand.Create<PageRequest>(request => PaginationState = new(request.PageIndex, request.PageSize, TotalItemCount));
-        ApplyFiltersCommand = ReactiveCommand.Create(() => Search("active"));
+        ApplyFiltersCommand = ReactiveCommand.Create<SearchQueryState>(state => SearchState = state);
         SelectChipCommand = ReactiveCommand.Create<string>(SelectChip);
         SelectSegmentCommand = ReactiveCommand.Create<string>(key => SegmentState = new(CreateSegments(), key));
-        SelectStepCommand = ReactiveCommand.Create<string>(key => StepperState = new(CreateSteps(), key, StepperOrientation.Horizontal));
+        SelectStepCommand = ReactiveCommand.Create<StepDescriptor>(step => StepperState = new(CreateSteps(), step.Key, StepperOrientation.Horizontal));
         ApplyRangeCommand = ReactiveCommand.Create<DateTimeRange>(range => DateRange = range);
-        SetThemeCommand = ReactiveCommand.Create<string>(SetTheme);
+        SetThemeCommand = ReactiveCommand.Create<ThemeChoice>(SetTheme);
         RestoreContentCommand = ReactiveCommand.Create(() => Search("restored"));
-        UpdatePropertyCommand = ReactiveCommand.Create(() => Search("configuration"));
+        UpdatePropertyCommand = ReactiveCommand.Create<PropertyGridState>(CommitProperties);
         RateCommand = ReactiveCommand.Create<int>(SetRating);
     }
 
@@ -166,10 +191,14 @@ public sealed class GalleryViewModel : ReactiveObject, IDisposable
     public EmptyStateModel EmptyState { get; } = new("Nothing saved", "Restore sample content to continue.");
 
     /// <summary>Gets the reflection-free filter panel state.</summary>
-    public DataFilterPanelState FilterPanelState { get; } = new();
+    public DataFilterPanelState FilterPanelState { get; } = CreateFilterPanelState();
 
     /// <summary>Gets the reflection-free property grid state.</summary>
-    public PropertyGridState PropertyGridState { get; } = new();
+    public PropertyGridState PropertyGridState
+    {
+        get;
+        private set => this.RaiseAndSetIfChanged(ref field, value);
+    } = CreatePropertyGridState();
 
     /// <summary>Gets the selected date range.</summary>
     public DateTimeRange DateRange
@@ -183,14 +212,14 @@ public sealed class GalleryViewModel : ReactiveObject, IDisposable
     {
         get;
         private set => this.RaiseAndSetIfChanged(ref field, value);
-    } = new(ThemeChoice.Light);
+    } = CreateThemeState(ThemeChoice.System);
 
     /// <summary>Gets the current theme description.</summary>
     public string ThemeDescription
     {
         get;
         private set => this.RaiseAndSetIfChanged(ref field, value);
-    } = "Light theme selected";
+    } = CreateThemeState(ThemeChoice.System).DisplayText;
 
     /// <summary>Gets the selected gallery rating.</summary>
     public int Rating
@@ -198,6 +227,34 @@ public sealed class GalleryViewModel : ReactiveObject, IDisposable
         get;
         private set => this.RaiseAndSetIfChanged(ref field, value);
     } = 4;
+
+    /// <summary>Gets a normal process-value sample.</summary>
+    public ProcessValueState NormalProcessValue { get; } = new(
+        "Reactor temperature",
+        ReactorTemperature,
+        "C",
+        0,
+        TemperatureMaximum,
+        TemperatureLowAlarm,
+        TemperatureHighAlarm);
+
+    /// <summary>Gets an alarm process-value sample.</summary>
+    public ProcessValueState AlarmProcessValue { get; } = new(
+        "Line pressure",
+        LinePressure,
+        "bar",
+        0,
+        PressureMaximum,
+        new ProcessValueOptions { HighAlarmLimit = PressureHighAlarm });
+
+    /// <summary>Gets a bad-quality process-value sample.</summary>
+    public ProcessValueState BadQualityProcessValue { get; } = new(
+        "Flow transmitter",
+        null,
+        "L/min",
+        0,
+        FlowMaximum,
+        new ProcessValueOptions { IsGoodQuality = false });
 
     /// <summary>Gets the accessible gallery rating description.</summary>
     public string RatingDescription
@@ -208,6 +265,17 @@ public sealed class GalleryViewModel : ReactiveObject, IDisposable
 
     /// <inheritdoc />
     public void Dispose() => _operationCancellation?.Dispose();
+
+    /// <summary>Creates a shared theme state snapshot for the selected gallery theme.</summary>
+    /// <param name="choice">The selected theme choice.</param>
+    /// <returns>The shared theme preference state.</returns>
+    private static ThemePreferenceState CreateThemeState(ThemeChoice choice) =>
+        new(choice, GetSystemTheme(), supportsHighContrast: true);
+
+    /// <summary>Gets the current MAUI application theme as a shared concrete theme choice.</summary>
+    /// <returns>The current concrete system theme choice.</returns>
+    private static ThemeChoice GetSystemTheme() =>
+        Application.Current?.RequestedTheme == AppTheme.Dark ? ThemeChoice.Dark : ThemeChoice.Light;
 
     /// <summary>Creates the initial range without directly reading the machine clock.</summary>
     /// <returns>The default range sample.</returns>
@@ -245,6 +313,43 @@ public sealed class GalleryViewModel : ReactiveObject, IDisposable
         new StepDescriptor("review", "Review"),
         new StepDescriptor("publish", "Publish"),
     ];
+
+    /// <summary>Creates filter descriptors for industrial event searches.</summary>
+    /// <returns>The editable filter state.</returns>
+    private static DataFilterPanelState CreateFilterPanelState() => new(
+    [
+        new FilterDescriptor("area", "Area", FilterEditorKind.Text),
+        new FilterDescriptor("status", "Status", FilterEditorKind.Enum, [FilterOperator.Equals], ["Running", "Stopped", "Alarm"]),
+    ]);
+
+    /// <summary>Creates editable equipment configuration descriptors.</summary>
+    /// <returns>The configuration state.</returns>
+    private static PropertyGridState CreatePropertyGridState() => new(
+    [
+        new PropertyDescriptorModel("tag", "Equipment tag", new() { Value = "PUMP-101", OriginalValue = "PUMP-101" }),
+        new PropertyDescriptorModel("enabled", "Enabled", new() { EditorKind = PropertyEditorKind.Boolean, Value = true, OriginalValue = true }),
+    ]);
+
+    /// <summary>Commits the edited descriptor snapshot as the new baseline.</summary>
+    /// <param name="state">The edited configuration state.</param>
+    private void CommitProperties(PropertyGridState state)
+    {
+        var descriptors = new List<PropertyDescriptorModel>();
+        foreach (var descriptor in state.Descriptors)
+        {
+            descriptors.Add(new(descriptor.Key, descriptor.DisplayName, new()
+            {
+                Category = descriptor.Category,
+                EditorKind = descriptor.EditorKind,
+                Value = descriptor.Value,
+                OriginalValue = descriptor.Value,
+                IsReadOnly = descriptor.IsReadOnly,
+                Choices = descriptor.Choices,
+            }));
+        }
+
+        PropertyGridState = new(descriptors);
+    }
 
     /// <summary>Runs a short cancellable operation for visual QA.</summary>
     /// <param name="cancellationToken">The reactive command cancellation token.</param>
@@ -297,15 +402,28 @@ public sealed class GalleryViewModel : ReactiveObject, IDisposable
     }
 
     /// <summary>Applies a supported MAUI theme preference.</summary>
-    /// <param name="themeText">The requested theme text.</param>
-    private void SetTheme(string themeText)
+    /// <param name="selected">The requested theme choice.</param>
+    private void SetTheme(ThemeChoice selected)
     {
-        var selected = string.Equals(themeText, nameof(ThemeChoice.Dark), StringComparison.OrdinalIgnoreCase)
-            ? ThemeChoice.Dark
-            : ThemeChoice.Light;
-        ThemeState = new(selected);
+        var application = Application.Current;
+        if (application is not null)
+        {
+            application.UserAppTheme = selected switch
+            {
+                ThemeChoice.Dark => AppTheme.Dark,
+                ThemeChoice.Light => AppTheme.Light,
+                _ => AppTheme.Unspecified,
+            };
+        }
+
+        ThemeState = CreateThemeState(selected);
         ThemeDescription = ThemeState.DisplayText;
-        Application.Current!.UserAppTheme = selected == ThemeChoice.Dark ? AppTheme.Dark : AppTheme.Light;
+        if (application is null)
+        {
+            return;
+        }
+
+        _ = application.Resources.UseCrissCrossMauiUiResources(ThemeState);
     }
 
     /// <summary>Updates the observable rating description from the reactive command parameter.</summary>

--- a/src/CrissCross.Maui.UI/Controls/BusyOverlay.cs
+++ b/src/CrissCross.Maui.UI/Controls/BusyOverlay.cs
@@ -2,6 +2,8 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using Microsoft.Maui.Controls.Shapes;
+
 namespace CrissCross.Maui.UI.Controls;
 
 /// <summary>Presents regional busy state over arbitrary content without replacing the content layout.</summary>
@@ -18,7 +20,66 @@ public class BusyOverlay : ContentView
     public static readonly BindableProperty IsBusyProperty = BindableProperty.Create(
         nameof(IsBusy),
         typeof(bool),
-        typeof(BusyOverlay));
+        typeof(BusyOverlay),
+        propertyChanged: static (bindable, _, _) => ((BusyOverlay)bindable).RefreshAccessibility());
+
+    /// <summary>Provides default spacing inside the busy card.</summary>
+    private const double CardSpacing = 8;
+
+    /// <summary>Provides the default busy card maximum width.</summary>
+    private const double CardMaximumWidth = 420;
+
+    /// <summary>Provides the default busy card padding.</summary>
+    private const double CardPadding = 20;
+
+    /// <summary>Provides the default busy card corner radius.</summary>
+    private const double CardCornerRadius = 12;
+
+    /// <summary>Provides the default overlay padding.</summary>
+    private const double OverlayPadding = 16;
+
+    /// <summary>Provides the default activity indicator size.</summary>
+    private const double ActivitySize = 44;
+
+    /// <summary>Provides the default operation title font size.</summary>
+    private const double TitleFontSize = 16;
+
+    /// <summary>Provides the default cancel button minimum width.</summary>
+    private const double CancelButtonMinimumWidth = 96;
+
+    /// <summary>Provides fallback accessibility text when no operation is active.</summary>
+    private const string IdleDescription = "Idle";
+
+    /// <summary>Provides fallback operation title text.</summary>
+    private const string FallbackTitle = "Working";
+
+    /// <summary>Provides the semantic resource key for accent elements.</summary>
+    private const string AccentColorResourceKey = "CrissCrossAccentColor";
+
+    /// <summary>Provides the semantic resource key for accent text.</summary>
+    private const string AccentTextColorResourceKey = "CrissCrossAccentTextColor";
+
+    /// <summary>Provides the semantic resource key for muted text.</summary>
+    private const string MutedTextColorResourceKey = "CrissCrossMutedTextColor";
+
+    /// <summary>Provides the semantic resource key for the busy overlay scrim.</summary>
+    private const string OverlayColorResourceKey = "CrissCrossOverlayColor";
+
+    /// <summary>Provides the semantic resource key for card surfaces.</summary>
+    private const string SurfaceColorResourceKey = "CrissCrossSurfaceColor";
+
+    /// <summary>Provides the semantic resource key for primary text.</summary>
+    private const string TextColorResourceKey = "CrissCrossTextColor";
+
+    /// <summary>Tracks the activity indicator in the applied default template.</summary>
+    private ActivityIndicator? _activity;
+
+    /// <summary>Initializes a new instance of the <see cref="BusyOverlay"/> class.</summary>
+    public BusyOverlay()
+    {
+        ControlTemplate = new(CreateDefaultTemplate);
+        RefreshAccessibility();
+    }
 
     /// <summary>Gets or sets the busy operation displayed by the overlay.</summary>
     public BusyOperation? Operation
@@ -45,5 +106,234 @@ public class BusyOverlay : ContentView
         }
 
         overlay.SetValue(IsBusyProperty, newValue is BusyOperation { IsActive: true });
+        overlay.RefreshAccessibility();
+    }
+
+    /// <summary>Creates the default template that preserves user content beneath a busy-only blocking layer.</summary>
+    /// <returns>The default template root.</returns>
+    private Grid CreateDefaultTemplate()
+    {
+        var operation = Operation;
+        var isDeterminate = operation?.IsDeterminate == true;
+        var isCancellable = operation?.IsCancellable == true;
+        var message = operation?.Message ?? string.Empty;
+        var title = string.IsNullOrWhiteSpace(operation?.Title) ? FallbackTitle : operation!.Title;
+        var presenter = new ContentPresenter();
+        var activity = CreateActivityIndicator(isDeterminate);
+        var progress = CreateProgressBar(operation, isDeterminate);
+        var titleLabel = CreateTitleLabel(title);
+        var messageLabel = CreateMessageLabel(message);
+        var cancelButton = CreateCancelButton(operation, isCancellable);
+        var card = CreateBusyCard(activity, progress, titleLabel, messageLabel, cancelButton);
+        var root = new Grid();
+        root.Children.Add(presenter);
+        root.Children.Add(CreateBlockingOverlay(card));
+        return root;
+    }
+
+    /// <summary>Creates the indeterminate activity indicator.</summary>
+    /// <param name="isDeterminate">A value indicating whether the operation has determinate progress.</param>
+    /// <returns>The activity indicator.</returns>
+    private ActivityIndicator CreateActivityIndicator(bool isDeterminate)
+    {
+        var activity = new ActivityIndicator { HeightRequest = ActivitySize };
+        activity.HorizontalOptions = LayoutOptions.Center;
+        activity.IsRunning = IsBusy && !isDeterminate;
+        activity.IsVisible = !isDeterminate;
+        activity.WidthRequest = ActivitySize;
+        activity.SetDynamicResource(ActivityIndicator.ColorProperty, AccentColorResourceKey);
+        activity.SetBinding(
+            ActivityIndicator.IsVisibleProperty,
+            new Binding(
+                $"{nameof(Operation)}.{nameof(BusyOperation.IsDeterminate)}",
+                converter: InvertedBooleanConverter.Instance,
+                source: this));
+        _activity = activity;
+        return activity;
+    }
+
+    /// <summary>Creates the determinate progress indicator.</summary>
+    /// <param name="operation">The current operation snapshot.</param>
+    /// <param name="isDeterminate">A value indicating whether the operation has determinate progress.</param>
+    /// <returns>The progress bar.</returns>
+    private ProgressBar CreateProgressBar(BusyOperation? operation, bool isDeterminate)
+    {
+        var progress = new ProgressBar { HorizontalOptions = LayoutOptions.Fill };
+        progress.IsVisible = isDeterminate;
+        progress.Progress = operation?.Progress ?? 0D;
+        progress.SetDynamicResource(ProgressBar.ProgressColorProperty, AccentColorResourceKey);
+        progress.SetBinding(
+            ProgressBar.IsVisibleProperty,
+            new Binding($"{nameof(Operation)}.{nameof(BusyOperation.IsDeterminate)}", source: this));
+
+        var progressBinding = new Binding($"{nameof(Operation)}.{nameof(BusyOperation.Progress)}", source: this);
+        progressBinding.FallbackValue = 0D;
+        progressBinding.TargetNullValue = 0D;
+        progress.SetBinding(ProgressBar.ProgressProperty, progressBinding);
+        return progress;
+    }
+
+    /// <summary>Creates the operation title label.</summary>
+    /// <param name="title">The initial operation title.</param>
+    /// <returns>The title label.</returns>
+    private Label CreateTitleLabel(string title)
+    {
+        var label = new Label { FontAttributes = FontAttributes.Bold };
+        label.FontSize = TitleFontSize;
+        label.HorizontalTextAlignment = TextAlignment.Center;
+        label.Text = title;
+        label.SetDynamicResource(Label.TextColorProperty, TextColorResourceKey);
+
+        var textBinding = new Binding($"{nameof(Operation)}.{nameof(BusyOperation.Title)}", source: this);
+        textBinding.FallbackValue = FallbackTitle;
+        textBinding.TargetNullValue = FallbackTitle;
+        label.SetBinding(Label.TextProperty, textBinding);
+        return label;
+    }
+
+    /// <summary>Creates the optional operation message label.</summary>
+    /// <param name="message">The initial operation message.</param>
+    /// <returns>The message label.</returns>
+    private Label CreateMessageLabel(string message)
+    {
+        var label = new Label { HorizontalTextAlignment = TextAlignment.Center };
+        label.IsVisible = !string.IsNullOrWhiteSpace(message);
+        label.Text = message;
+        label.SetDynamicResource(Label.TextColorProperty, MutedTextColorResourceKey);
+
+        var messageBinding = new Binding($"{nameof(Operation)}.{nameof(BusyOperation.Message)}", source: this);
+        messageBinding.FallbackValue = string.Empty;
+        messageBinding.TargetNullValue = string.Empty;
+        label.SetBinding(Label.TextProperty, messageBinding);
+        var visibilityBinding = new Binding(
+            $"{nameof(Operation)}.{nameof(BusyOperation.Message)}",
+            converter: HasTextConverter.Instance,
+            source: this);
+        label.SetBinding(
+            Label.IsVisibleProperty,
+            visibilityBinding);
+        return label;
+    }
+
+    /// <summary>Creates the optional operation cancel button.</summary>
+    /// <param name="operation">The current operation snapshot.</param>
+    /// <param name="isCancellable">A value indicating whether cancellation is available.</param>
+    /// <returns>The cancel button.</returns>
+    private Button CreateCancelButton(BusyOperation? operation, bool isCancellable)
+    {
+        var button = new Button { Command = operation?.CancelCommand };
+        button.HorizontalOptions = LayoutOptions.Center;
+        button.IsVisible = isCancellable;
+        button.MinimumWidthRequest = CancelButtonMinimumWidth;
+        button.Text = "Cancel";
+        button.SetDynamicResource(Button.BackgroundColorProperty, AccentColorResourceKey);
+        button.SetDynamicResource(Button.TextColorProperty, AccentTextColorResourceKey);
+        button.SetBinding(
+            Button.CommandProperty,
+            new Binding($"{nameof(Operation)}.{nameof(BusyOperation.CancelCommand)}", source: this));
+        button.SetBinding(
+            Button.IsVisibleProperty,
+            new Binding($"{nameof(Operation)}.{nameof(BusyOperation.IsCancellable)}", source: this));
+        return button;
+    }
+
+    /// <summary>Creates the centered card that presents busy details.</summary>
+    /// <param name="activity">The activity indicator.</param>
+    /// <param name="progress">The progress bar.</param>
+    /// <param name="title">The title label.</param>
+    /// <param name="message">The message label.</param>
+    /// <param name="cancelButton">The cancel button.</param>
+    /// <returns>The busy card.</returns>
+    private Border CreateBusyCard(
+        ActivityIndicator activity,
+        ProgressBar progress,
+        Label title,
+        Label message,
+        Button cancelButton)
+    {
+        var content = new VerticalStackLayout { Spacing = CardSpacing };
+        content.Children.Add(activity);
+        content.Children.Add(progress);
+        content.Children.Add(title);
+        content.Children.Add(message);
+        content.Children.Add(cancelButton);
+
+        var shape = new RoundRectangle { CornerRadius = new(CardCornerRadius) };
+
+        var card = new Border { HorizontalOptions = LayoutOptions.Center };
+        card.MaximumWidthRequest = CardMaximumWidth;
+        card.Padding = new(CardPadding);
+        card.StrokeShape = shape;
+        card.VerticalOptions = LayoutOptions.Center;
+        card.Content = content;
+        card.SetDynamicResource(VisualElement.BackgroundColorProperty, SurfaceColorResourceKey);
+        return card;
+    }
+
+    /// <summary>Creates the overlay layer that blocks covered content while busy.</summary>
+    /// <param name="card">The busy card.</param>
+    /// <returns>The blocking overlay layer.</returns>
+    private Grid CreateBlockingOverlay(Border card)
+    {
+        var overlay = new Grid { HorizontalOptions = LayoutOptions.Fill };
+        overlay.InputTransparent = false;
+        overlay.IsVisible = IsBusy;
+        overlay.Padding = new(OverlayPadding);
+        overlay.VerticalOptions = LayoutOptions.Fill;
+        overlay.Children.Add(card);
+        overlay.SetDynamicResource(VisualElement.BackgroundColorProperty, OverlayColorResourceKey);
+        overlay.SetBinding(IsVisibleProperty, new Binding(nameof(IsBusy), source: this));
+        return overlay;
+    }
+
+    /// <summary>Updates semantic description from the current busy state.</summary>
+    private void RefreshAccessibility()
+    {
+        if (_activity is not null)
+        {
+            _activity.IsRunning = IsBusy && Operation?.IsDeterminate != true;
+        }
+
+        if (!IsBusy)
+        {
+            SemanticProperties.SetDescription(this, IdleDescription);
+            return;
+        }
+
+        var operation = Operation;
+        var title = string.IsNullOrWhiteSpace(operation?.Title) ? FallbackTitle : operation!.Title;
+        var message = operation?.Message;
+        var description = string.IsNullOrWhiteSpace(message) ? title : $"{title} {message}";
+        SemanticProperties.SetDescription(this, description);
+    }
+
+    /// <summary>Converts non-empty text to visible state.</summary>
+    private sealed class HasTextConverter : IValueConverter
+    {
+        /// <summary>Gets the shared converter instance.</summary>
+        internal static readonly HasTextConverter Instance = new();
+
+        /// <inheritdoc />
+        public object Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture) =>
+            !string.IsNullOrWhiteSpace(value as string);
+
+        /// <inheritdoc />
+        public object ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture) =>
+            throw new NotSupportedException();
+    }
+
+    /// <summary>Converts boolean values to their inverse.</summary>
+    private sealed class InvertedBooleanConverter : IValueConverter
+    {
+        /// <summary>Gets the shared converter instance.</summary>
+        internal static readonly InvertedBooleanConverter Instance = new();
+
+        /// <inheritdoc />
+        public object Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture) =>
+            value is not true;
+
+        /// <inheritdoc />
+        public object ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture) =>
+            throw new NotSupportedException();
     }
 }

--- a/src/CrissCross.Maui.UI/Controls/CommandButton.cs
+++ b/src/CrissCross.Maui.UI/Controls/CommandButton.cs
@@ -81,11 +81,22 @@ public class CommandButton : Button
     /// <param name="newValue">The new value.</param>
     private static void OnIsExecutingChanged(BindableObject bindable, object newValue)
     {
-        if (bindable is not CommandButton button || newValue is not true)
+        if (bindable is not CommandButton button)
         {
             return;
         }
 
-        button.SetValue(StateProperty, CommandButtonState.Executing);
+        if (newValue is true)
+        {
+            button.SetValue(StateProperty, CommandButtonState.Executing);
+            return;
+        }
+
+        if (button.State != CommandButtonState.Executing)
+        {
+            return;
+        }
+
+        button.SetValue(StateProperty, CommandButtonState.Idle);
     }
 }

--- a/src/CrissCross.Maui.UI/Controls/DataFilterPanel.cs
+++ b/src/CrissCross.Maui.UI/Controls/DataFilterPanel.cs
@@ -2,6 +2,8 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Globalization;
+
 namespace CrissCross.Maui.UI.Controls;
 
 /// <summary>Displays a descriptor-driven filter editing surface.</summary>
@@ -11,13 +13,96 @@ public class DataFilterPanel : ContentView
     public static readonly BindableProperty FilterPanelStateProperty = BindableProperty.Create(
         nameof(FilterPanelState),
         typeof(DataFilterPanelState),
-        typeof(DataFilterPanel));
+        typeof(DataFilterPanel),
+        propertyChanged: static (bindable, _, newValue) => OnFilterPanelStateChanged(bindable, newValue));
 
     /// <summary>Bindable property for <see cref="ApplyFiltersCommand"/>.</summary>
     public static readonly BindableProperty ApplyFiltersCommandProperty = BindableProperty.Create(
         nameof(ApplyFiltersCommand),
         typeof(ICommand),
-        typeof(DataFilterPanel));
+        typeof(DataFilterPanel),
+        propertyChanged: static (bindable, _, _) => OnCommandChanged(bindable));
+
+    /// <summary>Bindable property for <see cref="ClearFiltersCommand"/>.</summary>
+    public static readonly BindableProperty ClearFiltersCommandProperty = BindableProperty.Create(
+        nameof(ClearFiltersCommand),
+        typeof(ICommand),
+        typeof(DataFilterPanel),
+        propertyChanged: static (bindable, _, _) => OnCommandChanged(bindable));
+
+    /// <summary>Bindable property for <see cref="SearchText"/>.</summary>
+    public static readonly BindableProperty SearchTextProperty = BindableProperty.Create(nameof(SearchText), typeof(string), typeof(DataFilterPanel));
+
+    /// <summary>Bindable property for <see cref="ResultCount"/>.</summary>
+    public static readonly BindableProperty ResultCountProperty = BindableProperty.Create(nameof(ResultCount), typeof(int?), typeof(DataFilterPanel));
+
+    /// <summary>Bindable property for <see cref="SubmittedQueryState"/>.</summary>
+    public static readonly BindableProperty SubmittedQueryStateProperty = BindableProperty.Create(nameof(SubmittedQueryState), typeof(SearchQueryState), typeof(DataFilterPanel));
+
+    /// <summary>Semantic text color resource key.</summary>
+    private const string TextColorResourceKey = "CrissCrossTextColor";
+
+    /// <summary>Semantic accent color resource key.</summary>
+    private const string AccentColorResourceKey = "CrissCrossAccentColor";
+
+    /// <summary>Semantic accent text color resource key.</summary>
+    private const string AccentTextColorResourceKey = "CrissCrossAccentTextColor";
+
+    /// <summary>Horizontal action padding.</summary>
+    private const double ActionPaddingHorizontal = 10D;
+
+    /// <summary>Vertical action padding.</summary>
+    private const double ActionPaddingVertical = 6D;
+
+    /// <summary>Minimum action width.</summary>
+    private const double ActionMinimumWidth = 112D;
+
+    /// <summary>Root layout spacing.</summary>
+    private const double RootSpacing = 12D;
+
+    /// <summary>Root vertical padding.</summary>
+    private const double RootPaddingVertical = 4D;
+
+    /// <summary>Action button spacing.</summary>
+    private const double ActionSpacing = 8D;
+
+    /// <summary>Descriptor host spacing.</summary>
+    private const double DescriptorHostSpacing = 10D;
+
+    /// <summary>Descriptor row spacing.</summary>
+    private const double DescriptorRowSpacing = 4D;
+
+    /// <summary>Descriptor row vertical padding.</summary>
+    private const double DescriptorRowPaddingVertical = 4D;
+
+    /// <summary>Stores pending editor values by descriptor key.</summary>
+    private readonly Dictionary<string, object?> _editedValues = [];
+
+    /// <summary>Stores selected operators by descriptor key.</summary>
+    private readonly Dictionary<string, FilterOperator> _selectedOperators = [];
+
+    /// <summary>Displays the current filter summary.</summary>
+    private readonly Label _summaryLabel = CreateLabel("No filters", FontAttributes.Bold);
+
+    /// <summary>Hosts descriptor editors.</summary>
+    private readonly VerticalStackLayout _descriptorHost = new() { Spacing = DescriptorHostSpacing };
+
+    /// <summary>Applies pending filters.</summary>
+    private readonly Button _applyButton = CreateActionButton("Apply filters");
+
+    /// <summary>Clears active filters.</summary>
+    private readonly Button _clearButton = CreateActionButton("Clear filters");
+
+    /// <summary>Initializes a new instance of the <see cref="DataFilterPanel"/> class.</summary>
+    public DataFilterPanel()
+    {
+        ApplyCommand = new PanelCommand(ApplyFilters, CanApplyFilters);
+        ClearCommand = new PanelCommand(ClearFilters, CanClearFilters);
+        _applyButton.Clicked += (_, _) => SubmittedQueryState = CreateQueryState();
+        _clearButton.Clicked += (_, _) => SubmittedQueryState = new(SearchText, submittedText: SearchText, resultCount: ResultCount);
+        Content = CreateLayout();
+        ApplyState(null);
+    }
 
     /// <summary>Gets or sets the shared CrissCross state projected by this control.</summary>
     public DataFilterPanelState? FilterPanelState
@@ -31,5 +116,459 @@ public class DataFilterPanel : ContentView
     {
         get => (ICommand?)GetValue(ApplyFiltersCommandProperty);
         set => SetValue(ApplyFiltersCommandProperty, value);
+    }
+
+    /// <summary>Gets or sets the command invoked when filters are cleared.</summary>
+    public ICommand? ClearFiltersCommand
+    {
+        get => (ICommand?)GetValue(ClearFiltersCommandProperty);
+        set => SetValue(ClearFiltersCommandProperty, value);
+    }
+
+    /// <summary>Gets or sets query text included in the applied query snapshot.</summary>
+    public string? SearchText
+    {
+        get => (string?)GetValue(SearchTextProperty);
+        set => SetValue(SearchTextProperty, value);
+    }
+
+    /// <summary>Gets or sets result count included in the applied query snapshot.</summary>
+    public int? ResultCount
+    {
+        get => (int?)GetValue(ResultCountProperty);
+        set => SetValue(ResultCountProperty, value);
+    }
+
+    /// <summary>Gets or sets the most recent query state emitted by <see cref="ApplyFilters"/>.</summary>
+    public SearchQueryState? SubmittedQueryState
+    {
+        get => (SearchQueryState?)GetValue(SubmittedQueryStateProperty);
+        set => SetValue(SubmittedQueryStateProperty, value);
+    }
+
+    /// <summary>Gets the command that applies current filters.</summary>
+    public ICommand ApplyCommand { get; }
+
+    /// <summary>Gets the command that clears current filters.</summary>
+    public ICommand ClearCommand { get; }
+
+    /// <summary>Sets a pending filter value for a descriptor.</summary>
+    /// <param name="descriptorKey">The descriptor key.</param>
+    /// <param name="value">The edited value.</param>
+    /// <returns><c>true</c> when the descriptor exists.</returns>
+    public bool SetFilterValue(string descriptorKey, object? value)
+    {
+        var descriptor = FilterPanelState?.GetDescriptor(descriptorKey);
+        if (descriptor is null)
+        {
+            return false;
+        }
+
+        _editedValues[descriptor.Key] = value;
+        RaiseCommandAvailability();
+        return true;
+    }
+
+    /// <summary>Applies current descriptor editor values and emits a query-state payload.</summary>
+    /// <returns><c>true</c> when the external command was executed.</returns>
+    public bool ApplyFilters()
+    {
+        var queryState = CreateQueryState();
+        SubmittedQueryState = queryState;
+        if (ApplyFiltersCommand?.CanExecute(queryState) != true)
+        {
+            return false;
+        }
+
+        ApplyFiltersCommand.Execute(queryState);
+        return true;
+    }
+
+    /// <summary>Clears current filter editor values and invokes the clear command with the existing state.</summary>
+    /// <returns><c>true</c> when the clear command was executed.</returns>
+    public bool ClearFilters()
+    {
+        var state = FilterPanelState;
+        _editedValues.Clear();
+        SubmittedQueryState = new(SearchText, submittedText: SearchText, resultCount: ResultCount);
+        ApplyState(state);
+        if (ClearFiltersCommand?.CanExecute(state) != true)
+        {
+            return false;
+        }
+
+        ClearFiltersCommand.Execute(state);
+        return true;
+    }
+
+    /// <summary>Creates a query-state snapshot from current editor values.</summary>
+    /// <returns>The query-state snapshot.</returns>
+    public SearchQueryState CreateQueryState()
+    {
+        var state = CreateEditedState();
+        return state.ToSearchQueryState(SearchText, ResultCount);
+    }
+
+    /// <summary>Creates the current edited filter state.</summary>
+    /// <returns>The edited filter state.</returns>
+    public DataFilterPanelState CreateEditedState()
+    {
+        var state = FilterPanelState;
+        if (state is null)
+        {
+            return new();
+        }
+
+        var expressions = new List<FilterExpression>();
+        foreach (var descriptor in state.Descriptors)
+        {
+            var value = GetEditorValue(descriptor, state);
+            var selectedOperator = _selectedOperators.TryGetValue(descriptor.Key, out var @operator) ? @operator : descriptor.DefaultOperator;
+            expressions.Add(new(descriptor.Key, selectedOperator, value, descriptor.DisplayName));
+        }
+
+        return new(state.Descriptors, expressions, _editedValues.Count > 0, state.IsApplying);
+    }
+
+    /// <summary>Creates a label using semantic theme color resources.</summary>
+    /// <param name="text">The label text.</param>
+    /// <param name="fontAttributes">The font attributes.</param>
+    /// <returns>The configured label.</returns>
+    private static Label CreateLabel(string text, FontAttributes fontAttributes)
+    {
+        var label = new Label { Text = text, FontAttributes = fontAttributes };
+        label.SetDynamicResource(Label.TextColorProperty, TextColorResourceKey);
+        return label;
+    }
+
+    /// <summary>Creates an action button using semantic theme color resources.</summary>
+    /// <param name="text">The button text.</param>
+    /// <returns>The configured button.</returns>
+    private static Button CreateActionButton(string text)
+    {
+        var button = new Button { Text = text, Padding = new(ActionPaddingHorizontal, ActionPaddingVertical), MinimumWidthRequest = ActionMinimumWidth };
+        button.SetDynamicResource(Button.BackgroundColorProperty, AccentColorResourceKey);
+        button.SetDynamicResource(Button.TextColorProperty, AccentTextColorResourceKey);
+        return button;
+    }
+
+    /// <summary>Runs when the filter state changes.</summary>
+    /// <param name="bindable">The bindable object.</param>
+    /// <param name="newValue">The new value.</param>
+    private static void OnFilterPanelStateChanged(BindableObject bindable, object? newValue)
+    {
+        if (bindable is not DataFilterPanel panel)
+        {
+            return;
+        }
+
+        panel.SeedEditors(newValue as DataFilterPanelState);
+        panel.ApplyState(newValue as DataFilterPanelState);
+    }
+
+    /// <summary>Runs when command availability changes.</summary>
+    /// <param name="bindable">The bindable object.</param>
+    private static void OnCommandChanged(BindableObject bindable)
+    {
+        if (bindable is not DataFilterPanel panel)
+        {
+            return;
+        }
+
+        panel.RaiseCommandAvailability();
+    }
+
+    /// <summary>Gets an expression value for a descriptor.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <param name="state">The state.</param>
+    /// <returns>The expression value.</returns>
+    private static object? GetExpressionValue(FilterDescriptor descriptor, DataFilterPanelState? state)
+    {
+        foreach (var expression in state?.Expressions ?? [])
+        {
+            if (expression.FieldKey == descriptor.Key)
+            {
+                return expression.Value;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Gets an expression operator for a descriptor.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <param name="state">The state.</param>
+    /// <returns>The expression operator.</returns>
+    private static FilterOperator GetExpressionOperator(FilterDescriptor descriptor, DataFilterPanelState? state)
+    {
+        foreach (var expression in state?.Expressions ?? [])
+        {
+            if (expression.FieldKey == descriptor.Key && descriptor.SupportsOperator(expression.Operator))
+            {
+                return expression.Operator;
+            }
+        }
+
+        return descriptor.DefaultOperator;
+    }
+
+    /// <summary>Finds the index of a choice value.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <param name="value">The value.</param>
+    /// <returns>The choice index, or -1.</returns>
+    private static int FindChoiceIndex(FilterDescriptor descriptor, object? value)
+    {
+        for (var index = 0; index < (descriptor.Choices?.Count ?? 0); index++)
+        {
+            if (Equals(descriptor.Choices![index], value))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>Finds the index of an operator.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <param name="operator">The operator.</param>
+    /// <returns>The operator index, or -1.</returns>
+    private static int FindOperatorIndex(FilterDescriptor descriptor, FilterOperator @operator)
+    {
+        for (var index = 0; index < descriptor.SupportedOperators.Count; index++)
+        {
+            if (descriptor.SupportedOperators[index] == @operator)
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>Creates the root layout.</summary>
+    /// <returns>The root layout.</returns>
+    private VerticalStackLayout CreateLayout()
+    {
+        var root = new VerticalStackLayout { Spacing = RootSpacing, Padding = new(0D, RootPaddingVertical) };
+        var actions = new HorizontalStackLayout { Spacing = ActionSpacing };
+        actions.Children.Add(_applyButton);
+        actions.Children.Add(_clearButton);
+        root.Children.Add(_summaryLabel);
+        root.Children.Add(_descriptorHost);
+        root.Children.Add(actions);
+        return root;
+    }
+
+    /// <summary>Seeds editor values from the supplied state.</summary>
+    /// <param name="state">The state.</param>
+    private void SeedEditors(DataFilterPanelState? state)
+    {
+        _editedValues.Clear();
+        _selectedOperators.Clear();
+        if (state is null)
+        {
+            return;
+        }
+
+        foreach (var descriptor in state.Descriptors)
+        {
+            _editedValues[descriptor.Key] = GetExpressionValue(descriptor, state) ?? descriptor.DefaultValue;
+            _selectedOperators[descriptor.Key] = GetExpressionOperator(descriptor, state);
+        }
+    }
+
+    /// <summary>Applies current state to native child presenters.</summary>
+    /// <param name="state">The state.</param>
+    private void ApplyState(DataFilterPanelState? state)
+    {
+        _descriptorHost.Children.Clear();
+        _summaryLabel.Text = state?.SummaryText ?? "No filters";
+        foreach (var descriptor in state?.Descriptors ?? [])
+        {
+            _descriptorHost.Children.Add(CreateDescriptorEditor(descriptor));
+        }
+
+        RaiseCommandAvailability();
+        SemanticProperties.SetDescription(this, _summaryLabel.Text);
+    }
+
+    /// <summary>Creates an editor row for a descriptor.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <returns>The editor row.</returns>
+    private VerticalStackLayout CreateDescriptorEditor(FilterDescriptor descriptor)
+    {
+        var row = new VerticalStackLayout { Spacing = DescriptorRowSpacing, Padding = new(0D, DescriptorRowPaddingVertical) };
+        row.Children.Add(CreateLabel(descriptor.DisplayName, FontAttributes.Bold));
+        row.Children.Add(CreateOperatorPicker(descriptor));
+        row.Children.Add(CreateValueEditor(descriptor));
+        SemanticProperties.SetDescription(row, descriptor.DisplayName);
+        return row;
+    }
+
+    /// <summary>Creates an operator picker for a descriptor.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <returns>The operator picker.</returns>
+    private Picker CreateOperatorPicker(FilterDescriptor descriptor)
+    {
+        var picker = new Picker { Title = $"Operator for {descriptor.DisplayName}" };
+        picker.SetDynamicResource(Picker.TextColorProperty, TextColorResourceKey);
+        foreach (var @operator in descriptor.SupportedOperators)
+        {
+            picker.Items.Add(@operator.ToString());
+        }
+
+        picker.SelectedIndex = Math.Max(0, FindOperatorIndex(descriptor, GetExpressionOperator(descriptor, FilterPanelState)));
+        picker.SelectedIndexChanged += (_, _) => ApplySelectedOperator(descriptor, picker);
+        return picker;
+    }
+
+    /// <summary>Creates a value editor for a descriptor.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <returns>The value editor.</returns>
+    private View CreateValueEditor(FilterDescriptor descriptor) =>
+        descriptor.EditorKind switch
+        {
+            FilterEditorKind.Boolean => CreateBooleanEditor(descriptor),
+            FilterEditorKind.Enum => CreateChoiceEditor(descriptor),
+            FilterEditorKind.Date or FilterEditorKind.DateTime or FilterEditorKind.DateRange => CreateDateEditor(descriptor),
+            FilterEditorKind.Number => CreateTextEditor(descriptor, Keyboard.Numeric),
+            _ => CreateTextEditor(descriptor, Keyboard.Text),
+        };
+
+    /// <summary>Creates a text editor for a descriptor.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <param name="keyboard">The keyboard type.</param>
+    /// <returns>The editor.</returns>
+    private Entry CreateTextEditor(FilterDescriptor descriptor, Keyboard keyboard)
+    {
+        var entry = new Entry { Text = Convert.ToString(GetEditorValue(descriptor, FilterPanelState), CultureInfo.InvariantCulture), Keyboard = keyboard };
+        entry.SetDynamicResource(Entry.TextColorProperty, TextColorResourceKey);
+        entry.TextChanged += (_, args) => _ = SetFilterValue(descriptor.Key, args.NewTextValue);
+        return entry;
+    }
+
+    /// <summary>Creates a boolean editor for a descriptor.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <returns>The editor.</returns>
+    private Switch CreateBooleanEditor(FilterDescriptor descriptor)
+    {
+        var toggle = new Switch { IsToggled = GetEditorValue(descriptor, FilterPanelState) is true };
+        toggle.Toggled += (_, args) => _ = SetFilterValue(descriptor.Key, args.Value);
+        return toggle;
+    }
+
+    /// <summary>Creates a choice editor for a descriptor.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <returns>The editor.</returns>
+    private Picker CreateChoiceEditor(FilterDescriptor descriptor)
+    {
+        var picker = new Picker { Title = descriptor.DisplayName };
+        picker.SetDynamicResource(Picker.TextColorProperty, TextColorResourceKey);
+        foreach (var choice in descriptor.Choices ?? [])
+        {
+            picker.Items.Add(Convert.ToString(choice, CultureInfo.InvariantCulture) ?? string.Empty);
+        }
+
+        picker.SelectedIndex = FindChoiceIndex(descriptor, GetEditorValue(descriptor, FilterPanelState));
+        picker.SelectedIndexChanged += (_, _) => ApplySelectedChoice(descriptor, picker);
+        return picker;
+    }
+
+    /// <summary>Creates a date editor for a descriptor.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <returns>The editor.</returns>
+    private DatePicker CreateDateEditor(FilterDescriptor descriptor)
+    {
+        var value = GetEditorValue(descriptor, FilterPanelState);
+        var picker = new DatePicker { Date = value is DateTime date ? date : DateTime.Today };
+        picker.SetDynamicResource(DatePicker.TextColorProperty, TextColorResourceKey);
+        picker.DateSelected += (_, args) => _ = SetFilterValue(descriptor.Key, args.NewDate);
+        return picker;
+    }
+
+    /// <summary>Applies a selected operator value.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <param name="picker">The picker.</param>
+    private void ApplySelectedOperator(FilterDescriptor descriptor, Picker picker)
+    {
+        if (picker.SelectedIndex < 0 || picker.SelectedIndex >= descriptor.SupportedOperators.Count)
+        {
+            return;
+        }
+
+        _selectedOperators[descriptor.Key] = descriptor.SupportedOperators[picker.SelectedIndex];
+    }
+
+    /// <summary>Applies a selected choice value.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <param name="picker">The picker.</param>
+    private void ApplySelectedChoice(FilterDescriptor descriptor, Picker picker)
+    {
+        if (picker.SelectedIndex < 0 || picker.SelectedIndex >= (descriptor.Choices?.Count ?? 0))
+        {
+            return;
+        }
+
+        _ = SetFilterValue(descriptor.Key, descriptor.Choices![picker.SelectedIndex]);
+    }
+
+    /// <summary>Gets the current editor value for a descriptor.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <param name="state">The state.</param>
+    /// <returns>The value.</returns>
+    private object? GetEditorValue(FilterDescriptor descriptor, DataFilterPanelState? state) =>
+        _editedValues.TryGetValue(descriptor.Key, out var value)
+            ? value
+            : GetExpressionValue(descriptor, state) ?? descriptor.DefaultValue;
+
+    /// <summary>Determines whether filters can be applied.</summary>
+    /// <returns><c>true</c> when filters can be applied.</returns>
+    private bool CanApplyFilters() =>
+        FilterPanelState?.IsApplying != true
+        && (_editedValues.Count > 0 || FilterPanelState?.CanApply == true);
+
+    /// <summary>Determines whether filters can be cleared.</summary>
+    /// <returns><c>true</c> when filters can be cleared.</returns>
+    private bool CanClearFilters() => FilterPanelState?.CanClear == true;
+
+    /// <summary>Refreshes native button command bindings and payloads.</summary>
+    private void RefreshCommandTargets()
+    {
+        var queryState = CreateQueryState();
+        _applyButton.Command = ApplyFiltersCommand;
+        _applyButton.CommandParameter = queryState;
+        _applyButton.IsEnabled = CanApplyFilters() && ApplyFiltersCommand?.CanExecute(queryState) == true;
+
+        var state = FilterPanelState;
+        _clearButton.Command = ClearFiltersCommand;
+        _clearButton.CommandParameter = state;
+        _clearButton.IsEnabled = CanClearFilters() && ClearFiltersCommand?.CanExecute(state) == true;
+    }
+
+    /// <summary>Updates button and command availability.</summary>
+    private void RaiseCommandAvailability()
+    {
+        RefreshCommandTargets();
+        (ApplyCommand as PanelCommand)?.RaiseCanExecuteChanged();
+        (ClearCommand as PanelCommand)?.RaiseCanExecuteChanged();
+    }
+
+    /// <summary>Command wrapper for panel actions.</summary>
+    /// <param name="execute">The action to execute.</param>
+    /// <param name="canExecute">The command guard.</param>
+    private sealed class PanelCommand(Func<bool> execute, Func<bool> canExecute) : ICommand
+    {
+        /// <inheritdoc />
+        public event EventHandler? CanExecuteChanged;
+
+        /// <inheritdoc />
+        public bool CanExecute(object? parameter) => canExecute();
+
+        /// <inheritdoc />
+        public void Execute(object? parameter) => _ = execute();
+
+        /// <summary>Raises command availability changes.</summary>
+        public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/src/CrissCross.Maui.UI/Controls/DataPager.cs
+++ b/src/CrissCross.Maui.UI/Controls/DataPager.cs
@@ -2,6 +2,8 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using Microsoft.Maui.Layouts;
+
 namespace CrissCross.Maui.UI.Controls;
 
 /// <summary>Represents a paging/navigation surface for local or remote MAUI data sources.</summary>
@@ -11,7 +13,8 @@ public class DataPager : ContentView
     public static readonly BindableProperty PaginationStateProperty = BindableProperty.Create(
         nameof(PaginationState),
         typeof(PaginationState),
-        typeof(DataPager));
+        typeof(DataPager),
+        propertyChanged: static (bindable, _, _) => OnPaginationStateChanged(bindable));
 
     /// <summary>Bindable property for <see cref="CurrentRequest"/>.</summary>
     public static readonly BindableProperty CurrentRequestProperty = BindableProperty.Create(
@@ -23,7 +26,8 @@ public class DataPager : ContentView
     public static readonly BindableProperty PageRequestCommandProperty = BindableProperty.Create(
         nameof(PageRequestCommand),
         typeof(ICommand),
-        typeof(DataPager));
+        typeof(DataPager),
+        propertyChanged: static (bindable, _, _) => OnPaginationStateChanged(bindable));
 
     /// <summary>Bindable property for <see cref="SortKey"/>.</summary>
     public static readonly BindableProperty SortKeyProperty = BindableProperty.Create(
@@ -46,6 +50,39 @@ public class DataPager : ContentView
     /// <summary>Default page size used when no pagination state has been supplied.</summary>
     private const int DefaultPageSize = 20;
 
+    /// <summary>Provides horizontal padding for pager buttons.</summary>
+    private const double ButtonHorizontalPadding = 10;
+
+    /// <summary>Provides vertical padding for pager buttons.</summary>
+    private const double ButtonVerticalPadding = 6;
+
+    /// <summary>Provides the minimum width for pager buttons.</summary>
+    private const double ButtonMinimumWidth = 72;
+
+    /// <summary>Provides vertical padding for the composed pager surface.</summary>
+    private const double RootVerticalPadding = 4;
+
+    /// <summary>Provides spacing for the composed pager surface.</summary>
+    private const double LayoutSpacing = 6;
+
+    /// <summary>Displays the current item range.</summary>
+    private readonly Label _summaryLabel = CreateLabel("No items", isEmphasized: true);
+
+    /// <summary>Displays the current page number and total pages.</summary>
+    private readonly Label _statusLabel = CreateLabel("Page 1 of 1", isEmphasized: false);
+
+    /// <summary>Requests the first page.</summary>
+    private readonly Button _firstButton = CreateButton("First");
+
+    /// <summary>Requests the previous page.</summary>
+    private readonly Button _previousButton = CreateButton("Previous");
+
+    /// <summary>Requests the next page.</summary>
+    private readonly Button _nextButton = CreateButton("Next");
+
+    /// <summary>Requests the last page.</summary>
+    private readonly Button _lastButton = CreateButton("Last");
+
     /// <summary>Initializes a new instance of the <see cref="DataPager"/> class.</summary>
     public DataPager()
     {
@@ -59,6 +96,13 @@ public class DataPager : ContentView
         LastPageCommand = new PageNavigationCommand(
             () => MoveToPage((PaginationState?.TotalPages ?? 1) - 1),
             () => PaginationState?.CanGoLast == true);
+
+        _firstButton.Command = FirstPageCommand;
+        _previousButton.Command = PreviousPageCommand;
+        _nextButton.Command = NextPageCommand;
+        _lastButton.Command = LastPageCommand;
+        Content = CreateLayout();
+        ApplyState();
     }
 
     /// <summary>Gets or sets the shared pagination state projected by the control.</summary>
@@ -121,7 +165,8 @@ public class DataPager : ContentView
     public PageRequest CreateRequest(int pageIndex)
     {
         var state = PaginationState;
-        var clampedPageIndex = state is null ? Math.Max(0, pageIndex) : Math.Clamp(pageIndex, 0, state.TotalPages - 1);
+        var maxPageIndex = state is null ? int.MaxValue : Math.Max(0, state.TotalPages - 1);
+        var clampedPageIndex = Math.Clamp(pageIndex, 0, maxPageIndex);
         var pageSize = state?.PageSize ?? DefaultPageSize;
         return new(clampedPageIndex, pageSize, SortKey, SortDescending, QueryState);
     }
@@ -133,12 +178,97 @@ public class DataPager : ContentView
         var request = CreateRequest(pageIndex);
         CurrentRequest = request;
 
-        if (PageRequestCommand?.CanExecute(request) != true)
+        if (PageRequestCommand?.CanExecute(request) == true)
+        {
+            PageRequestCommand.Execute(request);
+        }
+
+        ApplyState();
+    }
+
+    /// <summary>Creates a pager navigation button.</summary>
+    /// <param name="text">The button text.</param>
+    /// <returns>The configured button.</returns>
+    private static Button CreateButton(string text)
+    {
+        var button = new Button { Text = text, Padding = new(ButtonHorizontalPadding, ButtonVerticalPadding), MinimumWidthRequest = ButtonMinimumWidth };
+        button.SetDynamicResource(Button.BackgroundColorProperty, "CrissCrossAccentColor");
+        button.SetDynamicResource(Button.TextColorProperty, "CrissCrossAccentTextColor");
+        button.Margin = new(0, 0, LayoutSpacing, LayoutSpacing);
+        return button;
+    }
+
+    /// <summary>Creates a pager display label.</summary>
+    /// <param name="text">The label text.</param>
+    /// <param name="isEmphasized">A value indicating whether the label should use bold text.</param>
+    /// <returns>The configured label.</returns>
+    private static Label CreateLabel(string text, bool isEmphasized)
+    {
+        var label = new Label { Text = text, FontAttributes = isEmphasized ? FontAttributes.Bold : FontAttributes.None };
+        label.SetDynamicResource(Label.TextColorProperty, "CrissCrossTextColor");
+        return label;
+    }
+
+    /// <summary>Applies bindable property changes to the pager presentation.</summary>
+    /// <param name="bindable">The bindable control.</param>
+    private static void OnPaginationStateChanged(BindableObject bindable)
+    {
+        if (bindable is not DataPager pager)
         {
             return;
         }
 
-        PageRequestCommand.Execute(request);
+        pager.ApplyState();
+    }
+
+    /// <summary>Creates the native MAUI pager layout.</summary>
+    /// <returns>The composed pager view.</returns>
+    private VerticalStackLayout CreateLayout()
+    {
+        var root = new VerticalStackLayout { Spacing = LayoutSpacing, Padding = new(0, RootVerticalPadding) };
+        var buttonRow = new FlexLayout { Direction = FlexDirection.Row, Wrap = FlexWrap.Wrap, AlignItems = FlexAlignItems.Center };
+        buttonRow.Children.Add(_firstButton);
+        buttonRow.Children.Add(_previousButton);
+        buttonRow.Children.Add(_nextButton);
+        buttonRow.Children.Add(_lastButton);
+        root.Children.Add(_summaryLabel);
+        root.Children.Add(_statusLabel);
+        root.Children.Add(buttonRow);
+        return root;
+    }
+
+    /// <summary>Applies the current pagination state to labels, buttons, and command availability.</summary>
+    private void ApplyState()
+    {
+        var state = PaginationState;
+        _summaryLabel.Text = state?.SummaryText ?? "No items";
+        _statusLabel.Text = state is null ? "Page 1 of 1" : $"Page {state.PageNumber} of {state.TotalPages}";
+        _firstButton.IsEnabled = FirstPageCommand.CanExecute(null);
+        _previousButton.IsEnabled = PreviousPageCommand.CanExecute(null);
+        _nextButton.IsEnabled = NextPageCommand.CanExecute(null);
+        _lastButton.IsEnabled = LastPageCommand.CanExecute(null);
+
+        if (FirstPageCommand is PageNavigationCommand firstCommand)
+        {
+            firstCommand.RaiseCanExecuteChanged();
+        }
+
+        if (PreviousPageCommand is PageNavigationCommand previousCommand)
+        {
+            previousCommand.RaiseCanExecuteChanged();
+        }
+
+        if (NextPageCommand is PageNavigationCommand nextCommand)
+        {
+            nextCommand.RaiseCanExecuteChanged();
+        }
+
+        if (LastPageCommand is not PageNavigationCommand lastCommand)
+        {
+            return;
+        }
+
+        lastCommand.RaiseCanExecuteChanged();
     }
 
     /// <summary>Command wrapper for page navigation actions.</summary>
@@ -146,10 +276,10 @@ public class DataPager : ContentView
     /// <param name="canExecute">The can execute predicate.</param>
     private sealed class PageNavigationCommand(Action execute, Func<bool> canExecute) : ICommand
     {
-        /// <summary>Stores the can execute predicate.</summary>
+        /// <summary>Stores the command availability predicate.</summary>
         private readonly Func<bool> _canExecute = canExecute;
 
-        /// <summary>Stores the execute action.</summary>
+        /// <summary>Stores the command action.</summary>
         private readonly Action _execute = execute;
 
         /// <inheritdoc />
@@ -167,7 +297,9 @@ public class DataPager : ContentView
             }
 
             _execute();
-            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
         }
+
+        /// <summary>Raises command availability changes after pager state changes.</summary>
+        public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/src/CrissCross.Maui.UI/Controls/DateTimeRangePicker.cs
+++ b/src/CrissCross.Maui.UI/Controls/DateTimeRangePicker.cs
@@ -2,6 +2,8 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
+
 namespace CrissCross.Maui.UI.Controls;
 
 /// <summary>Displays and edits a shared date/time range snapshot.</summary>
@@ -11,13 +13,63 @@ public class DateTimeRangePicker : ContentView
     public static readonly BindableProperty RangeProperty = BindableProperty.Create(
         nameof(Range),
         typeof(DateTimeRange),
-        typeof(DateTimeRangePicker));
+        typeof(DateTimeRangePicker),
+        propertyChanged: static (bindable, _, newValue) => OnRangeChanged(bindable, newValue));
 
     /// <summary>Bindable property for <see cref="ApplyRangeCommand"/>.</summary>
     public static readonly BindableProperty ApplyRangeCommandProperty = BindableProperty.Create(
         nameof(ApplyRangeCommand),
         typeof(ICommand),
-        typeof(DateTimeRangePicker));
+        typeof(DateTimeRangePicker),
+        propertyChanged: OnApplyRangeCommandChanged);
+
+    /// <summary>Provides spacing for the composed range picker rows.</summary>
+    private const double LayoutSpacing = 8;
+
+    /// <summary>Displays the current range summary or validation message.</summary>
+    private readonly Label _summaryLabel = CreateLabel(isEmphasized: true);
+
+    /// <summary>Edits the start date.</summary>
+    private readonly DatePicker _startDatePicker = new();
+
+    /// <summary>Edits the start time.</summary>
+    private readonly TimePicker _startTimePicker = new();
+
+    /// <summary>Edits the end date.</summary>
+    private readonly DatePicker _endDatePicker = new();
+
+    /// <summary>Edits the end time.</summary>
+    private readonly TimePicker _endTimePicker = new();
+
+    /// <summary>Applies the current draft range.</summary>
+    private readonly Button _applyButton = new() { Text = "Apply range" };
+
+    /// <summary>Gates range application against current validation and command availability.</summary>
+    private readonly Command _applyCommand;
+
+    /// <summary>Stores the external command currently observed for availability changes.</summary>
+    private ICommand? _observedApplyRangeCommand;
+
+    /// <summary>Stores the weak availability-change handler attached to the external command.</summary>
+    private EventHandler? _applyRangeCanExecuteChangedHandler;
+
+    /// <summary>Prevents control-generated changes while projecting a new state snapshot.</summary>
+    private bool _isApplyingState;
+
+    /// <summary>Initializes a new instance of the <see cref="DateTimeRangePicker"/> class.</summary>
+    public DateTimeRangePicker()
+    {
+        _applyCommand = new(ExecuteCurrentRange, CanApplyCurrentRange);
+        _startDatePicker.DateSelected += OnDraftChanged;
+        _endDatePicker.DateSelected += OnDraftChanged;
+        _startTimePicker.PropertyChanged += OnTimePickerPropertyChanged;
+        _endTimePicker.PropertyChanged += OnTimePickerPropertyChanged;
+        _applyButton.Command = _applyCommand;
+        _applyButton.SetDynamicResource(Button.BackgroundColorProperty, "CrissCrossAccentColor");
+        _applyButton.SetDynamicResource(Button.TextColorProperty, "CrissCrossAccentTextColor");
+        Content = CreateLayout();
+        ApplyRange(Range);
+    }
 
     /// <summary>Gets or sets the shared CrissCross state projected by this control.</summary>
     public DateTimeRange? Range
@@ -31,5 +83,213 @@ public class DateTimeRangePicker : ContentView
     {
         get => (ICommand?)GetValue(ApplyRangeCommandProperty);
         set => SetValue(ApplyRangeCommandProperty, value);
+    }
+
+    /// <summary>Applies the current date/time draft through <see cref="ApplyRangeCommand"/> when valid.</summary>
+    /// <returns><c>true</c> when a valid range command was invoked; otherwise, <c>false</c>.</returns>
+    public bool ApplyCurrentRange()
+    {
+        var range = CreateRangeFromInputs();
+        Range = range;
+        if (!range.IsValid || ApplyRangeCommand?.CanExecute(range) != true)
+        {
+            return false;
+        }
+
+        ApplyRangeCommand.Execute(range);
+        return true;
+    }
+
+    /// <summary>Combines a selected local date and time without inventing missing input.</summary>
+    /// <param name="date">The selected date.</param>
+    /// <param name="time">The selected time.</param>
+    /// <param name="offset">The existing endpoint offset, when supplied.</param>
+    /// <returns>The selected endpoint, or null for incomplete input.</returns>
+    private static DateTimeOffset? CreateEndpoint(DateTime? date, TimeSpan? time, TimeSpan? offset)
+    {
+        if (date is null || time is null)
+        {
+            return null;
+        }
+
+        var localDateTime = DateOnly.FromDateTime(date.Value).ToDateTime(TimeOnly.FromTimeSpan(time.Value));
+        return new(localDateTime, offset ?? TimeZoneInfo.Local.GetUtcOffset(localDateTime));
+    }
+
+    /// <summary>Creates a display label.</summary>
+    /// <param name="isEmphasized">A value indicating whether the label should use emphasized text.</param>
+    /// <returns>The configured label.</returns>
+    private static Label CreateLabel(bool isEmphasized)
+    {
+        var label = new Label { FontAttributes = isEmphasized ? FontAttributes.Bold : FontAttributes.None };
+        label.SetDynamicResource(Label.TextColorProperty, "CrissCrossTextColor");
+        return label;
+    }
+
+    /// <summary>Applies a bindable range state change.</summary>
+    /// <param name="bindable">The bindable control.</param>
+    /// <param name="newValue">The new range value.</param>
+    private static void OnRangeChanged(BindableObject bindable, object newValue)
+    {
+        if (bindable is not DateTimeRangePicker picker)
+        {
+            return;
+        }
+
+        picker.ApplyRange(newValue as DateTimeRange);
+    }
+
+    /// <summary>Applies command availability changes to the current presentation.</summary>
+    /// <param name="bindable">The bindable control.</param>
+    /// <param name="oldValue">The previous command value.</param>
+    /// <param name="newValue">The new command value.</param>
+    private static void OnApplyRangeCommandChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is not DateTimeRangePicker picker)
+        {
+            return;
+        }
+
+        picker.ObserveApplyRangeCommand(oldValue as ICommand, newValue as ICommand);
+        picker.UpdateValidation(picker.CreateRangeFromInputs());
+    }
+
+    /// <summary>Creates the native MAUI layout.</summary>
+    /// <returns>The composed view.</returns>
+    private VerticalStackLayout CreateLayout()
+    {
+        var root = new VerticalStackLayout { Spacing = LayoutSpacing };
+        var startRow = new HorizontalStackLayout { Spacing = LayoutSpacing };
+        var endRow = new HorizontalStackLayout { Spacing = LayoutSpacing };
+        startRow.Children.Add(_startDatePicker);
+        startRow.Children.Add(_startTimePicker);
+        endRow.Children.Add(_endDatePicker);
+        endRow.Children.Add(_endTimePicker);
+        root.Children.Add(_summaryLabel);
+        root.Children.Add(startRow);
+        root.Children.Add(endRow);
+        root.Children.Add(_applyButton);
+        return root;
+    }
+
+    /// <summary>Projects the current range into the native date/time inputs.</summary>
+    /// <param name="range">The range to project.</param>
+    private void ApplyRange(DateTimeRange? range)
+    {
+        _isApplyingState = true;
+        try
+        {
+            _startDatePicker.Date = range?.Start?.Date;
+            _startTimePicker.Time = range?.Start?.TimeOfDay;
+            _endDatePicker.Date = range?.End?.Date;
+            _endTimePicker.Time = range?.End?.TimeOfDay;
+        }
+        finally
+        {
+            _isApplyingState = false;
+        }
+
+        UpdateValidation(range ?? CreateRangeFromInputs());
+    }
+
+    /// <summary>Creates a shared range snapshot from the current native inputs.</summary>
+    /// <returns>The draft range.</returns>
+    private DateTimeRange CreateRangeFromInputs()
+    {
+        var existingRange = Range;
+        var start = CreateEndpoint(_startDatePicker.Date, _startTimePicker.Time, existingRange?.Start?.Offset);
+        var end = CreateEndpoint(_endDatePicker.Date, _endTimePicker.Time, existingRange?.End?.Offset);
+        return existingRange is null ? new(start, end) : new(
+            start,
+            end,
+            existingRange.Preset,
+            existingRange.Label,
+            existingRange.IsEndInclusive,
+            existingRange.MaximumDuration);
+    }
+
+    /// <summary>Updates validation and apply affordance for a draft range.</summary>
+    /// <param name="range">The draft range.</param>
+    private void UpdateValidation(DateTimeRange range)
+    {
+        _summaryLabel.Text = range.IsValid ? range.DisplayText : range.ValidationMessage;
+        _applyButton.CommandParameter = range;
+        _applyCommand.ChangeCanExecute();
+        _applyButton.IsEnabled = _applyCommand.CanExecute(range);
+    }
+
+    /// <summary>Observes external command availability without retaining the control from the command event.</summary>
+    /// <param name="oldCommand">The previous command value.</param>
+    /// <param name="newCommand">The new command value.</param>
+    private void ObserveApplyRangeCommand(ICommand? oldCommand, ICommand? newCommand)
+    {
+        if (ReferenceEquals(_observedApplyRangeCommand, newCommand))
+        {
+            return;
+        }
+
+        if (oldCommand is not null && _applyRangeCanExecuteChangedHandler is not null)
+        {
+            oldCommand.CanExecuteChanged -= _applyRangeCanExecuteChangedHandler;
+        }
+
+        _observedApplyRangeCommand = newCommand;
+        if (newCommand is null)
+        {
+            _applyRangeCanExecuteChangedHandler = null;
+            return;
+        }
+
+        var weakPicker = new WeakReference<DateTimeRangePicker>(this);
+        _applyRangeCanExecuteChangedHandler = (_, _) =>
+        {
+            if (!weakPicker.TryGetTarget(out var picker))
+            {
+                return;
+            }
+
+            picker.UpdateValidation(picker.CreateRangeFromInputs());
+        };
+        newCommand.CanExecuteChanged += _applyRangeCanExecuteChangedHandler;
+    }
+
+    /// <summary>Updates validation after a date input changes.</summary>
+    /// <param name="sender">The event source.</param>
+    /// <param name="e">The date change arguments.</param>
+    private void OnDraftChanged(object? sender, DateChangedEventArgs e)
+    {
+        _ = sender;
+        _ = e;
+        if (_isApplyingState)
+        {
+            return;
+        }
+
+        UpdateValidation(CreateRangeFromInputs());
+    }
+
+    /// <summary>Updates validation after a time input changes.</summary>
+    /// <param name="sender">The event source.</param>
+    /// <param name="e">The property change arguments.</param>
+    private void OnTimePickerPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        _ = sender;
+        if (_isApplyingState || e.PropertyName != nameof(TimePicker.Time))
+        {
+            return;
+        }
+
+        UpdateValidation(CreateRangeFromInputs());
+    }
+
+    /// <summary>Applies a valid draft from the native button.</summary>
+    private void ExecuteCurrentRange() => _ = ApplyCurrentRange();
+
+    /// <summary>Checks whether the current draft can be applied.</summary>
+    /// <returns>Whether the external command accepts the valid draft.</returns>
+    private bool CanApplyCurrentRange()
+    {
+        var range = CreateRangeFromInputs();
+        return range.IsValid && ApplyRangeCommand?.CanExecute(range) == true;
     }
 }

--- a/src/CrissCross.Maui.UI/Controls/EmptyState.cs
+++ b/src/CrissCross.Maui.UI/Controls/EmptyState.cs
@@ -11,13 +11,73 @@ public class EmptyState : ContentView
     public static readonly BindableProperty ModelProperty = BindableProperty.Create(
         nameof(Model),
         typeof(EmptyStateModel),
-        typeof(EmptyState));
+        typeof(EmptyState),
+        propertyChanged: static (view, _, _) => ((EmptyState)view).Refresh());
 
     /// <summary>Bindable property for <see cref="PrimaryCommand"/>.</summary>
     public static readonly BindableProperty PrimaryCommandProperty = BindableProperty.Create(
         nameof(PrimaryCommand),
         typeof(ICommand),
-        typeof(EmptyState));
+        typeof(EmptyState),
+        propertyChanged: static (view, _, _) => ((EmptyState)view).Refresh());
+
+    /// <summary>Provides the icon size used by the default native presentation.</summary>
+    private const double IconFontSize = 32;
+
+    /// <summary>Provides the title size used by the default native presentation.</summary>
+    private const double TitleFontSize = 20;
+
+    /// <summary>Provides default spacing between empty-state elements.</summary>
+    private const double LayoutSpacing = 8;
+
+    /// <summary>Provides default spacing between empty-state action buttons.</summary>
+    private const double ActionSpacing = 8;
+
+    /// <summary>Provides horizontal default content padding.</summary>
+    private const double HorizontalPadding = 16;
+
+    /// <summary>Provides vertical default content padding.</summary>
+    private const double VerticalPadding = 24;
+
+    /// <summary>Provides the accessibility text used when no model has been supplied.</summary>
+    private const string FallbackTitle = "No content";
+
+    /// <summary>Provides the primary text semantic resource key.</summary>
+    private const string TextColorResourceKey = "CrissCrossTextColor";
+
+    /// <summary>Provides the muted text semantic resource key.</summary>
+    private const string MutedTextColorResourceKey = "CrissCrossMutedTextColor";
+
+    /// <summary>Provides the accent fill semantic resource key.</summary>
+    private const string AccentColorResourceKey = "CrissCrossAccentColor";
+
+    /// <summary>Provides the accent text semantic resource key.</summary>
+    private const string AccentTextColorResourceKey = "CrissCrossAccentTextColor";
+
+    /// <summary>Provides the neutral surface semantic resource key.</summary>
+    private const string NeutralSurfaceColorResourceKey = "CrissCrossNeutralSurfaceColor";
+
+    /// <summary>Displays a semantic glyph for the current empty-state variant.</summary>
+    private readonly Label _icon = new() { FontSize = IconFontSize, HorizontalTextAlignment = TextAlignment.Center };
+
+    /// <summary>Displays the empty-state title.</summary>
+    private readonly Label _title = new() { FontAttributes = FontAttributes.Bold, FontSize = TitleFontSize, HorizontalTextAlignment = TextAlignment.Center };
+
+    /// <summary>Displays the empty-state message.</summary>
+    private readonly Label _message = new() { HorizontalTextAlignment = TextAlignment.Center };
+
+    /// <summary>Invokes the primary action when available.</summary>
+    private readonly Button _primaryAction = new();
+
+    /// <summary>Invokes the secondary action when the model provides one.</summary>
+    private readonly Button _secondaryAction = new();
+
+    /// <summary>Initializes a new instance of the <see cref="EmptyState"/> class.</summary>
+    public EmptyState()
+    {
+        Content = CreateDefaultContent();
+        Refresh();
+    }
 
     /// <summary>Gets or sets the shared CrissCross state projected by this control.</summary>
     public EmptyStateModel? Model
@@ -31,5 +91,79 @@ public class EmptyState : ContentView
     {
         get => (ICommand?)GetValue(PrimaryCommandProperty);
         set => SetValue(PrimaryCommandProperty, value);
+    }
+
+    /// <summary>Gets the command currently projected by the primary button.</summary>
+    private ICommand? EffectivePrimaryCommand => PrimaryCommand ?? Model?.PrimaryActionCommand;
+
+    /// <summary>Combines title and message text for assistive technologies.</summary>
+    /// <param name="title">The empty-state title.</param>
+    /// <param name="message">The empty-state message.</param>
+    /// <returns>The combined accessibility description.</returns>
+    private static string GetAccessibleDescription(string title, string message) =>
+        string.IsNullOrWhiteSpace(message) ? title : $"{title} {message}";
+
+    /// <summary>Gets the glyph associated with an empty-state variant.</summary>
+    /// <param name="variant">The empty-state variant.</param>
+    /// <returns>The display glyph.</returns>
+    private static string GetVariantGlyph(EmptyStateVariant variant) => variant switch
+    {
+        EmptyStateVariant.Error => "!",
+        EmptyStateVariant.Offline => "↯",
+        EmptyStateVariant.NoResults => "⌕",
+        EmptyStateVariant.PermissionRequired => "⊘",
+        _ => "∅",
+    };
+
+    /// <summary>Gets the title from the current model.</summary>
+    /// <param name="model">The empty-state model.</param>
+    /// <returns>The visible title.</returns>
+    private static string GetTitle(EmptyStateModel? model)
+    {
+        var title = model?.Title;
+        return string.IsNullOrWhiteSpace(title) ? FallbackTitle : title!;
+    }
+
+    /// <summary>Updates one action button from the current state snapshot.</summary>
+    /// <param name="button">The button to update.</param>
+    /// <param name="text">The action text.</param>
+    /// <param name="command">The action command.</param>
+    private static void RefreshAction(Button button, string? text, ICommand? command)
+    {
+        button.Text = text;
+        button.Command = command;
+        button.IsVisible = !string.IsNullOrWhiteSpace(text) && command is not null;
+    }
+
+    /// <summary>Creates the composed native default content.</summary>
+    /// <returns>The default native content.</returns>
+    private VerticalStackLayout CreateDefaultContent()
+    {
+        HorizontalStackLayout actions = new() { HorizontalOptions = LayoutOptions.Center, Spacing = ActionSpacing, Children = { _primaryAction, _secondaryAction } };
+
+        _icon.SetDynamicResource(Label.TextColorProperty, MutedTextColorResourceKey);
+        _title.SetDynamicResource(Label.TextColorProperty, TextColorResourceKey);
+        _message.SetDynamicResource(Label.TextColorProperty, MutedTextColorResourceKey);
+        _primaryAction.SetDynamicResource(Button.BackgroundColorProperty, AccentColorResourceKey);
+        _primaryAction.SetDynamicResource(Button.TextColorProperty, AccentTextColorResourceKey);
+        _secondaryAction.SetDynamicResource(Button.BackgroundColorProperty, NeutralSurfaceColorResourceKey);
+        _secondaryAction.SetDynamicResource(Button.TextColorProperty, TextColorResourceKey);
+
+        return new() { Padding = new(HorizontalPadding, VerticalPadding), Spacing = LayoutSpacing, HorizontalOptions = LayoutOptions.Center, Children = { _icon, _title, _message, actions } };
+    }
+
+    /// <summary>Updates the composed native content from the current model.</summary>
+    private void Refresh()
+    {
+        var model = Model;
+        var title = GetTitle(model);
+        var message = model?.Message ?? string.Empty;
+        _icon.Text = GetVariantGlyph(model?.Variant ?? EmptyStateVariant.NoData);
+        _title.Text = title;
+        _message.Text = message;
+        _message.IsVisible = !string.IsNullOrWhiteSpace(message);
+        RefreshAction(_primaryAction, model?.PrimaryActionText, EffectivePrimaryCommand);
+        RefreshAction(_secondaryAction, model?.SecondaryActionText, model?.SecondaryActionCommand);
+        SemanticProperties.SetDescription(this, GetAccessibleDescription(title, message));
     }
 }

--- a/src/CrissCross.Maui.UI/Controls/FilterBar.cs
+++ b/src/CrissCross.Maui.UI/Controls/FilterBar.cs
@@ -2,6 +2,8 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using Microsoft.Maui.Layouts;
+
 namespace CrissCross.Maui.UI.Controls;
 
 /// <summary>Displays active search/filter tokens with clear and remove command hooks.</summary>
@@ -11,13 +13,74 @@ public class FilterBar : ContentView
     public static readonly BindableProperty SearchStateProperty = BindableProperty.Create(
         nameof(SearchState),
         typeof(SearchQueryState),
-        typeof(FilterBar));
+        typeof(FilterBar),
+        propertyChanged: static (bindable, _, newValue) => OnSearchStateChanged(bindable, newValue));
 
     /// <summary>Bindable property for <see cref="ClearFiltersCommand"/>.</summary>
     public static readonly BindableProperty ClearFiltersCommandProperty = BindableProperty.Create(
         nameof(ClearFiltersCommand),
         typeof(ICommand),
-        typeof(FilterBar));
+        typeof(FilterBar),
+        propertyChanged: static (bindable, _, _) => OnCommandChanged(bindable));
+
+    /// <summary>Bindable property for <see cref="RemoveFilterCommand"/>.</summary>
+    public static readonly BindableProperty RemoveFilterCommandProperty = BindableProperty.Create(
+        nameof(RemoveFilterCommand),
+        typeof(ICommand),
+        typeof(FilterBar),
+        propertyChanged: static (bindable, _, _) => OnCommandChanged(bindable));
+
+    /// <summary>Semantic text color resource key.</summary>
+    private const string TextColorResourceKey = "CrissCrossTextColor";
+
+    /// <summary>Semantic accent color resource key.</summary>
+    private const string AccentColorResourceKey = "CrissCrossAccentColor";
+
+    /// <summary>Semantic accent text color resource key.</summary>
+    private const string AccentTextColorResourceKey = "CrissCrossAccentTextColor";
+
+    /// <summary>Semantic subtle surface color resource key.</summary>
+    private const string SubtleSurfaceColorResourceKey = "CrissCrossSubtleSurfaceColor";
+
+    /// <summary>Horizontal action padding.</summary>
+    private const double ActionPaddingHorizontal = 10D;
+
+    /// <summary>Vertical action padding.</summary>
+    private const double ActionPaddingVertical = 6D;
+
+    /// <summary>Minimum action width.</summary>
+    private const double ActionMinimumWidth = 96D;
+
+    /// <summary>Root layout spacing.</summary>
+    private const double RootSpacing = 8D;
+
+    /// <summary>Root vertical padding.</summary>
+    private const double RootPaddingVertical = 4D;
+
+    /// <summary>Chip layout spacing.</summary>
+    private const double ChipSpacing = 6D;
+
+    /// <summary>Chip horizontal padding.</summary>
+    private const double ChipPaddingHorizontal = 10D;
+
+    /// <summary>Chip vertical padding.</summary>
+    private const double ChipPaddingVertical = 4D;
+
+    /// <summary>Displays the current active-filter summary.</summary>
+    private readonly Label _summaryLabel = CreateLabel("No active filters", FontAttributes.Bold);
+
+    /// <summary>Hosts active filter chip rows.</summary>
+    private readonly FlexLayout _chipHost = new() { Direction = FlexDirection.Row, Wrap = FlexWrap.Wrap, AlignItems = FlexAlignItems.Center };
+
+    /// <summary>Clears all active filters.</summary>
+    private readonly Button _clearButton = CreateActionButton("Clear filters");
+
+    /// <summary>Initializes a new instance of the <see cref="FilterBar"/> class.</summary>
+    public FilterBar()
+    {
+        Content = CreateLayout();
+        ApplyState(null);
+    }
 
     /// <summary>Gets or sets the shared CrissCross state projected by this control.</summary>
     public SearchQueryState? SearchState
@@ -31,5 +94,146 @@ public class FilterBar : ContentView
     {
         get => (ICommand?)GetValue(ClearFiltersCommandProperty);
         set => SetValue(ClearFiltersCommandProperty, value);
+    }
+
+    /// <summary>Gets or sets the command invoked when a removable filter token is removed.</summary>
+    public ICommand? RemoveFilterCommand
+    {
+        get => (ICommand?)GetValue(RemoveFilterCommandProperty);
+        set => SetValue(RemoveFilterCommandProperty, value);
+    }
+
+    /// <summary>Invokes the clear-filters command with the current search state.</summary>
+    /// <returns><c>true</c> when the clear command was executed.</returns>
+    public bool ClearFilters()
+    {
+        var state = SearchState;
+        if (ClearFiltersCommand?.CanExecute(state) != true)
+        {
+            return false;
+        }
+
+        ClearFiltersCommand.Execute(state);
+        return true;
+    }
+
+    /// <summary>Invokes the remove-filter command for a token.</summary>
+    /// <param name="token">The token to remove.</param>
+    /// <returns><c>true</c> when the remove command was executed.</returns>
+    public bool RemoveFilter(FilterToken token)
+    {
+        if (!token.IsRemovable || RemoveFilterCommand?.CanExecute(token) != true)
+        {
+            return false;
+        }
+
+        RemoveFilterCommand.Execute(token);
+        return true;
+    }
+
+    /// <summary>Creates a label using semantic theme color resources.</summary>
+    /// <param name="text">The label text.</param>
+    /// <param name="fontAttributes">The font attributes.</param>
+    /// <returns>The configured label.</returns>
+    private static Label CreateLabel(string text, FontAttributes fontAttributes)
+    {
+        var label = new Label { Text = text, FontAttributes = fontAttributes, VerticalTextAlignment = TextAlignment.Center };
+        label.SetDynamicResource(Label.TextColorProperty, TextColorResourceKey);
+        return label;
+    }
+
+    /// <summary>Creates an action button using semantic theme color resources.</summary>
+    /// <param name="text">The button text.</param>
+    /// <returns>The configured button.</returns>
+    private static Button CreateActionButton(string text)
+    {
+        var button = new Button { Text = text, Padding = new(ActionPaddingHorizontal, ActionPaddingVertical), MinimumWidthRequest = ActionMinimumWidth };
+        button.SetDynamicResource(Button.BackgroundColorProperty, AccentColorResourceKey);
+        button.SetDynamicResource(Button.TextColorProperty, AccentTextColorResourceKey);
+        return button;
+    }
+
+    /// <summary>Runs when the search state changes.</summary>
+    /// <param name="bindable">The bindable object.</param>
+    /// <param name="newValue">The new value.</param>
+    private static void OnSearchStateChanged(BindableObject bindable, object? newValue)
+    {
+        if (bindable is not FilterBar filterBar)
+        {
+            return;
+        }
+
+        filterBar.ApplyState(newValue as SearchQueryState);
+    }
+
+    /// <summary>Runs when command availability changes.</summary>
+    /// <param name="bindable">The bindable object.</param>
+    private static void OnCommandChanged(BindableObject bindable)
+    {
+        if (bindable is not FilterBar filterBar)
+        {
+            return;
+        }
+
+        filterBar.ApplyState(filterBar.SearchState);
+    }
+
+    /// <summary>Gets the summary text for the current filters.</summary>
+    /// <param name="filterCount">The active filter count.</param>
+    /// <param name="resultSummary">The optional result summary.</param>
+    /// <returns>The formatted summary text.</returns>
+    private static string GetSummaryText(int filterCount, string? resultSummary) => resultSummary is { Length: > 0 }
+        ? $"{filterCount} active filters, {resultSummary}"
+        : $"{filterCount} active filters";
+
+    /// <summary>Creates the root layout.</summary>
+    /// <returns>The root layout.</returns>
+    private VerticalStackLayout CreateLayout()
+    {
+        var root = new VerticalStackLayout { Spacing = RootSpacing, Padding = new(0D, RootPaddingVertical) };
+        root.Children.Add(_summaryLabel);
+        root.Children.Add(_chipHost);
+        root.Children.Add(_clearButton);
+        return root;
+    }
+
+    /// <summary>Applies search state to native child presenters.</summary>
+    /// <param name="state">The search state.</param>
+    private void ApplyState(SearchQueryState? state)
+    {
+        var filters = state?.ActiveFilters ?? [];
+        _chipHost.Children.Clear();
+        _summaryLabel.Text = filters.Count == 0
+            ? "No active filters"
+            : GetSummaryText(filters.Count, state?.ResultSummary);
+        _clearButton.Command = ClearFiltersCommand;
+        _clearButton.CommandParameter = state;
+        _clearButton.IsEnabled = filters.Count > 0 && ClearFiltersCommand?.CanExecute(state) == true;
+
+        foreach (var token in filters)
+        {
+            _chipHost.Children.Add(CreateChip(token));
+        }
+
+        SemanticProperties.SetDescription(this, _summaryLabel.Text);
+    }
+
+    /// <summary>Creates a native chip row for one active filter token.</summary>
+    /// <param name="token">The token to present.</param>
+    /// <returns>The chip view.</returns>
+    private HorizontalStackLayout CreateChip(FilterToken token)
+    {
+        var label = CreateLabel(token.DisplayText, FontAttributes.None);
+        var removeButton = CreateActionButton("Remove");
+        removeButton.Command = RemoveFilterCommand;
+        removeButton.CommandParameter = token;
+        removeButton.IsEnabled = token.IsRemovable && RemoveFilterCommand?.CanExecute(token) == true;
+
+        var chip = new HorizontalStackLayout { Spacing = ChipSpacing, Padding = new(ChipPaddingHorizontal, ChipPaddingVertical) };
+        chip.SetDynamicResource(VisualElement.BackgroundColorProperty, SubtleSurfaceColorResourceKey);
+        chip.Children.Add(label);
+        chip.Children.Add(removeButton);
+        SemanticProperties.SetDescription(chip, token.DisplayText);
+        return chip;
     }
 }

--- a/src/CrissCross.Maui.UI/Controls/PersonPicture.cs
+++ b/src/CrissCross.Maui.UI/Controls/PersonPicture.cs
@@ -37,6 +37,7 @@ public class PersonPicture : ContentView
     /// <summary>Initializes a new instance of the <see cref="PersonPicture"/> class.</summary>
     public PersonPicture()
     {
+        _initials.SetDynamicResource(Label.TextColorProperty, "CrissCrossAccentTextColor");
         Content = new Grid { Children = { _initials, _image } };
         Refresh();
     }

--- a/src/CrissCross.Maui.UI/Controls/ProcessValueIndicator.cs
+++ b/src/CrissCross.Maui.UI/Controls/ProcessValueIndicator.cs
@@ -1,0 +1,327 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace CrissCross.Maui.UI.Controls;
+
+/// <summary>Displays an industrial process reading with range, quality, and alarm state.</summary>
+public class ProcessValueIndicator : ContentView
+{
+    /// <summary>Bindable property for <see cref="State"/>.</summary>
+    public static readonly BindableProperty StateProperty;
+
+    /// <summary>Bindable property for <see cref="Label"/>.</summary>
+    public static readonly BindableProperty LabelProperty;
+
+    /// <summary>Bindable property for <see cref="DisplayText"/>.</summary>
+    public static readonly BindableProperty DisplayTextProperty;
+
+    /// <summary>Bindable property for <see cref="StatusText"/>.</summary>
+    public static readonly BindableProperty StatusTextProperty;
+
+    /// <summary>Bindable property for <see cref="Percentage"/>.</summary>
+    public static readonly BindableProperty PercentageProperty;
+
+    /// <summary>Bindable property for <see cref="NormalizedValue"/>.</summary>
+    public static readonly BindableProperty NormalizedValueProperty;
+
+    /// <summary>Bindable property for <see cref="HasValidValue"/>.</summary>
+    public static readonly BindableProperty HasValidValueProperty;
+
+    /// <summary>Bindable property for <see cref="IsAlarm"/>.</summary>
+    public static readonly BindableProperty IsAlarmProperty;
+
+    /// <summary>Bindable property for <see cref="Status"/>.</summary>
+    public static readonly BindableProperty StatusProperty;
+
+    /// <summary>Bindable property for <see cref="NormalStatusColor"/>.</summary>
+    public static readonly BindableProperty NormalStatusColorProperty;
+
+    /// <summary>Bindable property for <see cref="AlarmStatusColor"/>.</summary>
+    public static readonly BindableProperty AlarmStatusColorProperty;
+
+    /// <summary>Bindable property for <see cref="BadQualityStatusColor"/>.</summary>
+    public static readonly BindableProperty BadQualityStatusColorProperty;
+
+    /// <summary>Bindable property for <see cref="InvalidConfigurationStatusColor"/>.</summary>
+    public static readonly BindableProperty InvalidConfigurationStatusColorProperty;
+
+    /// <summary>Bindable property for <see cref="RangeTrackColor"/>.</summary>
+    public static readonly BindableProperty RangeTrackColorProperty;
+
+    /// <summary>Minimum visual bar width used for non-zero readings.</summary>
+    private const double MinimumFilledBarWidth = 2;
+
+    /// <summary>Maximum percentage value for display calculations.</summary>
+    private const double MaximumPercentage = 100;
+
+    /// <summary>Layout spacing between rows.</summary>
+    private const double LayoutSpacing = 6;
+
+    /// <summary>Default range bar height.</summary>
+    private const double RangeBarHeight = 8;
+
+    /// <summary>Default value label size.</summary>
+    private const double ValueFontSize = 22;
+
+    /// <summary>Default metadata label size.</summary>
+    private const double MetadataFontSize = 14;
+
+    /// <summary>Fallback state used when no process-value snapshot has been supplied.</summary>
+    private static readonly ProcessValueState EmptyState = new(
+        "Process value",
+        null,
+        string.Empty,
+        0D,
+        MaximumPercentage,
+        new ProcessValueOptions { IsGoodQuality = false });
+
+    /// <summary>Bindable property key for <see cref="Label"/>.</summary>
+    private static readonly BindablePropertyKey LabelPropertyKey;
+
+    /// <summary>Bindable property key for <see cref="DisplayText"/>.</summary>
+    private static readonly BindablePropertyKey DisplayTextPropertyKey;
+
+    /// <summary>Bindable property key for <see cref="StatusText"/>.</summary>
+    private static readonly BindablePropertyKey StatusTextPropertyKey;
+
+    /// <summary>Bindable property key for <see cref="Percentage"/>.</summary>
+    private static readonly BindablePropertyKey PercentagePropertyKey;
+
+    /// <summary>Bindable property key for <see cref="NormalizedValue"/>.</summary>
+    private static readonly BindablePropertyKey NormalizedValuePropertyKey;
+
+    /// <summary>Bindable property key for <see cref="HasValidValue"/>.</summary>
+    private static readonly BindablePropertyKey HasValidValuePropertyKey;
+
+    /// <summary>Bindable property key for <see cref="IsAlarm"/>.</summary>
+    private static readonly BindablePropertyKey IsAlarmPropertyKey;
+
+    /// <summary>Bindable property key for <see cref="Status"/>.</summary>
+    private static readonly BindablePropertyKey StatusPropertyKey;
+
+    /// <summary>Displays the process label.</summary>
+    private readonly Label _label = new() { FontAttributes = FontAttributes.Bold, FontSize = MetadataFontSize };
+
+    /// <summary>Displays the process value and unit.</summary>
+    private readonly Label _value = new() { FontAttributes = FontAttributes.Bold, FontSize = ValueFontSize };
+
+    /// <summary>Displays the process condition text.</summary>
+    private readonly Label _status = new() { FontSize = MetadataFontSize };
+
+    /// <summary>Hosts the normalized range bar.</summary>
+    private readonly Grid _bar = new() { HeightRequest = RangeBarHeight };
+
+    /// <summary>Displays the normalized range fill.</summary>
+    private readonly BoxView _barFill = new() { HorizontalOptions = LayoutOptions.Start };
+
+    /// <summary>Initializes static members of the <see cref="ProcessValueIndicator"/> class.</summary>
+    static ProcessValueIndicator()
+    {
+        StateProperty = BindableProperty.Create(
+            nameof(State),
+            typeof(ProcessValueState),
+            typeof(ProcessValueIndicator),
+            propertyChanged: static (view, _, _) => ((ProcessValueIndicator)view).Refresh());
+        LabelPropertyKey = CreateReadOnlyProperty(nameof(Label), EmptyState.Label);
+        DisplayTextPropertyKey = CreateReadOnlyProperty(nameof(DisplayText), EmptyState.DisplayText);
+        StatusTextPropertyKey = CreateReadOnlyProperty(nameof(StatusText), EmptyState.StatusText);
+        PercentagePropertyKey = CreateReadOnlyProperty(nameof(Percentage), EmptyState.Percentage);
+        NormalizedValuePropertyKey = CreateReadOnlyProperty(nameof(NormalizedValue), EmptyState.NormalizedValue);
+        HasValidValuePropertyKey = CreateReadOnlyProperty(nameof(HasValidValue), EmptyState.HasValidValue);
+        IsAlarmPropertyKey = CreateReadOnlyProperty(nameof(IsAlarm), EmptyState.IsAlarm);
+        StatusPropertyKey = CreateReadOnlyProperty(nameof(Status), EmptyState.Status);
+        LabelProperty = LabelPropertyKey.BindableProperty;
+        DisplayTextProperty = DisplayTextPropertyKey.BindableProperty;
+        StatusTextProperty = StatusTextPropertyKey.BindableProperty;
+        PercentageProperty = PercentagePropertyKey.BindableProperty;
+        NormalizedValueProperty = NormalizedValuePropertyKey.BindableProperty;
+        HasValidValueProperty = HasValidValuePropertyKey.BindableProperty;
+        IsAlarmProperty = IsAlarmPropertyKey.BindableProperty;
+        StatusProperty = StatusPropertyKey.BindableProperty;
+        NormalStatusColorProperty = CreateThemeColorProperty(nameof(NormalStatusColor));
+        AlarmStatusColorProperty = CreateThemeColorProperty(nameof(AlarmStatusColor));
+        BadQualityStatusColorProperty = CreateThemeColorProperty(nameof(BadQualityStatusColor));
+        InvalidConfigurationStatusColorProperty = CreateThemeColorProperty(nameof(InvalidConfigurationStatusColor));
+        RangeTrackColorProperty = CreateThemeColorProperty(nameof(RangeTrackColor));
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="ProcessValueIndicator"/> class.</summary>
+    public ProcessValueIndicator()
+    {
+        var layout = new VerticalStackLayout { Spacing = LayoutSpacing, Children = { _label, _value, _bar, _status } };
+        _bar.Children.Add(_barFill);
+        _bar.SizeChanged += (_, _) => RefreshBarWidth();
+        Content = layout;
+        Refresh();
+    }
+
+    /// <summary>Gets or sets the process-value snapshot projected by the control.</summary>
+    public ProcessValueState? State
+    {
+        get => (ProcessValueState?)GetValue(StateProperty);
+        set => SetValue(StateProperty, value);
+    }
+
+    /// <summary>Gets the measurement label projected from <see cref="State"/>.</summary>
+    public string Label
+    {
+        get => (string)GetValue(LabelProperty);
+        private set => SetValue(LabelPropertyKey, value);
+    }
+
+    /// <summary>Gets the measurement text projected from <see cref="State"/>.</summary>
+    public string DisplayText
+    {
+        get => (string)GetValue(DisplayTextProperty);
+        private set => SetValue(DisplayTextPropertyKey, value);
+    }
+
+    /// <summary>Gets the condition text projected from <see cref="State"/>.</summary>
+    public string StatusText
+    {
+        get => (string)GetValue(StatusTextProperty);
+        private set => SetValue(StatusTextPropertyKey, value);
+    }
+
+    /// <summary>Gets the range percentage projected from <see cref="State"/>.</summary>
+    public double Percentage
+    {
+        get => (double)GetValue(PercentageProperty);
+        private set => SetValue(PercentagePropertyKey, value);
+    }
+
+    /// <summary>Gets the normalized range position projected from <see cref="State"/>.</summary>
+    public double NormalizedValue
+    {
+        get => (double)GetValue(NormalizedValueProperty);
+        private set => SetValue(NormalizedValuePropertyKey, value);
+    }
+
+    /// <summary>Gets a value indicating whether the current reading is displayable.</summary>
+    public bool HasValidValue
+    {
+        get => (bool)GetValue(HasValidValueProperty);
+        private set => SetValue(HasValidValuePropertyKey, value);
+    }
+
+    /// <summary>Gets a value indicating whether the current reading is in alarm.</summary>
+    public bool IsAlarm
+    {
+        get => (bool)GetValue(IsAlarmProperty);
+        private set => SetValue(IsAlarmPropertyKey, value);
+    }
+
+    /// <summary>Gets the current process-value condition.</summary>
+    public ProcessValueStatus Status
+    {
+        get => (ProcessValueStatus)GetValue(StatusProperty);
+        private set => SetValue(StatusPropertyKey, value);
+    }
+
+    /// <summary>Gets or sets the theme color used for normal readings.</summary>
+    public Color? NormalStatusColor
+    {
+        get => (Color?)GetValue(NormalStatusColorProperty);
+        set => SetValue(NormalStatusColorProperty, value);
+    }
+
+    /// <summary>Gets or sets the theme color used for alarm readings.</summary>
+    public Color? AlarmStatusColor
+    {
+        get => (Color?)GetValue(AlarmStatusColorProperty);
+        set => SetValue(AlarmStatusColorProperty, value);
+    }
+
+    /// <summary>Gets or sets the theme color used for bad-quality readings.</summary>
+    public Color? BadQualityStatusColor
+    {
+        get => (Color?)GetValue(BadQualityStatusColorProperty);
+        set => SetValue(BadQualityStatusColorProperty, value);
+    }
+
+    /// <summary>Gets or sets the theme color used for invalid configuration readings.</summary>
+    public Color? InvalidConfigurationStatusColor
+    {
+        get => (Color?)GetValue(InvalidConfigurationStatusColorProperty);
+        set => SetValue(InvalidConfigurationStatusColorProperty, value);
+    }
+
+    /// <summary>Gets or sets the theme color used for the unfilled range track.</summary>
+    public Color? RangeTrackColor
+    {
+        get => (Color?)GetValue(RangeTrackColorProperty);
+        set => SetValue(RangeTrackColorProperty, value);
+    }
+
+    /// <summary>Creates a read-only bindable property key for a projected state value.</summary>
+    /// <typeparam name="T">The property value type.</typeparam>
+    /// <param name="name">The public property name.</param>
+    /// <param name="defaultValue">The default value.</param>
+    /// <returns>The read-only bindable property key.</returns>
+    private static BindablePropertyKey CreateReadOnlyProperty<T>(string name, T defaultValue) => BindableProperty.CreateReadOnly(
+        name,
+        typeof(T),
+        typeof(ProcessValueIndicator),
+        defaultValue);
+
+    /// <summary>Creates a theme color property that refreshes the composed native view.</summary>
+    /// <param name="name">The public property name.</param>
+    /// <returns>The bindable property definition.</returns>
+    private static BindableProperty CreateThemeColorProperty(string name) => BindableProperty.Create(
+        name,
+        typeof(Color),
+        typeof(ProcessValueIndicator),
+        propertyChanged: static (view, _, _) => ((ProcessValueIndicator)view).ApplyStatusTheme());
+
+    /// <summary>Updates the visual and accessibility projection from the current state snapshot.</summary>
+    private void Refresh()
+    {
+        var state = State ?? EmptyState;
+        Label = state.Label;
+        DisplayText = state.DisplayText;
+        StatusText = state.StatusText;
+        Percentage = state.Percentage;
+        NormalizedValue = state.NormalizedValue;
+        HasValidValue = state.HasValidValue;
+        IsAlarm = state.IsAlarm;
+        Status = state.Status;
+
+        _label.Text = Label;
+        _label.IsVisible = !string.IsNullOrWhiteSpace(Label);
+        _value.Text = DisplayText;
+        _status.Text = StatusText;
+        ApplyStatusTheme();
+        RefreshBarWidth();
+        SemanticProperties.SetDescription(this, $"{Label} {DisplayText} {StatusText}".Trim());
+    }
+
+    /// <summary>Updates semantic colors for the current condition.</summary>
+    private void ApplyStatusTheme()
+    {
+        var statusColor = Status switch
+        {
+            ProcessValueStatus.LowAlarm or ProcessValueStatus.HighAlarm => AlarmStatusColor,
+            ProcessValueStatus.BadQuality => BadQualityStatusColor,
+            ProcessValueStatus.InvalidConfiguration => InvalidConfigurationStatusColor,
+            _ => NormalStatusColor,
+        };
+
+        _status.TextColor = statusColor;
+        _barFill.Color = statusColor;
+        _bar.BackgroundColor = RangeTrackColor;
+    }
+
+    /// <summary>Updates the filled range bar width from the current percentage.</summary>
+    private void RefreshBarWidth()
+    {
+        var width = _bar.Width;
+        if (width <= 0)
+        {
+            return;
+        }
+
+        var fillWidth = width * Math.Clamp(Percentage, 0, MaximumPercentage) / MaximumPercentage;
+        _barFill.WidthRequest = fillWidth <= 0 ? 0 : Math.Max(fillWidth, MinimumFilledBarWidth);
+    }
+}

--- a/src/CrissCross.Maui.UI/Controls/PropertyGridLite.cs
+++ b/src/CrissCross.Maui.UI/Controls/PropertyGridLite.cs
@@ -2,6 +2,8 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Globalization;
+
 namespace CrissCross.Maui.UI.Controls;
 
 /// <summary>Displays categorized editable property descriptors without reflection-heavy discovery.</summary>
@@ -11,13 +13,88 @@ public class PropertyGridLite : ContentView
     public static readonly BindableProperty PropertyGridStateProperty = BindableProperty.Create(
         nameof(PropertyGridState),
         typeof(PropertyGridState),
-        typeof(PropertyGridLite));
+        typeof(PropertyGridLite),
+        propertyChanged: static (bindable, _, newValue) => OnPropertyGridStateChanged(bindable, newValue));
 
     /// <summary>Bindable property for <see cref="UpdatePropertyCommand"/>.</summary>
     public static readonly BindableProperty UpdatePropertyCommandProperty = BindableProperty.Create(
         nameof(UpdatePropertyCommand),
         typeof(ICommand),
-        typeof(PropertyGridLite));
+        typeof(PropertyGridLite),
+        propertyChanged: static (bindable, _, _) => OnCommandChanged(bindable));
+
+    /// <summary>Bindable property for <see cref="CommitChangesCommand"/>.</summary>
+    public static readonly BindableProperty CommitChangesCommandProperty = BindableProperty.Create(
+        nameof(CommitChangesCommand),
+        typeof(ICommand),
+        typeof(PropertyGridLite),
+        propertyChanged: static (bindable, _, _) => OnCommandChanged(bindable));
+
+    /// <summary>Bindable property for <see cref="SearchText"/>.</summary>
+    public static readonly BindableProperty SearchTextProperty = BindableProperty.Create(
+        nameof(SearchText),
+        typeof(string),
+        typeof(PropertyGridLite),
+        propertyChanged: static (bindable, _, _) => OnSearchTextChanged(bindable));
+
+    /// <summary>Semantic text color resource key.</summary>
+    private const string TextColorResourceKey = "CrissCrossTextColor";
+
+    /// <summary>Semantic accent color resource key.</summary>
+    private const string AccentColorResourceKey = "CrissCrossAccentColor";
+
+    /// <summary>Semantic accent text color resource key.</summary>
+    private const string AccentTextColorResourceKey = "CrissCrossAccentTextColor";
+
+    /// <summary>Semantic warning text color resource key.</summary>
+    private const string WarningTextColorResourceKey = "CrissCrossWarningTextColor";
+
+    /// <summary>Horizontal action padding.</summary>
+    private const double ActionPaddingHorizontal = 10D;
+
+    /// <summary>Vertical action padding.</summary>
+    private const double ActionPaddingVertical = 6D;
+
+    /// <summary>Minimum action width.</summary>
+    private const double ActionMinimumWidth = 120D;
+
+    /// <summary>Root layout spacing.</summary>
+    private const double RootSpacing = 12D;
+
+    /// <summary>Root vertical padding.</summary>
+    private const double RootPaddingVertical = 4D;
+
+    /// <summary>Group presenter spacing.</summary>
+    private const double GroupSpacing = 8D;
+
+    /// <summary>Group presenter vertical padding.</summary>
+    private const double GroupPaddingVertical = 4D;
+
+    /// <summary>Descriptor presenter spacing.</summary>
+    private const double DescriptorSpacing = 4D;
+
+    /// <summary>Descriptor presenter vertical padding.</summary>
+    private const double DescriptorPaddingVertical = 4D;
+
+    /// <summary>Stores edited descriptors by stable property key.</summary>
+    private readonly Dictionary<string, PropertyDescriptorModel> _editedDescriptors = [];
+
+    /// <summary>Displays current property grid summary.</summary>
+    private readonly Label _summaryLabel = CreateLabel("No properties", FontAttributes.Bold);
+
+    /// <summary>Hosts category and editor presenters.</summary>
+    private readonly VerticalStackLayout _groupHost = new() { Spacing = RootSpacing };
+
+    /// <summary>Commits pending edits.</summary>
+    private readonly Button _commitButton = CreateActionButton("Commit changes");
+
+    /// <summary>Initializes a new instance of the <see cref="PropertyGridLite"/> class.</summary>
+    public PropertyGridLite()
+    {
+        CommitCommand = new GridCommand(CommitChanges, CanCommitChanges);
+        Content = CreateLayout();
+        ApplyState(new());
+    }
 
     /// <summary>Gets or sets the shared CrissCross state projected by this control.</summary>
     public PropertyGridState? PropertyGridState
@@ -31,5 +108,377 @@ public class PropertyGridLite : ContentView
     {
         get => (ICommand?)GetValue(UpdatePropertyCommandProperty);
         set => SetValue(UpdatePropertyCommandProperty, value);
+    }
+
+    /// <summary>Gets or sets the command invoked when edited descriptors are committed.</summary>
+    public ICommand? CommitChangesCommand
+    {
+        get => (ICommand?)GetValue(CommitChangesCommandProperty);
+        set => SetValue(CommitChangesCommandProperty, value);
+    }
+
+    /// <summary>Gets or sets search text used to project visible descriptors.</summary>
+    public string? SearchText
+    {
+        get => (string?)GetValue(SearchTextProperty);
+        set => SetValue(SearchTextProperty, value);
+    }
+
+    /// <summary>Gets the command that commits current property edits.</summary>
+    public ICommand CommitCommand { get; }
+
+    /// <summary>Edits a property descriptor value using the public descriptor model.</summary>
+    /// <param name="descriptorKey">The stable descriptor key.</param>
+    /// <param name="value">The edited value.</param>
+    /// <returns><c>true</c> when the descriptor exists and accepts edits.</returns>
+    public bool EditProperty(string descriptorKey, object? value)
+    {
+        var descriptor = PropertyGridState?.GetDescriptor(descriptorKey);
+        if (descriptor is not { CanEdit: true })
+        {
+            return false;
+        }
+
+        var updatedDescriptor = descriptor.WithValue(value);
+        _editedDescriptors[updatedDescriptor.Key] = updatedDescriptor;
+        ExecuteSetValueCommand(updatedDescriptor);
+        ApplyState(CreateCurrentState());
+        return true;
+    }
+
+    /// <summary>Commits current property edits using the configured command.</summary>
+    /// <returns><c>true</c> when the commit command was executed.</returns>
+    public bool CommitChanges()
+    {
+        var state = CreateCurrentState();
+        if (!state.CanCommit)
+        {
+            return false;
+        }
+
+        var command = CommitChangesCommand ?? UpdatePropertyCommand;
+        if (command?.CanExecute(state) != true)
+        {
+            return false;
+        }
+
+        command.Execute(state);
+        return true;
+    }
+
+    /// <summary>Creates a state snapshot from the current property editor values.</summary>
+    /// <returns>The projected property grid state.</returns>
+    public PropertyGridState CreateCurrentState()
+    {
+        var state = PropertyGridState;
+        if (state is null)
+        {
+            return new();
+        }
+
+        var descriptors = new List<PropertyDescriptorModel>(state.Descriptors.Count);
+        foreach (var descriptor in state.Descriptors)
+        {
+            descriptors.Add(_editedDescriptors.TryGetValue(descriptor.Key, out var editedDescriptor) ? editedDescriptor : descriptor);
+        }
+
+        return new(descriptors, SearchText ?? state.SearchText, state.IsCommitting);
+    }
+
+    /// <summary>Creates a label using semantic theme color resources.</summary>
+    /// <param name="text">The label text.</param>
+    /// <param name="fontAttributes">The font attributes.</param>
+    /// <returns>The configured label.</returns>
+    private static Label CreateLabel(string text, FontAttributes fontAttributes)
+    {
+        var label = new Label { Text = text, FontAttributes = fontAttributes, VerticalTextAlignment = TextAlignment.Center };
+        label.SetDynamicResource(Label.TextColorProperty, TextColorResourceKey);
+        return label;
+    }
+
+    /// <summary>Creates an action button using semantic theme color resources.</summary>
+    /// <param name="text">The button text.</param>
+    /// <returns>The configured button.</returns>
+    private static Button CreateActionButton(string text)
+    {
+        var button = new Button { Text = text, Padding = new(ActionPaddingHorizontal, ActionPaddingVertical), MinimumWidthRequest = ActionMinimumWidth };
+        button.SetDynamicResource(Button.BackgroundColorProperty, AccentColorResourceKey);
+        button.SetDynamicResource(Button.TextColorProperty, AccentTextColorResourceKey);
+        return button;
+    }
+
+    /// <summary>Runs when the grid state changes.</summary>
+    /// <param name="bindable">The bindable object.</param>
+    /// <param name="newValue">The new value.</param>
+    private static void OnPropertyGridStateChanged(BindableObject bindable, object? newValue)
+    {
+        if (bindable is not PropertyGridLite grid)
+        {
+            return;
+        }
+
+        grid._editedDescriptors.Clear();
+        grid.ApplyState(newValue as PropertyGridState ?? new());
+    }
+
+    /// <summary>Runs when command availability changes.</summary>
+    /// <param name="bindable">The bindable object.</param>
+    private static void OnCommandChanged(BindableObject bindable)
+    {
+        if (bindable is not PropertyGridLite grid)
+        {
+            return;
+        }
+
+        grid.RaiseCommandAvailability();
+    }
+
+    /// <summary>Runs when search text changes.</summary>
+    /// <param name="bindable">The bindable object.</param>
+    private static void OnSearchTextChanged(BindableObject bindable)
+    {
+        if (bindable is not PropertyGridLite grid)
+        {
+            return;
+        }
+
+        grid.ApplyState(grid.CreateCurrentState());
+    }
+
+    /// <summary>Adds validation messages to a descriptor presenter.</summary>
+    /// <param name="row">The descriptor row.</param>
+    /// <param name="descriptor">The descriptor.</param>
+    private static void AddValidationMessages(VerticalStackLayout row, PropertyDescriptorModel descriptor)
+    {
+        foreach (var message in descriptor.ValidationMessages)
+        {
+            var label = CreateLabel(message.DisplayText, FontAttributes.Italic);
+            label.SetDynamicResource(Label.TextColorProperty, WarningTextColorResourceKey);
+            SemanticProperties.SetDescription(label, message.DisplayText);
+            row.Children.Add(label);
+        }
+    }
+
+    /// <summary>Executes a descriptor-level set-value command.</summary>
+    /// <param name="descriptor">The updated descriptor.</param>
+    private static void ExecuteSetValueCommand(PropertyDescriptorModel descriptor)
+    {
+        if (descriptor.SetValueCommand?.CanExecute(descriptor) != true)
+        {
+            return;
+        }
+
+        descriptor.SetValueCommand.Execute(descriptor);
+    }
+
+    /// <summary>Finds the index of a choice value.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <param name="value">The value.</param>
+    /// <returns>The choice index, or -1.</returns>
+    private static int FindChoiceIndex(PropertyDescriptorModel descriptor, object? value)
+    {
+        for (var index = 0; index < descriptor.Choices.Count; index++)
+        {
+            if (Equals(descriptor.Choices[index], value))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>Creates a read-only value presenter.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <returns>The value presenter.</returns>
+    private static Label CreateReadOnlyPresenter(PropertyDescriptorModel descriptor)
+    {
+        var label = CreateLabel(descriptor.ValueDisplayText, FontAttributes.Italic);
+        SemanticProperties.SetDescription(label, $"{descriptor.DisplayName} read only");
+        return label;
+    }
+
+    /// <summary>Creates the root layout.</summary>
+    /// <returns>The root layout.</returns>
+    private VerticalStackLayout CreateLayout()
+    {
+        var root = new VerticalStackLayout { Spacing = RootSpacing, Padding = new(0D, RootPaddingVertical) };
+        root.Children.Add(_summaryLabel);
+        root.Children.Add(_groupHost);
+        root.Children.Add(_commitButton);
+        return root;
+    }
+
+    /// <summary>Applies grid state to native child presenters.</summary>
+    /// <param name="state">The grid state.</param>
+    private void ApplyState(PropertyGridState state)
+    {
+        _groupHost.Children.Clear();
+        _summaryLabel.Text = state.SummaryText;
+        foreach (var group in state.Categories)
+        {
+            _groupHost.Children.Add(CreateGroupPresenter(group));
+        }
+
+        RaiseCommandAvailability();
+        SemanticProperties.SetDescription(this, _summaryLabel.Text);
+    }
+
+    /// <summary>Creates a category presenter.</summary>
+    /// <param name="group">The descriptor group.</param>
+    /// <returns>The group presenter.</returns>
+    private VerticalStackLayout CreateGroupPresenter(PropertyDescriptorGroup group)
+    {
+        var container = new VerticalStackLayout { Spacing = GroupSpacing, Padding = new(0D, GroupPaddingVertical) };
+        container.Children.Add(CreateLabel(group.Name, FontAttributes.Bold));
+        foreach (var descriptor in group.Descriptors)
+        {
+            container.Children.Add(CreateDescriptorPresenter(descriptor));
+        }
+
+        SemanticProperties.SetDescription(container, group.Name);
+        return container;
+    }
+
+    /// <summary>Creates a descriptor presenter.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <returns>The descriptor presenter.</returns>
+    private VerticalStackLayout CreateDescriptorPresenter(PropertyDescriptorModel descriptor)
+    {
+        var row = new VerticalStackLayout { Spacing = DescriptorSpacing, Padding = new(0D, DescriptorPaddingVertical) };
+        row.Children.Add(CreateLabel(descriptor.DisplayName, FontAttributes.None));
+        row.Children.Add(CreateValuePresenter(descriptor));
+        AddValidationMessages(row, descriptor);
+        SemanticProperties.SetDescription(row, $"{descriptor.DisplayName}: {descriptor.ValueDisplayText}");
+        return row;
+    }
+
+    /// <summary>Creates the value editor for a descriptor.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <returns>The value presenter.</returns>
+    private View CreateValuePresenter(PropertyDescriptorModel descriptor) => !descriptor.CanEdit
+        ? CreateReadOnlyPresenter(descriptor)
+        : descriptor.EditorKind switch
+        {
+            PropertyEditorKind.Boolean => CreateBooleanEditor(descriptor),
+            PropertyEditorKind.Enum => CreateChoiceEditor(descriptor),
+            PropertyEditorKind.Date or PropertyEditorKind.DateTime => CreateDateEditor(descriptor),
+            PropertyEditorKind.Command => CreateCommandPresenter(descriptor),
+            PropertyEditorKind.Number => CreateTextEditor(descriptor, Keyboard.Numeric),
+            _ => CreateTextEditor(descriptor, Keyboard.Text),
+        };
+
+    /// <summary>Creates a text editor.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <param name="keyboard">The keyboard type.</param>
+    /// <returns>The editor.</returns>
+    private Entry CreateTextEditor(PropertyDescriptorModel descriptor, Keyboard keyboard)
+    {
+        var entry = new Entry { Text = descriptor.ValueDisplayText, Keyboard = keyboard };
+        entry.SetDynamicResource(Entry.TextColorProperty, TextColorResourceKey);
+        entry.TextChanged += (_, args) => _ = EditProperty(descriptor.Key, args.NewTextValue);
+        return entry;
+    }
+
+    /// <summary>Creates a boolean editor.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <returns>The editor.</returns>
+    private Switch CreateBooleanEditor(PropertyDescriptorModel descriptor)
+    {
+        var toggle = new Switch { IsToggled = descriptor.Value is true };
+        toggle.Toggled += (_, args) => _ = EditProperty(descriptor.Key, args.Value);
+        return toggle;
+    }
+
+    /// <summary>Creates an explicit choice editor.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <returns>The editor.</returns>
+    private Picker CreateChoiceEditor(PropertyDescriptorModel descriptor)
+    {
+        var picker = new Picker { Title = descriptor.DisplayName };
+        picker.SetDynamicResource(Picker.TextColorProperty, TextColorResourceKey);
+        foreach (var choice in descriptor.Choices)
+        {
+            picker.Items.Add(Convert.ToString(choice, CultureInfo.InvariantCulture) ?? string.Empty);
+        }
+
+        picker.SelectedIndex = FindChoiceIndex(descriptor, descriptor.Value);
+        picker.SelectedIndexChanged += (_, _) => ApplySelectedChoice(descriptor, picker);
+        return picker;
+    }
+
+    /// <summary>Creates a date editor.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <returns>The editor.</returns>
+    private DatePicker CreateDateEditor(PropertyDescriptorModel descriptor)
+    {
+        var datePicker = new DatePicker { Date = descriptor.Value is DateTime date ? date : DateTime.Today };
+        datePicker.SetDynamicResource(DatePicker.TextColorProperty, TextColorResourceKey);
+        datePicker.DateSelected += (_, args) => _ = EditProperty(descriptor.Key, args.NewDate);
+        return datePicker;
+    }
+
+    /// <summary>Creates a command presenter.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <returns>The command presenter.</returns>
+    private Button CreateCommandPresenter(PropertyDescriptorModel descriptor)
+    {
+        var button = CreateActionButton(descriptor.DisplayName);
+        button.Command = descriptor.SetValueCommand;
+        button.CommandParameter = descriptor;
+        button.IsEnabled = descriptor.SetValueCommand?.CanExecute(descriptor) == true;
+        return button;
+    }
+
+    /// <summary>Applies a selected choice value.</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <param name="picker">The picker.</param>
+    private void ApplySelectedChoice(PropertyDescriptorModel descriptor, Picker picker)
+    {
+        if (picker.SelectedIndex < 0 || picker.SelectedIndex >= descriptor.Choices.Count)
+        {
+            return;
+        }
+
+        _ = EditProperty(descriptor.Key, descriptor.Choices[picker.SelectedIndex]);
+    }
+
+    /// <summary>Determines whether changes can be committed.</summary>
+    /// <returns><c>true</c> when changes can be committed.</returns>
+    private bool CanCommitChanges() => CreateCurrentState().CanCommit;
+
+    /// <summary>Refreshes the native commit button command binding and payload.</summary>
+    private void RefreshCommandTarget()
+    {
+        var state = CreateCurrentState();
+        var command = CommitChangesCommand ?? UpdatePropertyCommand;
+        _commitButton.Command = command;
+        _commitButton.CommandParameter = state;
+        _commitButton.IsEnabled = state.CanCommit && command?.CanExecute(state) == true;
+    }
+
+    /// <summary>Updates command and button availability.</summary>
+    private void RaiseCommandAvailability()
+    {
+        RefreshCommandTarget();
+        (CommitCommand as GridCommand)?.RaiseCanExecuteChanged();
+    }
+
+    /// <summary>Command wrapper for grid actions.</summary>
+    /// <param name="execute">The action to execute.</param>
+    /// <param name="canExecute">The command guard.</param>
+    private sealed class GridCommand(Func<bool> execute, Func<bool> canExecute) : ICommand
+    {
+        /// <inheritdoc />
+        public event EventHandler? CanExecuteChanged;
+
+        /// <inheritdoc />
+        public bool CanExecute(object? parameter) => canExecute();
+
+        /// <inheritdoc />
+        public void Execute(object? parameter) => _ = execute();
+
+        /// <summary>Raises command availability changes.</summary>
+        public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/src/CrissCross.Maui.UI/Controls/ReactiveFormField.cs
+++ b/src/CrissCross.Maui.UI/Controls/ReactiveFormField.cs
@@ -11,12 +11,214 @@ public class ReactiveFormField : ContentView
     public static readonly BindableProperty FieldStateProperty = BindableProperty.Create(
         nameof(FieldState),
         typeof(FormFieldState),
-        typeof(ReactiveFormField));
+        typeof(ReactiveFormField),
+        FormFieldState.Normal,
+        propertyChanged: static (view, _, value) => ((ReactiveFormField)view).State = (FormFieldState)value,
+        coerceValue: static (_, value) => value ?? FormFieldState.Normal);
+
+    /// <summary>Bindable property for <see cref="State"/>.</summary>
+    public static readonly BindableProperty StateProperty = BindableProperty.Create(
+        nameof(State),
+        typeof(FormFieldState),
+        typeof(ReactiveFormField),
+        FormFieldState.Normal,
+        propertyChanged: static (view, _, value) => ((ReactiveFormField)view).UpdateState((FormFieldState)value));
+
+    /// <summary>Bindable property for <see cref="Header"/>.</summary>
+    public static readonly BindableProperty HeaderProperty = CreateProperty<object?>(nameof(Header), null);
+
+    /// <summary>Bindable property for <see cref="HelperText"/>.</summary>
+    public static readonly BindableProperty HelperTextProperty = CreateProperty<string?>(nameof(HelperText), null);
+
+    /// <summary>Bindable property for <see cref="FieldKey"/>.</summary>
+    public static readonly BindableProperty FieldKeyProperty = CreateProperty<string?>(nameof(FieldKey), null);
+
+    /// <summary>Bindable property for <see cref="Messages"/>.</summary>
+    public static readonly BindableProperty MessagesProperty = CreateProperty<IEnumerable<ValidationMessage>?>(nameof(Messages), null);
+
+    /// <summary>Bindable property for <see cref="IsRequired"/>.</summary>
+    public static readonly BindableProperty IsRequiredProperty = CreateProperty(nameof(IsRequired), false);
+
+    /// <summary>Spacing between input metadata rows.</summary>
+    private const double RowSpacing = 6;
+
+    /// <summary>Visual state rail width.</summary>
+    private const double StateRailWidth = 3;
+
+    /// <summary>The semantic color used for secondary field metadata.</summary>
+    private const string MutedTextResource = "CrissCrossMutedTextColor";
+
+    /// <summary>The semantic color used for active input and pending validation.</summary>
+    private const string AccentResource = "CrissCrossAccentColor";
+
+    /// <summary>Hosts the field header.</summary>
+    private ContentView? _header;
+
+    /// <summary>Displays required-field metadata.</summary>
+    private Label? _required;
+
+    /// <summary>Displays input guidance.</summary>
+    private Label? _helper;
+
+    /// <summary>Displays validation state in text as well as color.</summary>
+    private Label? _status;
+
+    /// <summary>Displays the state accent beside the input.</summary>
+    private BoxView? _rail;
+
+    /// <summary>Hosts validation messages.</summary>
+    private VerticalStackLayout? _messages;
+
+    /// <summary>Initializes a new instance of the <see cref="ReactiveFormField"/> class.</summary>
+    public ReactiveFormField() => ControlTemplate = new(CreateTemplate);
 
     /// <summary>Gets or sets the shared CrissCross state projected by this control.</summary>
     public FormFieldState? FieldState
     {
         get => (FormFieldState?)GetValue(FieldStateProperty);
-        set => SetValue(FieldStateProperty, value);
+        set => SetValue(FieldStateProperty, value ?? FormFieldState.Normal);
+    }
+
+    /// <summary>Gets or sets the current field validation state.</summary>
+    public FormFieldState State
+    {
+        get => (FormFieldState)GetValue(StateProperty);
+        set => SetValue(StateProperty, value);
+    }
+
+    /// <summary>Gets or sets the field header content.</summary>
+    public object? Header
+    {
+        get => GetValue(HeaderProperty);
+        set => SetValue(HeaderProperty, value);
+    }
+
+    /// <summary>Gets or sets guidance displayed below the input.</summary>
+    public string? HelperText
+    {
+        get => (string?)GetValue(HelperTextProperty);
+        set => SetValue(HelperTextProperty, value);
+    }
+
+    /// <summary>Gets or sets the stable validation field key.</summary>
+    public string? FieldKey
+    {
+        get => (string?)GetValue(FieldKeyProperty);
+        set => SetValue(FieldKeyProperty, value);
+    }
+
+    /// <summary>Gets or sets the validation messages displayed for this field.</summary>
+    public IEnumerable<ValidationMessage>? Messages
+    {
+        get => (IEnumerable<ValidationMessage>?)GetValue(MessagesProperty);
+        set => SetValue(MessagesProperty, value);
+    }
+
+    /// <summary>Gets or sets a value indicating whether input is required.</summary>
+    public bool IsRequired
+    {
+        get => (bool)GetValue(IsRequiredProperty);
+        set => SetValue(IsRequiredProperty, value);
+    }
+
+    /// <summary>Creates a property that refreshes the composed template.</summary>
+    /// <typeparam name="T">The property value type.</typeparam>
+    /// <param name="name">The property name.</param>
+    /// <param name="defaultValue">The initial value.</param>
+    /// <returns>The bindable property.</returns>
+    private static BindableProperty CreateProperty<T>(string name, T defaultValue) => BindableProperty.Create(
+        name,
+        typeof(T),
+        typeof(ReactiveFormField),
+        defaultValue,
+        propertyChanged: static (view, _, _) => ((ReactiveFormField)view).Refresh());
+
+    /// <summary>Creates the input slot and its surrounding metadata.</summary>
+    /// <returns>The composed template root.</returns>
+    private VerticalStackLayout CreateTemplate()
+    {
+        _header = new();
+        _required = new() { Text = "Required" };
+        _helper = new();
+        _status = new();
+        _rail = new() { WidthRequest = StateRailWidth };
+        _messages = new() { Spacing = RowSpacing };
+        _required.SetDynamicResource(Label.TextColorProperty, MutedTextResource);
+        _helper.SetDynamicResource(Label.TextColorProperty, MutedTextResource);
+        var presenter = new ContentPresenter();
+        var input = new Grid { ColumnSpacing = RowSpacing, ColumnDefinitions = [new(GridLength.Auto), new(GridLength.Star)], Children = { _rail, presenter } };
+        Grid.SetColumn(presenter, 1);
+        var layout = new VerticalStackLayout { Spacing = RowSpacing, Children = { _header, _required, input, _helper, _status, _messages } };
+        Refresh();
+        return layout;
+    }
+
+    /// <summary>Keeps both state properties synchronized.</summary>
+    /// <param name="state">The current state.</param>
+    private void UpdateState(FormFieldState state)
+    {
+        SetValue(FieldStateProperty, state);
+        Refresh();
+    }
+
+    /// <summary>Refreshes metadata and accessible validation feedback.</summary>
+    private void Refresh()
+    {
+        if (_header is null || _required is null || _helper is null || _status is null || _rail is null || _messages is null)
+        {
+            return;
+        }
+
+        _header.Content = Header as View ?? new Label { Text = Header?.ToString(), FontAttributes = FontAttributes.Bold };
+        _header.IsVisible = Header is not null;
+        _required.IsVisible = IsRequired;
+        _helper.Text = HelperText;
+        _helper.IsVisible = !string.IsNullOrWhiteSpace(HelperText);
+        RefreshStatus(_status, _rail);
+        RefreshMessages(_messages);
+        SemanticProperties.SetDescription(this, $"{FieldKey} {Header} {(IsRequired ? "Required" : string.Empty)} {_status.Text} {HelperText}".Trim());
+    }
+
+    /// <summary>Updates the visible validation state.</summary>
+    /// <param name="status">The status label.</param>
+    /// <param name="rail">The input state rail.</param>
+    private void RefreshStatus(Label status, BoxView rail)
+    {
+        var (text, stateResource) = State switch
+        {
+            FormFieldState.Focused => ("Focused", AccentResource),
+            FormFieldState.Valid => ("Valid", "CrissCrossSuccessColor"),
+            FormFieldState.Warning => ("Warning", "CrissCrossCautionColor"),
+            FormFieldState.Invalid => ("Invalid", "CrissCrossDangerColor"),
+            FormFieldState.Pending => ("Validating…", AccentResource),
+            _ => (string.Empty, "CrissCrossBorderColor"),
+        };
+        status.Text = text;
+        status.IsVisible = State != FormFieldState.Normal;
+        status.SetDynamicResource(Label.TextColorProperty, stateResource);
+        rail.SetDynamicResource(BoxView.ColorProperty, stateResource);
+    }
+
+    /// <summary>Updates validation messages from the current snapshot.</summary>
+    /// <param name="messages">The message panel.</param>
+    private void RefreshMessages(VerticalStackLayout messages)
+    {
+        messages.Children.Clear();
+        foreach (var message in Messages ?? [])
+        {
+            var label = new Label { Text = message.Message };
+            var resource = message.Severity switch
+            {
+                ValidationSeverity.Error => "CrissCrossDangerColor",
+                ValidationSeverity.Warning => "CrissCrossCautionColor",
+                ValidationSeverity.Success => "CrissCrossSuccessColor",
+                ValidationSeverity.Pending => AccentResource,
+                _ => MutedTextResource,
+            };
+            label.SetDynamicResource(Label.TextColorProperty, resource);
+            messages.Children.Add(label);
+        }
+
+        messages.IsVisible = messages.Children.Count > 0;
     }
 }

--- a/src/CrissCross.Maui.UI/Controls/Stepper.cs
+++ b/src/CrissCross.Maui.UI/Controls/Stepper.cs
@@ -11,13 +11,106 @@ public class Stepper : ContentView
     public static readonly BindableProperty StepperStateProperty = BindableProperty.Create(
         nameof(StepperState),
         typeof(StepperState),
-        typeof(Stepper));
+        typeof(Stepper),
+        propertyChanged: static (view, _, _) => ((Stepper)view).Refresh());
 
     /// <summary>Bindable property for <see cref="StepCommand"/>.</summary>
     public static readonly BindableProperty StepCommandProperty = BindableProperty.Create(
         nameof(StepCommand),
         typeof(ICommand),
-        typeof(Stepper));
+        typeof(Stepper),
+        propertyChanged: static (view, _, _) => ((Stepper)view).Refresh());
+
+    /// <summary>Provides default spacing between rendered steps.</summary>
+    private const double StepSpacing = 8;
+
+    /// <summary>Provides default spacing between command buttons.</summary>
+    private const double ActionSpacing = 8;
+
+    /// <summary>Provides the default width for step status glyphs.</summary>
+    private const double GlyphWidth = 24;
+
+    /// <summary>Provides the progress label font size.</summary>
+    private const double ProgressFontSize = 13;
+
+    /// <summary>Provides vertical default content padding.</summary>
+    private const double VerticalPadding = 4;
+
+    /// <summary>Provides the previous navigation offset.</summary>
+    private const int PreviousStepOffset = -1;
+
+    /// <summary>Provides the next navigation offset.</summary>
+    private const int NextStepOffset = 1;
+
+    /// <summary>Provides the primary text semantic resource key.</summary>
+    private const string TextColorResourceKey = "CrissCrossTextColor";
+
+    /// <summary>Provides the muted text semantic resource key.</summary>
+    private const string MutedTextColorResourceKey = "CrissCrossMutedTextColor";
+
+    /// <summary>Provides the accent fill semantic resource key.</summary>
+    private const string AccentColorResourceKey = "CrissCrossAccentColor";
+
+    /// <summary>Provides the accent text semantic resource key.</summary>
+    private const string AccentTextColorResourceKey = "CrissCrossAccentTextColor";
+
+    /// <summary>Provides the neutral surface semantic resource key.</summary>
+    private const string NeutralSurfaceColorResourceKey = "CrissCrossNeutralSurfaceColor";
+
+    /// <summary>Provides the success semantic resource key.</summary>
+    private const string SuccessColorResourceKey = "CrissCrossSuccessColor";
+
+    /// <summary>Provides the caution semantic resource key.</summary>
+    private const string CautionColorResourceKey = "CrissCrossCautionColor";
+
+    /// <summary>Provides the danger semantic resource key.</summary>
+    private const string DangerColorResourceKey = "CrissCrossDangerColor";
+
+    /// <summary>Displays compact progress text.</summary>
+    private readonly Label _progress = new() { FontSize = ProgressFontSize };
+
+    /// <summary>Hosts rendered step rows.</summary>
+    private readonly VerticalStackLayout _steps = new() { Spacing = StepSpacing };
+
+    /// <summary>Moves to the previous allowed step.</summary>
+    private readonly Button _previous = new() { Text = "Previous" };
+
+    /// <summary>Moves to the next allowed step.</summary>
+    private readonly Button _next = new() { Text = "Next" };
+
+    /// <summary>Emits a finish request when the state allows completion.</summary>
+    private readonly Button _finish = new() { Text = "Finish" };
+
+    /// <summary>Command that moves to the previous allowed step.</summary>
+    private readonly Command _previousCommand;
+
+    /// <summary>Command that moves to the next allowed step.</summary>
+    private readonly Command _nextCommand;
+
+    /// <summary>Command that emits a finish request when allowed.</summary>
+    private readonly Command _finishCommand;
+
+    /// <summary>Initializes a new instance of the <see cref="Stepper"/> class.</summary>
+    public Stepper()
+    {
+        _previousCommand = new(() => MoveBy(PreviousStepOffset), () => StepperState?.CanGoPrevious == true);
+        _nextCommand = new(() => MoveBy(NextStepOffset), () => StepperState?.CanGoNext == true);
+        _finishCommand = new(Finish, () => StepperState?.CanFinish == true);
+        _progress.SetDynamicResource(Label.TextColorProperty, MutedTextColorResourceKey);
+        _previous.SetDynamicResource(Button.BackgroundColorProperty, NeutralSurfaceColorResourceKey);
+        _previous.SetDynamicResource(Button.TextColorProperty, TextColorResourceKey);
+        _next.SetDynamicResource(Button.BackgroundColorProperty, AccentColorResourceKey);
+        _next.SetDynamicResource(Button.TextColorProperty, AccentTextColorResourceKey);
+        _finish.SetDynamicResource(Button.BackgroundColorProperty, AccentColorResourceKey);
+        _finish.SetDynamicResource(Button.TextColorProperty, AccentTextColorResourceKey);
+        _previous.Command = _previousCommand;
+        _next.Command = _nextCommand;
+        _finish.Command = _finishCommand;
+
+        HorizontalStackLayout actions = new() { Spacing = ActionSpacing, Children = { _previous, _next, _finish } };
+        Content = new VerticalStackLayout { Padding = new(0, VerticalPadding), Spacing = StepSpacing, Children = { _progress, _steps, actions } };
+        Refresh();
+    }
 
     /// <summary>Gets or sets the shared CrissCross state projected by this control.</summary>
     public StepperState? StepperState
@@ -31,5 +124,154 @@ public class Stepper : ContentView
     {
         get => (ICommand?)GetValue(StepCommandProperty);
         set => SetValue(StepCommandProperty, value);
+    }
+
+    /// <summary>Creates a label for one step descriptor.</summary>
+    /// <param name="step">The step descriptor.</param>
+    /// <param name="isCurrent">A value indicating whether the row represents the current step.</param>
+    /// <returns>The configured row.</returns>
+    private static HorizontalStackLayout CreateStepRow(StepDescriptor step, bool isCurrent)
+    {
+        Label glyph = new() { FontAttributes = FontAttributes.Bold, HorizontalTextAlignment = TextAlignment.Center, Text = GetStatusGlyph(step.Status, isCurrent), WidthRequest = GlyphWidth };
+        Label title = new() { FontAttributes = isCurrent ? FontAttributes.Bold : FontAttributes.None, Text = step.DisplayTitle };
+        glyph.SetDynamicResource(Label.TextColorProperty, GetStatusResource(step.Status, isCurrent));
+        title.SetDynamicResource(Label.TextColorProperty, step.IsAvailable ? TextColorResourceKey : MutedTextColorResourceKey);
+        return new() { Spacing = StepSpacing, Children = { glyph, title } };
+    }
+
+    /// <summary>Gets the glyph for a step status.</summary>
+    /// <param name="status">The step status.</param>
+    /// <param name="isCurrent">A value indicating whether the step is current.</param>
+    /// <returns>The visible glyph.</returns>
+    private static string GetStatusGlyph(StepStatus status, bool isCurrent) => status switch
+    {
+        StepStatus.Completed => "✓",
+        StepStatus.Skipped => "−",
+        StepStatus.Warning => "!",
+        StepStatus.Error => "×",
+        _ => isCurrent ? "●" : "○",
+    };
+
+    /// <summary>Gets the semantic resource key for a step status.</summary>
+    /// <param name="status">The step status.</param>
+    /// <param name="isCurrent">A value indicating whether the step is current.</param>
+    /// <returns>The dynamic resource key.</returns>
+    private static string GetStatusResource(StepStatus status, bool isCurrent) => status switch
+    {
+        StepStatus.Completed => SuccessColorResourceKey,
+        StepStatus.Warning => CautionColorResourceKey,
+        StepStatus.Error => DangerColorResourceKey,
+        _ => isCurrent ? AccentColorResourceKey : MutedTextColorResourceKey,
+    };
+
+    /// <summary>Gets a value indicating whether a relative move is allowed by current state.</summary>
+    /// <param name="state">The current stepper state.</param>
+    /// <param name="offset">The requested movement offset.</param>
+    /// <returns><c>true</c> when movement is allowed.</returns>
+    private static bool CanMove(StepperState state, int offset) => offset switch
+    {
+        PreviousStepOffset => state.CanGoPrevious,
+        NextStepOffset => state.CanGoNext,
+        _ => false,
+    };
+
+    /// <summary>Emits a finish request through the external command.</summary>
+    private void Finish()
+    {
+        var state = StepperState;
+        if (state?.CanFinish != true || state.CurrentStep is null)
+        {
+            return;
+        }
+
+        EmitStep(state.CurrentStep);
+    }
+
+    /// <summary>Moves relative to the current step when that movement is allowed.</summary>
+    /// <param name="offset">The relative step offset.</param>
+    private void MoveBy(int offset)
+    {
+        var state = StepperState;
+        if (state is null)
+        {
+            return;
+        }
+
+        var requestedIndex = state.CurrentIndex + offset;
+        if (!CanMove(state, offset) || requestedIndex < 0 || requestedIndex >= state.Steps.Count)
+        {
+            return;
+        }
+
+        EmitAvailableStep(state.Steps[requestedIndex]);
+    }
+
+    /// <summary>Emits a step only when it is available.</summary>
+    /// <param name="step">The requested step.</param>
+    private void EmitAvailableStep(StepDescriptor step)
+    {
+        if (!step.IsAvailable)
+        {
+            return;
+        }
+
+        EmitStep(step);
+    }
+
+    /// <summary>Emits an allowed step through per-step and aggregate commands.</summary>
+    /// <param name="step">The emitted step.</param>
+    private void EmitStep(StepDescriptor step)
+    {
+        var current = StepperState?.CurrentStep;
+        if (current?.LeaveCommand?.CanExecute(current) == true)
+        {
+            current.LeaveCommand.Execute(current);
+        }
+
+        if (step.EnterCommand?.CanExecute(step) == true)
+        {
+            step.EnterCommand.Execute(step);
+        }
+
+        if (StepCommand?.CanExecute(step) != true)
+        {
+            return;
+        }
+
+        StepCommand.Execute(step);
+    }
+
+    /// <summary>Updates the composed native content from the current stepper snapshot.</summary>
+    private void Refresh()
+    {
+        var state = StepperState;
+        _progress.Text = state?.ProgressText ?? "No steps";
+        _steps.Children.Clear();
+
+        if (state is null)
+        {
+            RefreshCommandAvailability();
+            SemanticProperties.SetDescription(this, _progress.Text ?? string.Empty);
+            return;
+        }
+
+        foreach (var step in state.Steps)
+        {
+            _steps.Children.Add(CreateStepRow(step, ReferenceEquals(step, state.CurrentStep)));
+        }
+
+        RefreshCommandAvailability();
+        SemanticProperties.SetDescription(this, _progress.Text ?? string.Empty);
+    }
+
+    /// <summary>Updates command availability and button enabled states.</summary>
+    private void RefreshCommandAvailability()
+    {
+        _previousCommand.ChangeCanExecute();
+        _nextCommand.ChangeCanExecute();
+        _finishCommand.ChangeCanExecute();
+        _previous.IsEnabled = _previousCommand.CanExecute(null);
+        _next.IsEnabled = _nextCommand.CanExecute(null);
+        _finish.IsEnabled = _finishCommand.CanExecute(null);
     }
 }

--- a/src/CrissCross.Maui.UI/Controls/ThemeSwitcher.cs
+++ b/src/CrissCross.Maui.UI/Controls/ThemeSwitcher.cs
@@ -2,6 +2,8 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using Microsoft.Maui.Layouts;
+
 namespace CrissCross.Maui.UI.Controls;
 
 /// <summary>Displays and changes a shared theme preference snapshot.</summary>
@@ -11,13 +13,34 @@ public class ThemeSwitcher : ContentView
     public static readonly BindableProperty ThemeStateProperty = BindableProperty.Create(
         nameof(ThemeState),
         typeof(ThemePreferenceState),
-        typeof(ThemeSwitcher));
+        typeof(ThemeSwitcher),
+        propertyChanged: static (bindable, _, newValue) => OnThemeStateChanged(bindable, newValue));
 
     /// <summary>Bindable property for <see cref="ChangeThemeCommand"/>.</summary>
     public static readonly BindableProperty ChangeThemeCommandProperty = BindableProperty.Create(
         nameof(ChangeThemeCommand),
         typeof(ICommand),
-        typeof(ThemeSwitcher));
+        typeof(ThemeSwitcher),
+        propertyChanged: static (bindable, _, _) => OnThemeCommandChanged(bindable));
+
+    /// <summary>Provides spacing for the composed theme switcher surface.</summary>
+    private const double LayoutSpacing = 6;
+
+    /// <summary>Provides default state when callers have not supplied a theme snapshot.</summary>
+    private static readonly ThemePreferenceState DefaultThemeState = new(ThemeChoice.System, ThemeChoice.Light, supportsHighContrast: true);
+
+    /// <summary>Displays the active theme description.</summary>
+    private readonly Label _descriptionLabel = CreateLabel(isEmphasized: true);
+
+    /// <summary>Hosts theme choice buttons.</summary>
+    private readonly FlexLayout _choicesPanel = new() { Direction = FlexDirection.Row, Wrap = FlexWrap.Wrap, AlignItems = FlexAlignItems.Center };
+
+    /// <summary>Initializes a new instance of the <see cref="ThemeSwitcher"/> class.</summary>
+    public ThemeSwitcher()
+    {
+        Content = CreateLayout();
+        ApplyState(DefaultThemeState);
+    }
 
     /// <summary>Gets or sets the shared CrissCross state projected by this control.</summary>
     public ThemePreferenceState? ThemeState
@@ -31,5 +54,102 @@ public class ThemeSwitcher : ContentView
     {
         get => (ICommand?)GetValue(ChangeThemeCommandProperty);
         set => SetValue(ChangeThemeCommandProperty, value);
+    }
+
+    /// <summary>Selects a theme choice and invokes <see cref="ChangeThemeCommand"/> with the selected <see cref="ThemeChoice"/>.</summary>
+    /// <param name="choice">The selected theme choice.</param>
+    /// <returns><c>true</c> when the command was invoked; otherwise, <c>false</c>.</returns>
+    public bool SelectTheme(ThemeChoice choice)
+    {
+        var state = ThemeState ?? DefaultThemeState;
+        if (!state.SupportsChoice(choice) || ChangeThemeCommand?.CanExecute(choice) != true)
+        {
+            return false;
+        }
+
+        ChangeThemeCommand.Execute(choice);
+        return true;
+    }
+
+    /// <summary>Creates a display label.</summary>
+    /// <param name="isEmphasized">A value indicating whether the label should use emphasized text.</param>
+    /// <returns>The configured label.</returns>
+    private static Label CreateLabel(bool isEmphasized)
+    {
+        var label = new Label { FontAttributes = isEmphasized ? FontAttributes.Bold : FontAttributes.None };
+        label.SetDynamicResource(Label.TextColorProperty, "CrissCrossTextColor");
+        return label;
+    }
+
+    /// <summary>Gets display text for a theme choice.</summary>
+    /// <param name="choice">The theme choice.</param>
+    /// <returns>The display text.</returns>
+    private static string GetChoiceText(ThemeChoice choice) => choice switch
+    {
+        ThemeChoice.Dark => "Dark",
+        ThemeChoice.Light => "Light",
+        ThemeChoice.HighContrast => "High contrast",
+        _ => "System",
+    };
+
+    /// <summary>Applies a state change from the bindable property.</summary>
+    /// <param name="bindable">The bindable control.</param>
+    /// <param name="newValue">The new state value.</param>
+    private static void OnThemeStateChanged(BindableObject bindable, object newValue)
+    {
+        if (bindable is not ThemeSwitcher switcher)
+        {
+            return;
+        }
+
+        switcher.ApplyState(newValue as ThemePreferenceState ?? DefaultThemeState);
+    }
+
+    /// <summary>Applies command availability changes to the current presentation.</summary>
+    /// <param name="bindable">The bindable control.</param>
+    private static void OnThemeCommandChanged(BindableObject bindable)
+    {
+        if (bindable is not ThemeSwitcher switcher)
+        {
+            return;
+        }
+
+        switcher.ApplyState(switcher.ThemeState ?? DefaultThemeState);
+    }
+
+    /// <summary>Creates the native MAUI layout.</summary>
+    /// <returns>The composed view.</returns>
+    private VerticalStackLayout CreateLayout()
+    {
+        var root = new VerticalStackLayout { Spacing = LayoutSpacing };
+        root.Children.Add(_descriptionLabel);
+        root.Children.Add(_choicesPanel);
+        return root;
+    }
+
+    /// <summary>Applies the supplied theme state to the visual choices.</summary>
+    /// <param name="state">The theme state.</param>
+    private void ApplyState(ThemePreferenceState state)
+    {
+        _descriptionLabel.Text = state.DisplayText;
+        _choicesPanel.Children.Clear();
+        foreach (var choice in state.AvailableChoices)
+        {
+            var button = new Button
+            {
+                Text = GetChoiceText(choice),
+                Command = ChangeThemeCommand,
+                CommandParameter = choice,
+                Margin = new(0, 0, LayoutSpacing, LayoutSpacing),
+                IsEnabled = state.SupportsChoice(choice) && ChangeThemeCommand is not null,
+            };
+            button.SetDynamicResource(
+                Button.BackgroundColorProperty,
+                choice == state.SelectedChoice ? "CrissCrossAccentColor" : "CrissCrossNeutralSurfaceColor");
+            button.SetDynamicResource(
+                Button.TextColorProperty,
+                choice == state.SelectedChoice ? "CrissCrossAccentTextColor" : "CrissCrossTextColor");
+            _choicesPanel.Children.Add(button);
+        }
     }
 }

--- a/src/CrissCross.Maui.UI/Controls/ValidationSummary.cs
+++ b/src/CrissCross.Maui.UI/Controls/ValidationSummary.cs
@@ -11,12 +11,108 @@ public class ValidationSummary : ContentView
     public static readonly BindableProperty SummaryStateProperty = BindableProperty.Create(
         nameof(SummaryState),
         typeof(ValidationSummaryState),
-        typeof(ValidationSummary));
+        typeof(ValidationSummary),
+        propertyChanged: static (view, _, _) => ((ValidationSummary)view).Refresh());
+
+    /// <summary>Provides the heading label font size.</summary>
+    private const double HeadingFontSize = 16;
+
+    /// <summary>Provides spacing between summary rows.</summary>
+    private const double LayoutSpacing = 6;
+
+    /// <summary>Provides default control padding.</summary>
+    private const double ControlPadding = 12;
+
+    /// <summary>Provides indentation for validation message rows.</summary>
+    private const double MessageIndent = 12;
+
+    /// <summary>Provides the primary text semantic resource key.</summary>
+    private const string TextColorResourceKey = "CrissCrossTextColor";
+
+    /// <summary>Provides the muted text semantic resource key.</summary>
+    private const string MutedTextColorResourceKey = "CrissCrossMutedTextColor";
+
+    /// <summary>Provides the danger semantic resource key.</summary>
+    private const string DangerColorResourceKey = "CrissCrossDangerColor";
+
+    /// <summary>Provides the caution semantic resource key.</summary>
+    private const string CautionColorResourceKey = "CrissCrossCautionColor";
+
+    /// <summary>Provides the success semantic resource key.</summary>
+    private const string SuccessColorResourceKey = "CrissCrossSuccessColor";
+
+    /// <summary>Displays the validation summary heading.</summary>
+    private readonly Label _heading = new() { FontAttributes = FontAttributes.Bold, FontSize = HeadingFontSize };
+
+    /// <summary>Displays validation message rows.</summary>
+    private readonly VerticalStackLayout _messages = new() { Spacing = LayoutSpacing };
+
+    /// <summary>Initializes a new instance of the <see cref="ValidationSummary"/> class.</summary>
+    public ValidationSummary()
+    {
+        _heading.SetDynamicResource(Label.TextColorProperty, TextColorResourceKey);
+        Content = new VerticalStackLayout { Padding = new(ControlPadding), Spacing = LayoutSpacing, Children = { _heading, _messages } };
+        Refresh();
+    }
 
     /// <summary>Gets or sets the shared CrissCross state projected by this control.</summary>
     public ValidationSummaryState? SummaryState
     {
         get => (ValidationSummaryState?)GetValue(SummaryStateProperty);
         set => SetValue(SummaryStateProperty, value);
+    }
+
+    /// <summary>Gets a text prefix for a validation severity.</summary>
+    /// <param name="severity">The validation severity.</param>
+    /// <returns>The visible severity prefix.</returns>
+    private static string GetSeverityPrefix(ValidationSeverity severity) => severity switch
+    {
+        ValidationSeverity.Error => "Error:",
+        ValidationSeverity.Warning => "Warning:",
+        ValidationSeverity.Pending => "Pending:",
+        ValidationSeverity.Success => "Success:",
+        _ => "Info:",
+    };
+
+    /// <summary>Gets a semantic text resource for a validation severity.</summary>
+    /// <param name="severity">The validation severity.</param>
+    /// <returns>The dynamic resource key.</returns>
+    private static string GetSeverityTextResource(ValidationSeverity severity) => severity switch
+    {
+        ValidationSeverity.Error => DangerColorResourceKey,
+        ValidationSeverity.Warning => CautionColorResourceKey,
+        ValidationSeverity.Pending => MutedTextColorResourceKey,
+        ValidationSeverity.Success => SuccessColorResourceKey,
+        _ => TextColorResourceKey,
+    };
+
+    /// <summary>Creates a label for one validation message.</summary>
+    /// <param name="message">The validation message.</param>
+    /// <returns>The configured label.</returns>
+    private static Label CreateMessageLabel(ValidationMessage message)
+    {
+        Label label = new() { Margin = new(MessageIndent, 0, 0, 0), Text = $"{GetSeverityPrefix(message.Severity)} {message.DisplayText}" };
+        label.SetDynamicResource(Label.TextColorProperty, GetSeverityTextResource(message.Severity));
+        return label;
+    }
+
+    /// <summary>Updates the composed native content from the current validation snapshot.</summary>
+    private void Refresh()
+    {
+        var state = SummaryState;
+        var summaryText = state?.SummaryText ?? "No validation messages";
+        _heading.Text = summaryText;
+        _messages.Children.Clear();
+
+        if (state is not null)
+        {
+            foreach (var message in state.Messages)
+            {
+                _messages.Children.Add(CreateMessageLabel(message));
+            }
+        }
+
+        _messages.IsVisible = _messages.Children.Count > 0;
+        SemanticProperties.SetDescription(this, summaryText);
     }
 }

--- a/src/CrissCross.Maui.UI/CrissCross.Maui.UI.csproj
+++ b/src/CrissCross.Maui.UI/CrissCross.Maui.UI.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net10.0-ios;net10.0-tvos;net10.0-macos;net10.0-maccatalyst;net10.0-android</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net10.0-ios;net10.0-tvos;net10.0-macos;net10.0-maccatalyst;net10.0-android;net11.0;net11.0-ios;net11.0-tvos;net11.0-macos;net11.0-maccatalyst;net11.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0;net11.0-windows10.0.19041.0</TargetFrameworks>
     <RootNamespace>CrissCross.Maui.UI</RootNamespace>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
@@ -10,11 +10,11 @@
     <Nullable>enable</Nullable>
     <Description>MAUI controls, resources, and reactive state projections for CrissCross applications.</Description>
     <PackageTags>$(PackageTags);maui;controls;styles;reactive-ui</PackageTags>
-    <IsPackable>false</IsPackable>
 
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">23.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' and $(TargetFramework.StartsWith('net11.0'))">24.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' and !$(TargetFramework.StartsWith('net11.0'))">23.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
@@ -23,7 +23,6 @@
   <ItemGroup>
     <PackageReference Include="CP.Extensions.Hosting.ReactiveUI.Maui" />
     <PackageReference Include="Microsoft.Maui.Controls" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
     <PackageReference Include="ReactiveUI.Maui" />
   </ItemGroup>
 

--- a/src/CrissCross.Maui.UI/MauiUiAppBuilderExtensions.cs
+++ b/src/CrissCross.Maui.UI/MauiUiAppBuilderExtensions.cs
@@ -33,17 +33,189 @@ public static class MauiUiAppBuilderExtensions
         public ResourceDictionary UseCrissCrossMauiUiResources()
         {
             ArgumentNullException.ThrowIfNull(resources);
+            EnsureBaseResources(resources);
+            UseSystemThemeResources(resources, ThemeChoice.Light, useApplicationTheme: true);
+            return resources;
+        }
 
-            foreach (var dictionary in resources.MergedDictionaries)
+        /// <summary>Provides the UseCrissCrossMauiUiResources member for a concrete theme snapshot.</summary>
+        /// <param name="themeState">The shared theme preference snapshot.</param>
+        /// <returns>The supplied resource dictionary.</returns>
+        public ResourceDictionary UseCrissCrossMauiUiResources(ThemePreferenceState? themeState)
+        {
+            if (themeState is null)
             {
-                if (dictionary is CrissCrossMauiUi)
-                {
-                    return resources;
-                }
+                return resources.UseCrissCrossMauiUiResources();
             }
 
-            resources.MergedDictionaries.Add(new CrissCrossMauiUi());
+            if (themeState.SelectedChoice == ThemeChoice.System)
+            {
+                ArgumentNullException.ThrowIfNull(resources);
+                EnsureBaseResources(resources);
+                UseSystemThemeResources(resources, themeState.EffectiveChoice, useApplicationTheme: false);
+                return resources;
+            }
+
+            return resources.UseCrissCrossMauiUiResources(themeState.EffectiveChoice);
+        }
+
+        /// <summary>Provides the UseCrissCrossMauiUiResources member for a concrete theme choice.</summary>
+        /// <param name="themeChoice">The requested theme choice.</param>
+        /// <returns>The supplied resource dictionary.</returns>
+        public ResourceDictionary UseCrissCrossMauiUiResources(ThemeChoice themeChoice)
+        {
+            ArgumentNullException.ThrowIfNull(resources);
+            EnsureBaseResources(resources);
+            if (themeChoice == ThemeChoice.System)
+            {
+                UseSystemThemeResources(resources, ThemeChoice.Light, useApplicationTheme: true);
+                return resources;
+            }
+
+            RemoveSystemThemeSubscription(resources);
+            ApplyThemeResources(resources, themeChoice);
             return resources;
+        }
+    }
+
+    /// <summary>Stores weak resource theme subscriptions without rooting resource dictionaries.</summary>
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<ResourceDictionary, MauiUiThemeSubscription> ThemeSubscriptions = new();
+
+    /// <summary>Adds the base MAUI UI resource dictionary when it is not already present.</summary>
+    /// <param name="resources">The target resources.</param>
+    private static void EnsureBaseResources(ResourceDictionary resources)
+    {
+        foreach (var dictionary in resources.MergedDictionaries)
+        {
+            if (dictionary is CrissCrossMauiUi)
+            {
+                return;
+            }
+        }
+
+        resources.MergedDictionaries.Add(new CrissCrossMauiUi());
+    }
+
+    /// <summary>Applies system-following resources and subscribes weakly to requested theme changes when an application exists.</summary>
+    /// <param name="resources">The target resources.</param>
+    /// <param name="fallbackChoice">The fallback concrete choice used when no application is available.</param>
+    /// <param name="useApplicationTheme">A value indicating whether to use the current application requested theme immediately.</param>
+    private static void UseSystemThemeResources(ResourceDictionary resources, ThemeChoice fallbackChoice, bool useApplicationTheme)
+    {
+        RemoveSystemThemeSubscription(resources);
+        if (Application.Current is { } application)
+        {
+            var themeChoice = useApplicationTheme ? ResolveThemeChoice(application.RequestedTheme) : fallbackChoice;
+            ApplyThemeResources(resources, themeChoice);
+            ThemeSubscriptions.Add(resources, new(resources, application));
+            return;
+        }
+
+        ApplyThemeResources(resources, fallbackChoice);
+    }
+
+    /// <summary>Applies the active semantic-token dictionary for the requested concrete theme.</summary>
+    /// <param name="resources">The target resources.</param>
+    /// <param name="themeChoice">The concrete theme choice.</param>
+    private static void ApplyThemeResources(ResourceDictionary resources, ThemeChoice themeChoice)
+    {
+        RemoveThemeOverrideResources(resources);
+        ResourceDictionary themeResources = themeChoice switch
+        {
+            ThemeChoice.Dark => new CrissCrossMauiDarkTheme(),
+            ThemeChoice.HighContrast => new CrissCrossMauiHighContrastTheme(),
+            _ => new CrissCrossMauiLightTheme(),
+        };
+        resources.MergedDictionaries.Add(themeResources);
+    }
+
+    /// <summary>Removes the system theme subscription for a resource dictionary.</summary>
+    /// <param name="resources">The target resources.</param>
+    private static void RemoveSystemThemeSubscription(ResourceDictionary resources)
+    {
+        if (!ThemeSubscriptions.TryGetValue(resources, out var subscription))
+        {
+            return;
+        }
+
+        subscription.Dispose();
+        _ = ThemeSubscriptions.Remove(resources);
+    }
+
+    /// <summary>Removes explicit theme override dictionaries before the next choice is applied.</summary>
+    /// <param name="resources">The target resources.</param>
+    private static void RemoveThemeOverrideResources(ResourceDictionary resources)
+    {
+        var dictionaries = new List<ResourceDictionary>();
+        foreach (var dictionary in resources.MergedDictionaries)
+        {
+            if (IsThemeOverrideDictionary(dictionary))
+            {
+                dictionaries.Add(dictionary);
+            }
+        }
+
+        foreach (var dictionary in dictionaries)
+        {
+            _ = resources.MergedDictionaries.Remove(dictionary);
+        }
+    }
+
+    /// <summary>Resolves a MAUI app theme to the shared concrete theme choice.</summary>
+    /// <param name="theme">The MAUI app theme.</param>
+    /// <returns>The shared concrete theme choice.</returns>
+    private static ThemeChoice ResolveThemeChoice(AppTheme theme) => theme == AppTheme.Dark ? ThemeChoice.Dark : ThemeChoice.Light;
+
+    /// <summary>Gets whether the dictionary is a theme override dictionary controlled by CrissCross.</summary>
+    /// <param name="dictionary">The candidate resource dictionary.</param>
+    /// <returns><c>true</c> when the dictionary is a CrissCross theme override dictionary.</returns>
+    private static bool IsThemeOverrideDictionary(ResourceDictionary dictionary) =>
+        dictionary is CrissCrossMauiLightTheme or CrissCrossMauiDarkTheme or CrissCrossMauiHighContrastTheme;
+
+    /// <summary>Tracks a system-theme registration without keeping the target resource dictionary alive.</summary>
+    private sealed class MauiUiThemeSubscription : IDisposable
+    {
+        /// <summary>Stores the subscribed resource dictionary without rooting it.</summary>
+        private readonly WeakReference<ResourceDictionary> _resources;
+
+        /// <summary>Stores the subscribed application without creating a cycle back to the event source.</summary>
+        private readonly WeakReference<Application> _application;
+
+        /// <summary>Initializes a new instance of the <see cref="MauiUiThemeSubscription"/> class.</summary>
+        /// <param name="resources">The subscribed resources.</param>
+        /// <param name="application">The application that raises requested-theme changes.</param>
+        public MauiUiThemeSubscription(ResourceDictionary resources, Application application)
+        {
+            _resources = new(resources);
+            _application = new(application);
+            application.RequestedThemeChanged += HandleRequestedThemeChanged;
+        }
+
+        /// <summary>Unsubscribes from the requested-theme event.</summary>
+        public void Dispose()
+        {
+            if (!_application.TryGetTarget(out var application))
+            {
+                return;
+            }
+
+            application.RequestedThemeChanged -= HandleRequestedThemeChanged;
+        }
+
+        /// <summary>Updates the active theme dictionary when the operating system requested theme changes.</summary>
+        /// <param name="sender">The event source.</param>
+        /// <param name="args">The requested-theme change arguments.</param>
+        private void HandleRequestedThemeChanged(object? sender, AppThemeChangedEventArgs args)
+        {
+            _ = args;
+            if (!_resources.TryGetTarget(out var resources))
+            {
+                Dispose();
+                return;
+            }
+
+            var theme = sender is Application application ? application.RequestedTheme : AppTheme.Unspecified;
+            ApplyThemeResources(resources, ResolveThemeChoice(theme));
         }
     }
 }

--- a/src/CrissCross.Maui.UI/README.md
+++ b/src/CrissCross.Maui.UI/README.md
@@ -21,16 +21,18 @@ Implemented parity controls:
 - `InfoBar` and `InfoBadge`
 - `PersonPicture`
 - `RatingControl`
+- `ProcessValueIndicator`
 
-The controls intentionally expose bindable state snapshots and command hooks instead of reflection-heavy discovery or platform-specific renderer hacks. Add the shared resource dictionary with:
+The controls intentionally expose bindable state snapshots and command hooks instead of reflection-heavy discovery or platform-specific renderer hacks. The default resource extension follows the MAUI application requested theme; explicit Light, Dark, and High Contrast selections use concrete semantic-token dictionaries. Add the shared resource dictionary with:
 
 ```csharp
 Application.Current.Resources.UseCrissCrossMauiUiResources();
+Application.Current.Resources.UseCrissCrossMauiUiResources(themeState);
 ```
 
 ## WPF-to-MAUI control parity
 
-The Gallery instantiates all 24 controls below. MAUI variants use bindable snapshots and command boundaries; they do not emulate WPF template-part or routed-event internals.
+The Gallery instantiates all 28 controls below. MAUI variants use bindable snapshots and command boundaries; they do not emulate WPF template-part or routed-event internals.
 
 | WPF.UI family | MAUI status | MAUI control or reason |
 | --- | --- | --- |
@@ -38,9 +40,10 @@ The Gallery instantiates all 24 controls below. MAUI variants use bindable snaps
 | Cards and action/expansion surfaces | Implemented | `Card`, `CardAction`, `CardExpander` use MAUI `Border`, `Button`, and composed layouts. |
 | Feedback and status | Implemented | `InfoBar`, `InfoBadge`, plus the existing `ValidationSummary` and `BusyOverlay`. |
 | Identity and ratings | Implemented | `PersonPicture` has image/initials fallback; `RatingControl` is command-driven and accessible. |
-| WPF window, title bar, app bar, taskbar, client-area, shell and DWM interop | Platform-inapplicable | These require Win32/WPF presentation infrastructure and remain owned by the application shell on MAUI. |
-| WPF navigation view, page-service, dialogs, snackbars and message boxes | Platform-inapplicable as controls | MAUI navigation and alerts are shell/platform services; duplicating WPF's routed/template APIs would be misleading. |
-| WPF virtualization, TreeGrid, GridView, DataGrid, custom scroll bars and panel implementations | Platform-inapplicable | MAUI provides its own CollectionView/handler virtualization model rather than WPF panels. |
+| Industrial process readouts | Implemented | `ProcessValueIndicator` projects immutable `ProcessValueState` snapshots into value, status, and range-bar presentation. |
+| WPF window, title bar, app bar, taskbar, client-area, shell and DWM interop | Incomplete in shared MAUI.UI | MAUI Windows can host desktop applications, but these features need MAUI window/handler integration owned by the application shell. |
+| WPF navigation view, page-service, dialogs, snackbars and message boxes | Partially implemented / incomplete | Snackbar is implemented; broader navigation and dialog parity remains shell/platform-service work for MAUI applications. |
+| WPF virtualization, TreeGrid, GridView, DataGrid, custom scroll bars and panel implementations | Incomplete | MAUI provides CollectionView/handler virtualization, but equivalent shared controls are not implemented. |
 | WPF media, rich-text, BBCode, GIF, icon-element and color-selector template systems | Not yet portable | These depend on WPF text/media/template APIs; a MAUI-native design needs dedicated requirements before adding an incomplete replica. |
 
 MAUI handler-level customization remains intentionally avoided so the package stays AOT- and trimming-friendly.

--- a/src/CrissCross.Maui.UI/Resources/Styles/Colors.xaml
+++ b/src/CrissCross.Maui.UI/Resources/Styles/Colors.xaml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+<ResourceDictionary
+    x:Class="CrissCross.Maui.UI.Resources.Styles.CrissCrossMauiColors"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
     <!--
-        Cross-platform semantic palette. The paired resources are consumed
-        with AppThemeBinding so values update when RequestedTheme changes.
+        Cross-platform semantic palette. Light, Dark, and High Contrast dictionaries
+        project these paired values into active dynamic resource tokens.
     -->
     <Color x:Key="CrissCrossAccentColorLight">#3B55C9</Color>
     <Color x:Key="CrissCrossAccentColorDark">#8EA2FF</Color>
@@ -42,4 +45,6 @@
     <Color x:Key="CrissCrossNeutralColorDark">#FF9D9D9D</Color>
     <Color x:Key="CrissCrossNeutralSurfaceColorLight">#FFF3F3F3</Color>
     <Color x:Key="CrissCrossNeutralSurfaceColorDark">#FF2E2E2E</Color>
+
+
 </ResourceDictionary>

--- a/src/CrissCross.Maui.UI/Resources/Styles/Colors.xaml.cs
+++ b/src/CrissCross.Maui.UI/Resources/Styles/Colors.xaml.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace CrissCross.Maui.UI.Resources.Styles;
+
+/// <summary>Base Light and Dark semantic palette for CrissCross MAUI UI resources.</summary>
+public partial class CrissCrossMauiColors : ResourceDictionary
+{
+    /// <summary>Initializes a new instance of the <see cref="CrissCrossMauiColors"/> class.</summary>
+    public CrissCrossMauiColors() => InitializeComponent();
+}

--- a/src/CrissCross.Maui.UI/Resources/Styles/Controls.xaml
+++ b/src/CrissCross.Maui.UI/Resources/Styles/Controls.xaml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ResourceDictionary
+    x:Class="CrissCross.Maui.UI.Resources.Styles.Controls"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:controls="clr-namespace:CrissCross.Maui.UI.Controls">
@@ -9,8 +10,8 @@
     </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="CrissCrossCommandButtonStyle" TargetType="controls:CommandButton">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource CrissCrossAccentColorLight}, Dark={StaticResource CrissCrossAccentColorDark}}" />
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource CrissCrossAccentTextColorLight}, Dark={StaticResource CrissCrossAccentTextColorDark}}" />
+        <Setter Property="BackgroundColor" Value="{DynamicResource CrissCrossAccentColor}" />
+        <Setter Property="TextColor" Value="{DynamicResource CrissCrossAccentTextColor}" />
         <Setter Property="CornerRadius" Value="8" />
         <Setter Property="Padding" Value="14,8" />
         <Setter Property="MinimumHeightRequest" Value="40" />
@@ -20,28 +21,28 @@
     <Style TargetType="controls:AsyncCommandButton" BasedOn="{StaticResource CrissCrossCommandButtonStyle}" />
 
     <Style TargetType="controls:Chip">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource CrissCrossSubtleSurfaceColorLight}, Dark={StaticResource CrissCrossSubtleSurfaceColorDark}}" />
-        <Setter Property="BorderColor" Value="{AppThemeBinding Light={StaticResource CrissCrossBorderColorLight}, Dark={StaticResource CrissCrossBorderColorDark}}" />
+        <Setter Property="BackgroundColor" Value="{DynamicResource CrissCrossSubtleSurfaceColor}" />
+        <Setter Property="BorderColor" Value="{DynamicResource CrissCrossBorderColor}" />
         <Setter Property="BorderWidth" Value="1" />
         <Setter Property="CornerRadius" Value="16" />
         <Setter Property="Padding" Value="12,6" />
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource CrissCrossTextColorLight}, Dark={StaticResource CrissCrossTextColorDark}}" />
+        <Setter Property="TextColor" Value="{DynamicResource CrissCrossTextColor}" />
     </Style>
 
     <Style TargetType="controls:BusyOverlay">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource CrissCrossOverlayColorLight}, Dark={StaticResource CrissCrossOverlayColorDark}}" />
-        <Setter Property="Padding" Value="16" />
+        <Setter Property="BackgroundColor" Value="Transparent" />
+        <Setter Property="Padding" Value="0" />
     </Style>
 
     <Style TargetType="controls:EmptyState">
         <Setter Property="Padding" Value="24" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource CrissCrossSubtleSurfaceColorLight}, Dark={StaticResource CrissCrossSubtleSurfaceColorDark}}" />
+        <Setter Property="BackgroundColor" Value="{DynamicResource CrissCrossSubtleSurfaceColor}" />
     </Style>
 
     <Style TargetType="controls:SearchBox">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource CrissCrossSurfaceColorLight}, Dark={StaticResource CrissCrossSurfaceColorDark}}" />
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource CrissCrossTextColorLight}, Dark={StaticResource CrissCrossTextColorDark}}" />
-        <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource CrissCrossMutedTextColorLight}, Dark={StaticResource CrissCrossMutedTextColorDark}}" />
+        <Setter Property="BackgroundColor" Value="{DynamicResource CrissCrossSurfaceColor}" />
+        <Setter Property="TextColor" Value="{DynamicResource CrissCrossTextColor}" />
+        <Setter Property="PlaceholderColor" Value="{DynamicResource CrissCrossMutedTextColor}" />
     </Style>
 
     <Style TargetType="controls:FilterBar">
@@ -54,7 +55,7 @@
 
     <Style TargetType="controls:ValidationSummary">
         <Setter Property="Padding" Value="12" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource CrissCrossCautionSurfaceColorLight}, Dark={StaticResource CrissCrossCautionSurfaceColorDark}}" />
+        <Setter Property="BackgroundColor" Value="{DynamicResource CrissCrossCautionSurfaceColor}" />
     </Style>
 
     <Style TargetType="controls:ChipGroup">
@@ -66,7 +67,7 @@
     <Style TargetType="controls:SegmentedControl">
         <Setter Property="Spacing" Value="4" />
         <Setter Property="Padding" Value="4" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource CrissCrossSubtleSurfaceColorLight}, Dark={StaticResource CrissCrossSubtleSurfaceColorDark}}" />
+        <Setter Property="BackgroundColor" Value="{DynamicResource CrissCrossSubtleSurfaceColor}" />
     </Style>
 
     <Style TargetType="controls:DataPager">
@@ -95,46 +96,56 @@
 
     <Style TargetType="controls:Card">
         <Setter Property="Padding" Value="16" />
-        <Setter Property="Stroke" Value="{AppThemeBinding Light={StaticResource CrissCrossBorderColorLight}, Dark={StaticResource CrissCrossBorderColorDark}}" />
-        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource CrissCrossSurfaceColorLight}, Dark={StaticResource CrissCrossSurfaceColorDark}}" />
+        <Setter Property="Stroke" Value="{DynamicResource CrissCrossBorderColor}" />
+        <Setter Property="Background" Value="{DynamicResource CrissCrossSurfaceColor}" />
         <Setter Property="StrokeShape" Value="RoundRectangle 8" />
     </Style>
 
     <Style TargetType="controls:CardAction">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource CrissCrossSubtleSurfaceColorLight}, Dark={StaticResource CrissCrossSubtleSurfaceColorDark}}" />
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource CrissCrossTextColorLight}, Dark={StaticResource CrissCrossTextColorDark}}" />
+        <Setter Property="BackgroundColor" Value="{DynamicResource CrissCrossSubtleSurfaceColor}" />
+        <Setter Property="TextColor" Value="{DynamicResource CrissCrossTextColor}" />
         <Setter Property="HorizontalOptions" Value="Fill" />
     </Style>
 
     <Style TargetType="controls:CardExpander">
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource CrissCrossSubtleSurfaceColorLight}, Dark={StaticResource CrissCrossSubtleSurfaceColorDark}}" />
+        <Setter Property="BackgroundColor" Value="{DynamicResource CrissCrossSubtleSurfaceColor}" />
         <Setter Property="Padding" Value="12" />
     </Style>
 
     <Style TargetType="controls:InfoBadge">
         <Setter Property="Padding" Value="8,2" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource CrissCrossAttentionSurfaceColorLight}, Dark={StaticResource CrissCrossAttentionSurfaceColorDark}}" />
-        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource CrissCrossAttentionColorLight}, Dark={StaticResource CrissCrossAttentionColorDark}}" />
+        <Setter Property="BackgroundColor" Value="{DynamicResource CrissCrossAttentionSurfaceColor}" />
+        <Setter Property="TextColor" Value="{DynamicResource CrissCrossAttentionColor}" />
     </Style>
 
     <Style TargetType="controls:InfoBar">
         <Setter Property="Padding" Value="12" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource CrissCrossAttentionSurfaceColorLight}, Dark={StaticResource CrissCrossAttentionSurfaceColorDark}}" />
+        <Setter Property="BackgroundColor" Value="{DynamicResource CrissCrossAttentionSurfaceColor}" />
     </Style>
 
     <Style TargetType="controls:PersonPicture">
         <Setter Property="HeightRequest" Value="48" />
         <Setter Property="WidthRequest" Value="48" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource CrissCrossAccentColorLight}, Dark={StaticResource CrissCrossAccentColorDark}}" />
+        <Setter Property="BackgroundColor" Value="{DynamicResource CrissCrossAccentColor}" />
     </Style>
 
     <Style TargetType="controls:RatingControl">
         <Setter Property="Spacing" Value="2" />
     </Style>
 
+    <Style TargetType="controls:ProcessValueIndicator">
+        <Setter Property="Padding" Value="12" />
+        <Setter Property="BackgroundColor" Value="{DynamicResource CrissCrossSubtleSurfaceColor}" />
+        <Setter Property="NormalStatusColor" Value="{DynamicResource CrissCrossSuccessColor}" />
+        <Setter Property="AlarmStatusColor" Value="{DynamicResource CrissCrossDangerColor}" />
+        <Setter Property="BadQualityStatusColor" Value="{DynamicResource CrissCrossCautionColor}" />
+        <Setter Property="InvalidConfigurationStatusColor" Value="{DynamicResource CrissCrossNeutralColor}" />
+        <Setter Property="RangeTrackColor" Value="{DynamicResource CrissCrossNeutralSurfaceColor}" />
+    </Style>
+
     <Style TargetType="controls:AlarmBanner">
         <Setter Property="Padding" Value="12" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource CrissCrossDangerSurfaceColorLight}, Dark={StaticResource CrissCrossDangerSurfaceColorDark}}" />
+        <Setter Property="BackgroundColor" Value="{DynamicResource CrissCrossDangerSurfaceColor}" />
     </Style>
 
     <Style TargetType="controls:CardColor">
@@ -144,6 +155,6 @@
 
     <Style TargetType="controls:Snackbar">
         <Setter Property="Padding" Value="12" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource CrissCrossNeutralSurfaceColorLight}, Dark={StaticResource CrissCrossNeutralSurfaceColorDark}}" />
+        <Setter Property="BackgroundColor" Value="{DynamicResource CrissCrossNeutralSurfaceColor}" />
     </Style>
 </ResourceDictionary>

--- a/src/CrissCross.Maui.UI/Resources/Styles/Controls.xaml.cs
+++ b/src/CrissCross.Maui.UI/Resources/Styles/Controls.xaml.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace CrissCross.Maui.UI.Resources.Styles;
+
+/// <summary>Control styles for CrissCross MAUI UI resources.</summary>
+public partial class Controls : ResourceDictionary
+{
+    /// <summary>Initializes a new instance of the <see cref="Controls"/> class.</summary>
+    public Controls() => InitializeComponent();
+}

--- a/src/CrissCross.Maui.UI/Resources/Styles/CrissCrossMauiUi.xaml
+++ b/src/CrissCross.Maui.UI/Resources/Styles/CrissCrossMauiUi.xaml
@@ -4,6 +4,8 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
     <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="Colors.xaml" />
+        <ResourceDictionary Source="Light.xaml" />
         <ResourceDictionary Source="Controls.xaml" />
     </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/src/CrissCross.Maui.UI/Resources/Styles/Dark.xaml
+++ b/src/CrissCross.Maui.UI/Resources/Styles/Dark.xaml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary
+    x:Class="CrissCross.Maui.UI.Resources.Styles.CrissCrossMauiDarkTheme"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <Color x:Key="CrissCrossAccentColor">#8EA2FF</Color>
+    <Color x:Key="CrissCrossAccentTextColor">#FF1B1D23</Color>
+    <Color x:Key="CrissCrossSurfaceColor">#FF1B1D23</Color>
+    <Color x:Key="CrissCrossSubtleSurfaceColor">#FF252831</Color>
+    <Color x:Key="CrissCrossBorderColor">#FF454A57</Color>
+    <Color x:Key="CrissCrossTextColor">#FFF4F6FA</Color>
+    <Color x:Key="CrissCrossMutedTextColor">#FFB9C0CC</Color>
+    <Color x:Key="CrissCrossOverlayColor">#66000000</Color>
+    <Color x:Key="CrissCrossAttentionColor">#FF4CC2FF</Color>
+    <Color x:Key="CrissCrossAttentionSurfaceColor">#FF2E2E2E</Color>
+    <Color x:Key="CrissCrossDangerColor">#FFFF9B9B</Color>
+    <Color x:Key="CrissCrossDangerSurfaceColor">#FF442726</Color>
+    <Color x:Key="CrissCrossSuccessColor">#FF85D990</Color>
+    <Color x:Key="CrissCrossSuccessSurfaceColor">#FF393D1B</Color>
+    <Color x:Key="CrissCrossCautionColor">#FFFCE100</Color>
+    <Color x:Key="CrissCrossCautionSurfaceColor">#FF433519</Color>
+    <Color x:Key="CrissCrossNeutralColor">#FF9D9D9D</Color>
+    <Color x:Key="CrissCrossNeutralSurfaceColor">#FF2E2E2E</Color>
+</ResourceDictionary>

--- a/src/CrissCross.Maui.UI/Resources/Styles/Dark.xaml.cs
+++ b/src/CrissCross.Maui.UI/Resources/Styles/Dark.xaml.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace CrissCross.Maui.UI.Resources.Styles;
+
+/// <summary>Provides the CrissCross MAUI dark semantic resource dictionary.</summary>
+public partial class CrissCrossMauiDarkTheme : ResourceDictionary
+{
+    /// <summary>Initializes a new instance of the <see cref="CrissCrossMauiDarkTheme"/> class.</summary>
+    public CrissCrossMauiDarkTheme() => InitializeComponent();
+}

--- a/src/CrissCross.Maui.UI/Resources/Styles/HighContrast.xaml
+++ b/src/CrissCross.Maui.UI/Resources/Styles/HighContrast.xaml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary
+    x:Class="CrissCross.Maui.UI.Resources.Styles.CrissCrossMauiHighContrastTheme"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <Color x:Key="CrissCrossAccentColor">#FFFFFF00</Color>
+    <Color x:Key="CrissCrossAccentTextColor">#FF000000</Color>
+    <Color x:Key="CrissCrossSurfaceColor">#FF000000</Color>
+    <Color x:Key="CrissCrossSubtleSurfaceColor">#FF000000</Color>
+    <Color x:Key="CrissCrossBorderColor">#FFFFFFFF</Color>
+    <Color x:Key="CrissCrossTextColor">#FFFFFFFF</Color>
+    <Color x:Key="CrissCrossMutedTextColor">#FFFFFFFF</Color>
+    <Color x:Key="CrissCrossOverlayColor">#99000000</Color>
+    <Color x:Key="CrissCrossAttentionColor">#FF00FFFF</Color>
+    <Color x:Key="CrissCrossAttentionSurfaceColor">#FF000000</Color>
+    <Color x:Key="CrissCrossDangerColor">#FFFF00FF</Color>
+    <Color x:Key="CrissCrossDangerSurfaceColor">#FF000000</Color>
+    <Color x:Key="CrissCrossSuccessColor">#FF00FF00</Color>
+    <Color x:Key="CrissCrossSuccessSurfaceColor">#FF000000</Color>
+    <Color x:Key="CrissCrossCautionColor">#FFFFFF00</Color>
+    <Color x:Key="CrissCrossCautionSurfaceColor">#FF000000</Color>
+    <Color x:Key="CrissCrossNeutralColor">#FFFFFFFF</Color>
+    <Color x:Key="CrissCrossNeutralSurfaceColor">#FF000000</Color>
+</ResourceDictionary>

--- a/src/CrissCross.Maui.UI/Resources/Styles/HighContrast.xaml.cs
+++ b/src/CrissCross.Maui.UI/Resources/Styles/HighContrast.xaml.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace CrissCross.Maui.UI.Resources.Styles;
+
+/// <summary>Provides the CrissCross MAUI high-contrast semantic resource dictionary.</summary>
+public partial class CrissCrossMauiHighContrastTheme : ResourceDictionary
+{
+    /// <summary>Initializes a new instance of the <see cref="CrissCrossMauiHighContrastTheme"/> class.</summary>
+    public CrissCrossMauiHighContrastTheme() => InitializeComponent();
+}

--- a/src/CrissCross.Maui.UI/Resources/Styles/Light.xaml
+++ b/src/CrissCross.Maui.UI/Resources/Styles/Light.xaml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary
+    x:Class="CrissCross.Maui.UI.Resources.Styles.CrissCrossMauiLightTheme"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <Color x:Key="CrissCrossAccentColor">#3B55C9</Color>
+    <Color x:Key="CrissCrossAccentTextColor">#FFFFFFFF</Color>
+    <Color x:Key="CrissCrossSurfaceColor">#FFFFFFFF</Color>
+    <Color x:Key="CrissCrossSubtleSurfaceColor">#FFF7F9FC</Color>
+    <Color x:Key="CrissCrossBorderColor">#FFD8DEE9</Color>
+    <Color x:Key="CrissCrossTextColor">#FF1F2937</Color>
+    <Color x:Key="CrissCrossMutedTextColor">#FF6B7280</Color>
+    <Color x:Key="CrissCrossOverlayColor">#66000000</Color>
+    <Color x:Key="CrissCrossAttentionColor">#FF005FB8</Color>
+    <Color x:Key="CrissCrossAttentionSurfaceColor">#FFF7F7F7</Color>
+    <Color x:Key="CrissCrossDangerColor">#FFD13438</Color>
+    <Color x:Key="CrissCrossDangerSurfaceColor">#FFFDE7E9</Color>
+    <Color x:Key="CrissCrossSuccessColor">#FF107C10</Color>
+    <Color x:Key="CrissCrossSuccessSurfaceColor">#FFDFF6DD</Color>
+    <Color x:Key="CrissCrossCautionColor">#FF9D5D00</Color>
+    <Color x:Key="CrissCrossCautionSurfaceColor">#FFFFF4CE</Color>
+    <Color x:Key="CrissCrossNeutralColor">#FF6E6E6E</Color>
+    <Color x:Key="CrissCrossNeutralSurfaceColor">#FFF3F3F3</Color>
+</ResourceDictionary>

--- a/src/CrissCross.Maui.UI/Resources/Styles/Light.xaml.cs
+++ b/src/CrissCross.Maui.UI/Resources/Styles/Light.xaml.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace CrissCross.Maui.UI.Resources.Styles;
+
+/// <summary>Provides the CrissCross MAUI light semantic resource dictionary.</summary>
+public partial class CrissCrossMauiLightTheme : ResourceDictionary
+{
+    /// <summary>Initializes a new instance of the <see cref="CrissCrossMauiLightTheme"/> class.</summary>
+    public CrissCrossMauiLightTheme() => InitializeComponent();
+}

--- a/src/CrissCross.Maui.UI/UI-PARITY.md
+++ b/src/CrissCross.Maui.UI/UI-PARITY.md
@@ -6,19 +6,17 @@ semantic presentation rather than replacing MAUI's built-in input, layout,
 navigation, window, and virtualisation controls.
 
 Every public MAUI control is instantiated in `CrissCross.Maui.UI.Gallery` and
-uses the paired Light/Dark resources in `Resources/Styles/Colors.xaml` through
-`AppThemeBinding`. The gallery demonstrates 27 controls:
+uses dynamic semantic tokens backed by system-following Light/Dark resources plus
+explicit Light, Dark, and High Contrast resource dictionaries. The gallery
+demonstrates 28 controls:
 
 `AlarmBanner`, `AsyncCommandButton`, `BusyOverlay`, `Card`, `CardAction`,
 `CardColor`, `CardExpander`, `Chip`, `ChipGroup`, `CommandButton`,
 `DataFilterPanel`, `DataPager`, `DateTimeRangePicker`, `EmptyState`,
 `FilterBar`, `InfoBadge`, `InfoBar`, `PersonPicture`, `PropertyGridLite`,
-`RatingControl`, `ReactiveFormField`, `SearchBox`, `SegmentedControl`,
+`ProcessValueIndicator`, `RatingControl`, `ReactiveFormField`, `SearchBox`, `SegmentedControl`,
 `Snackbar`, `Stepper`, `ThemeSwitcher`, and `ValidationSummary`.
 
 `AlarmBanner`, `CardColor`, and `Snackbar` are deliberate MAUI additions that
 close shared WPF feedback/card parity using native `ContentView` composition
-and reactive default commands. The remaining WPF controls fall into one of
-these platform-inapplicable groups: native MAUI primitives (text/input, layout,
-lists, menus, pickers, scrolling), desktop-only window/title/dialog hosts,
-WPF-specific plotting/virtualisation, and WPF generated icon assets.
+and reactive default commands. The remaining WPF controls are not implemented in the shared MAUI.UI package. Some map to native MAUI primitives (text/input, layout, lists, menus, pickers, scrolling). Others are incomplete for MAUI Windows until there is a MAUI-native design for desktop window chrome, title/dialog hosts, virtualization, plotting, rich text, media, and generated icon assets.

--- a/src/CrissCross.WPF.Plot.Reactive/CrissCross.WPF.Plot.Reactive.csproj
+++ b/src/CrissCross.WPF.Plot.Reactive/CrissCross.WPF.Plot.Reactive.csproj
@@ -25,8 +25,10 @@
   <ItemGroup>
     <Using Include="ReactiveUI.Reactive" />
     <PackageReference Include="ReactiveUI.SourceGenerators" PrivateAssets="all" />
+    <PackageReference Include="ReactiveUI.Binding.Wpf.Reactive" />
     <PackageReference Include="ReactiveList.Reactive" />
     <PackageReference Include="ScottPlot.WPF" />
+    <PackageReference Include="ReactiveUI.Primitives.ObservableEvents" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/src/CrissCross.WPF.Plot/CrissCross.WPF.Plot.csproj
+++ b/src/CrissCross.WPF.Plot/CrissCross.WPF.Plot.csproj
@@ -10,8 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="ReactiveUI.SourceGenerators" PrivateAssets="all" />
+    <PackageReference Include="ReactiveUI.Binding.Wpf" />
     <PackageReference Include="ReactiveList" />
     <PackageReference Include="ScottPlot.WPF" />
+    <PackageReference Include="ReactiveUI.Primitives.ObservableEvents" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/src/CrissCross.WPF.Plot/ReactivePlotBinder.cs
+++ b/src/CrissCross.WPF.Plot/ReactivePlotBinder.cs
@@ -338,52 +338,87 @@ public sealed class ReactivePlotBinder : IReactivePlotBinder
         ReactivePlotUpdate update,
         ReactivePlotBindingOptions options,
         HashSet<PlotSeriesKey> stoppedSeries,
-        ReactivePlotConnection connection)
-    {
-        if (update.Key.Axis < 0 || update.Key.Axis >= options.MaxAxisCount)
+        ReactivePlotConnection connection) =>
+        HasValidAxis(update, options, stoppedSeries, connection)
+        && ((update.X, update.Y) switch
         {
-            return SurfaceValidationError(
+            ({ } x, { } y) => ValidateUpdateValues(update, options, stoppedSeries, connection, x, y),
+            _ => SurfaceValidationError(
                 update,
                 options,
                 stoppedSeries,
                 connection,
-                $"Invalid Y-axis index: {update.Key.Axis}");
-        }
+                "Reactive plot update X and Y collections must be non-null."),
+        });
 
-        if (update.X is null || update.Y is null)
-        {
-            return SurfaceValidationError(
-                update,
-                options,
-                stoppedSeries,
-                connection,
-                "Reactive plot update X and Y collections must be non-null.");
-        }
+    /// <summary>Checks whether a plot update targets a valid Y axis.</summary>
+    /// <param name="update">The update value.</param>
+    /// <param name="options">The options value.</param>
+    /// <param name="stoppedSeries">The stoppedSeries value.</param>
+    /// <param name="connection">The connection value.</param>
+    /// <returns><see langword="true"/> when the update targets a valid axis.</returns>
+    private static bool HasValidAxis(
+        ReactivePlotUpdate update,
+        ReactivePlotBindingOptions options,
+        HashSet<PlotSeriesKey> stoppedSeries,
+        ReactivePlotConnection connection) =>
+        (update.Key.Axis >= 0
+        && update.Key.Axis < options.MaxAxisCount)
+        || SurfaceValidationError(
+            update,
+            options,
+            stoppedSeries,
+            connection,
+            $"Invalid Y-axis index: {update.Key.Axis}");
 
-        if (update.Kind == ReactivePlotUpdateKind.Clear)
-        {
-            return true;
-        }
+    /// <summary>Validates non-null plot update values.</summary>
+    /// <param name="update">The update value.</param>
+    /// <param name="options">The options value.</param>
+    /// <param name="stoppedSeries">The stoppedSeries value.</param>
+    /// <param name="connection">The connection value.</param>
+    /// <param name="x">The X values.</param>
+    /// <param name="y">The Y values.</param>
+    /// <returns><see langword="true"/> when the update values are valid.</returns>
+    private static bool ValidateUpdateValues(
+        ReactivePlotUpdate update,
+        ReactivePlotBindingOptions options,
+        HashSet<PlotSeriesKey> stoppedSeries,
+        ReactivePlotConnection connection,
+        IReadOnlyList<double> x,
+        IReadOnlyList<double> y) =>
+        update.Kind == ReactivePlotUpdateKind.Clear
+        || (HasUpdateValues(update, options, stoppedSeries, connection, x, y)
+        && (x.Count == y.Count
+        || SurfaceValidationError(
+            update,
+            options,
+            stoppedSeries,
+            connection,
+            "Reactive plot update X and Y collections must have matching counts.")));
 
-        if (update.X.Count == 0 || update.Y.Count == 0)
-        {
-            return SurfaceValidationError(
-                update,
-                options,
-                stoppedSeries,
-                connection,
-                "Reactive plot update must contain at least one X and Y value.");
-        }
-
-        return update.X.Count != update.Y.Count
-            ? SurfaceValidationError(
-                update,
-                options,
-                stoppedSeries,
-                connection,
-                "Reactive plot update X and Y collections must have matching counts.")
-            : true;
-    }
+    /// <summary>Checks whether a plot update has non-empty X and Y collections.</summary>
+    /// <param name="update">The update value.</param>
+    /// <param name="options">The options value.</param>
+    /// <param name="stoppedSeries">The stoppedSeries value.</param>
+    /// <param name="connection">The connection value.</param>
+    /// <param name="x">The X values.</param>
+    /// <param name="y">The Y values.</param>
+    /// <returns><see langword="true"/> when the update carries at least one X and Y value.</returns>
+    private static bool HasUpdateValues(
+        ReactivePlotUpdate update,
+        ReactivePlotBindingOptions options,
+        HashSet<PlotSeriesKey> stoppedSeries,
+        ReactivePlotConnection connection,
+        IReadOnlyList<double> x,
+        IReadOnlyList<double> y) =>
+        (x.Count != 0
+        && y.Count != 0)
+        || SurfaceValidationError(
+            update,
+            options,
+            stoppedSeries,
+            connection,
+            "Reactive plot update must contain at least one X and Y value.");
 
     /// <summary>Handles the SurfaceValidationError operation.</summary>
     /// <param name="update">The update value.</param>

--- a/src/CrissCross.WPF.Plot/ThrowHelper.cs
+++ b/src/CrissCross.WPF.Plot/ThrowHelper.cs
@@ -45,4 +45,22 @@ internal static class ThrowHelper
 
         throw new ArgumentOutOfRangeException(paramName, message);
     }
+
+    /// <summary>Throws when an object has already been disposed.</summary>
+    /// <param name="condition">A value indicating whether the object is disposed.</param>
+    /// <param name="instance">The disposed object instance.</param>
+#if NET8_0_OR_GREATER
+    internal static void ThrowIfDisposed(bool condition, object instance) =>
+        ObjectDisposedException.ThrowIf(condition, instance);
+#else
+    internal static void ThrowIfDisposed(bool condition, object instance)
+    {
+        if (!condition)
+        {
+            return;
+        }
+
+        throw new ObjectDisposedException(instance.GetType().Name);
+    }
+#endif
 }

--- a/src/CrissCross.WPF.Plot/ViewModels/LiveChartViewModel{Initializations}.cs
+++ b/src/CrissCross.WPF.Plot/ViewModels/LiveChartViewModel{Initializations}.cs
@@ -335,29 +335,22 @@ public partial class LiveChartViewModel : RxObject
     /// <param name="lineUI">The plot UI element.</param>
     private void AssignYAxis(object axisSource, IPlottable line, IPlottableUI lineUI)
     {
-        switch (axisSource)
+        if (axisSource is IObservable<int> observable)
         {
-            case IObservable<int> observable:
-            {
-                _ = observable
-                    .DistinctUntilChanged()
-                    .Subscribe(axis => AssignYAxis(axis, line, lineUI))
-                    .DisposeWith(Disposables);
-                break;
-            }
-
-            case int axis:
-            {
-                AssignYAxis(axis, line, lineUI);
-                break;
-            }
-
-            default:
-            {
-                AssignDefaultYAxis(line, lineUI);
-                break;
-            }
+            _ = observable
+                .DistinctUntilChanged()
+                .Subscribe(axis => AssignYAxis(axis, line, lineUI))
+                .DisposeWith(Disposables);
+            return;
         }
+
+        if (axisSource is int axis)
+        {
+            AssignYAxis(axis, line, lineUI);
+            return;
+        }
+
+        AssignDefaultYAxis(line, lineUI);
     }
 
     /// <summary>Assigns a Y axis by index.</summary>

--- a/src/CrissCross.WPF.Plot/Views/LiveChart.xaml.cs
+++ b/src/CrissCross.WPF.Plot/Views/LiveChart.xaml.cs
@@ -7,14 +7,22 @@ using System.Runtime.Versioning;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+#if REACTIVE_SHIM
+using ReactiveUI.Binding.Reactive.Observables;
+#else
+using ReactiveUI.Binding.Observables;
+#endif
 #if !REACTIVE_SHIM
 using ReactiveUI;
 #endif
+using ReactiveUI.Primitives.ObservableEvents;
 using ScottPlot;
 using ScottPlot.Plottables;
 #if REACTIVELIST_REACTIVE
+using AppBarButton = CrissCross.Reactive.WPF.UI.Controls.AppBarButton;
 using AppBarIcons = CrissCross.Reactive.WPF.UI.Controls.AppBarIcons;
 #else
+using AppBarButton = CrissCross.WPF.UI.Controls.AppBarButton;
 using AppBarIcons = CrissCross.WPF.UI.Controls.AppBarIcons;
 #endif
 
@@ -96,12 +104,41 @@ public partial class LiveChart : ReactiveUserControl<LiveChartViewModel>
     /// </value>
     public bool First { get; set; } = true;
 
+    /// <summary>Gets the live-history command button.</summary>
+    public AppBarButton LiveHistoryButton => LiveHistoryBtn;
+
+    /// <summary>Gets the marker command button.</summary>
+    public AppBarButton EnableMarkerButton => EnableMarkerBtn;
+
+    /// <summary>Gets the add-crosshair command button.</summary>
+    public AppBarButton AddCrosshairButton => AddCrosshairBtn;
+
+    /// <summary>Gets the remove-label command button.</summary>
+    public AppBarButton RemoveLabelButton => RemoveLabelBtn;
+
+    /// <summary>Gets the right properties panel.</summary>
+    public RightPropertiesView RightPropertiesPanel => RightProperties;
+
+    /// <summary>Gets the chart title text block.</summary>
+    public TextBlock ChartTitleTextBlock => Title;
+
+    /// <summary>Gets the right legend scroll viewer.</summary>
+    public ScrollViewer RightLegendViewer => RightLegend;
+
+    /// <summary>Gets the top legend scroll viewer.</summary>
+    public ScrollViewer TopLegendViewer => TopLegend;
+
+    /// <summary>Converts a Boolean visibility state to a WPF visibility value.</summary>
+    /// <param name="isVisible">Whether the target should be visible.</param>
+    /// <returns>The matching WPF visibility value.</returns>
+    private static Visibility ToVisibility(bool isVisible) => isVisible ? Visibility.Visible : Visibility.Collapsed;
+
     /// <summary>Handles the ElementBinding1 operation.</summary>
     /// <param name="d">The d value.</param>
-    private void ElementBinding1(CompositeDisposable d)
+    private void ElementBinding1(ActivationDisposable d)
     {
         _ = new ActionDisposable(DisposeReactivePlotConnection).DisposeWith(d);
-        _ = UnloadedObservable().Subscribe(_ => DisposeReactivePlotConnection()).DisposeWith(d);
+        _ = this.Events().Unloaded.Subscribe(_ => DisposeReactivePlotConnection()).DisposeWith(d);
         BindCommands(d);
         BindMenuVisibility(d);
         BindRightProperties(d);
@@ -110,7 +147,7 @@ public partial class LiveChart : ReactiveUserControl<LiveChartViewModel>
 
     /// <summary>Binds the chart commands.</summary>
     /// <param name="disposables">The activation disposables.</param>
-    private void BindCommands(CompositeDisposable disposables)
+    private void BindCommands(ActivationDisposable disposables)
     {
         _ = this.BindCommand(ViewModel, static vm => vm.GraphLocked, static v => v.LiveHistoryBtn)
             .DisposeWith(disposables);
@@ -126,42 +163,55 @@ public partial class LiveChart : ReactiveUserControl<LiveChartViewModel>
 
     /// <summary>Binds menu expansion to command visibility.</summary>
     /// <param name="disposables">The activation disposables.</param>
-    private void BindMenuVisibility(CompositeDisposable disposables)
+    private void BindMenuVisibility(ActivationDisposable disposables)
     {
-        _ = this.OneWayBind(
-                ViewModel,
-                static vm => vm.IsMenuExpanded,
-                static v => v.LiveHistoryBtn.Visibility,
-                static x => x ? Visibility.Visible : Visibility.Collapsed)
+        var viewModel = ViewModel!;
+        _ = new PropertyObservable<bool>(
+                viewModel,
+                nameof(LiveChartViewModel.IsMenuExpanded),
+                static source => ((LiveChartViewModel)source).IsMenuExpanded,
+                true)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(isExpanded => LiveHistoryButton.Visibility = ToVisibility(isExpanded))
             .DisposeWith(disposables);
-        _ = this.OneWayBind(
-                ViewModel,
-                static vm => vm.IsMenuExpanded,
-                static v => v.EnableMarkerBtn.Visibility,
-                static x => x ? Visibility.Visible : Visibility.Collapsed)
+        _ = new PropertyObservable<bool>(
+                viewModel,
+                nameof(LiveChartViewModel.IsMenuExpanded),
+                static source => ((LiveChartViewModel)source).IsMenuExpanded,
+                true)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(isExpanded => EnableMarkerButton.Visibility = ToVisibility(isExpanded))
             .DisposeWith(disposables);
-        _ = this.OneWayBind(
-                ViewModel,
-                static vm => vm.IsMenuExpanded,
-                static v => v.AddCrosshairBtn.Visibility,
-                static x => x ? Visibility.Visible : Visibility.Collapsed)
+        _ = new PropertyObservable<bool>(
+                viewModel,
+                nameof(LiveChartViewModel.IsMenuExpanded),
+                static source => ((LiveChartViewModel)source).IsMenuExpanded,
+                true)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(isExpanded => AddCrosshairButton.Visibility = ToVisibility(isExpanded))
             .DisposeWith(disposables);
-        _ = this.OneWayBind(
-                ViewModel,
-                static vm => vm.IsMenuExpanded,
-                static v => v.RemoveLabelBtn.Visibility,
-                static x => x ? Visibility.Visible : Visibility.Collapsed)
+        _ = new PropertyObservable<bool>(
+                viewModel,
+                nameof(LiveChartViewModel.IsMenuExpanded),
+                static source => ((LiveChartViewModel)source).IsMenuExpanded,
+                true)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(isExpanded => RemoveLabelButton.Visibility = ToVisibility(isExpanded))
             .DisposeWith(disposables);
     }
 
     /// <summary>Binds the selected chart object to the right properties panel.</summary>
     /// <param name="disposables">The activation disposables.</param>
-    private void BindRightProperties(CompositeDisposable disposables)
+    private void BindRightProperties(ActivationDisposable disposables)
     {
-        _ = this.OneWayBind(
-                ViewModel,
-                static vm => vm.RightPropertyVisibility,
-                static v => v.RightProperties.Visibility)
+        var viewModel = ViewModel!;
+        _ = new PropertyObservable<Visibility>(
+                viewModel,
+                nameof(LiveChartViewModel.RightPropertyVisibility),
+                static source => ((LiveChartViewModel)source).RightPropertyVisibility,
+                true)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(visibility => RightPropertiesPanel.Visibility = visibility)
             .DisposeWith(disposables);
 
         _ = this.WhenAnyValue(static x => x.ViewModel!.SelectedSetting)
@@ -181,32 +231,60 @@ public partial class LiveChart : ReactiveUserControl<LiveChartViewModel>
 
     /// <summary>Binds chart titles, legends, and point-window settings.</summary>
     /// <param name="disposables">The activation disposables.</param>
-    private void BindChartMetadata(CompositeDisposable disposables)
+    private void BindChartMetadata(ActivationDisposable disposables)
     {
-        _ = this.OneWayBind(ViewModel, static vm => vm.Title, static v => v.Title.Text)
+        var viewModel = ViewModel!;
+        _ = new PropertyObservable<string>(
+                viewModel,
+                nameof(LiveChartViewModel.Title),
+                static source => ((LiveChartViewModel)source).Title,
+                true)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(title => ChartTitleTextBlock.Text = title)
             .DisposeWith(disposables);
-        _ = this.OneWayBind(
-                ViewModel,
-                static vm => vm.Title,
-                static v => v.Title.Visibility,
-                static x => x == " " ? Visibility.Collapsed : Visibility.Visible)
+        _ = new PropertyObservable<string>(
+                viewModel,
+                nameof(LiveChartViewModel.Title),
+                static source => ((LiveChartViewModel)source).Title,
+                true)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(title => ChartTitleTextBlock.Visibility = title == " " ? Visibility.Collapsed : Visibility.Visible)
             .DisposeWith(disposables);
-        _ = this.OneWayBind(
-                ViewModel,
-                static vm => vm.LegendPosition,
-                static v => v.RightLegend.Visibility,
-                static x => x == LegendPosition.Right ? Visibility.Visible : Visibility.Collapsed)
+        _ = new PropertyObservable<LegendPosition>(
+                viewModel,
+                nameof(LiveChartViewModel.LegendPosition),
+                static source => ((LiveChartViewModel)source).LegendPosition,
+                true)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(position => RightLegendViewer.Visibility = position == LegendPosition.Right
+                ? Visibility.Visible
+                : Visibility.Collapsed)
             .DisposeWith(disposables);
-        _ = this.OneWayBind(
-                ViewModel,
-                static vm => vm.LegendPosition,
-                static v => v.TopLegend.Visibility,
-                static x => x == LegendPosition.Top ? Visibility.Visible : Visibility.Collapsed)
+        _ = new PropertyObservable<LegendPosition>(
+                viewModel,
+                nameof(LiveChartViewModel.LegendPosition),
+                static source => ((LiveChartViewModel)source).LegendPosition,
+                true)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(position => TopLegendViewer.Visibility = position == LegendPosition.Top
+                ? Visibility.Visible
+                : Visibility.Collapsed)
             .DisposeWith(disposables);
-
-        _ = this.Bind(ViewModel, static vm => vm.UseFixedNumberOfPoints, static v => v.UseFixedNumberOfPoints)
+        _ = new PropertyObservable<bool>(
+                viewModel,
+                nameof(LiveChartViewModel.UseFixedNumberOfPoints),
+                static source => ((LiveChartViewModel)source).UseFixedNumberOfPoints,
+                true)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(value => UseFixedNumberOfPoints = value)
             .DisposeWith(disposables);
-        _ = this.Bind(ViewModel, static vm => vm.NumberPointsPlotted, static v => v.NumberPointsPlotted)
+        _ = new PropertyObservable<int>(
+                viewModel,
+                nameof(LiveChartViewModel.NumberPointsPlotted),
+                static source => ((LiveChartViewModel)source).NumberPointsPlotted,
+                true)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(value => NumberPointsPlotted = value)
             .DisposeWith(disposables);
     }
 

--- a/src/CrissCross.WPF.Plot/Views/LiveChart{DataSources}.cs
+++ b/src/CrissCross.WPF.Plot/Views/LiveChart{DataSources}.cs
@@ -2,7 +2,6 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Windows;
 #if !REACTIVE_SHIM
 using ReactiveUI;
 #endif
@@ -59,14 +58,15 @@ public partial class LiveChart
     {
         _reactivePlotConnection?.Dispose();
         _reactivePlotConnection = null;
+        DisposeCrosshairSubscription();
     }
 
-    /// <summary>Handles the UnloadedObservable operation.</summary>
-    /// <returns>The result.</returns>
-    private IObservable<EventPattern<RoutedEventArgs>> UnloadedObservable() =>
-        Observable.FromEventPattern<RoutedEventHandler, RoutedEventArgs>(
-            handler => Unloaded += handler,
-            handler => Unloaded -= handler);
+    /// <summary>Disposes the crosshair visibility subscription.</summary>
+    private void DisposeCrosshairSubscription()
+    {
+        _crosshairDisposable?.Dispose();
+        _crosshairDisposable = null;
+    }
 
     /// <summary>Handles the ChangeScatterObserver operation.</summary>
     /// <param name="input">The input value.</param>
@@ -80,7 +80,7 @@ public partial class LiveChart
         ExecuteMarkerOnOff();
         ViewModel?.InitializeScatterPlotLines(input.Data);
         ViewModel?.InitializeAxisLines();
-        _crosshairDisposable?.Dispose();
+        DisposeCrosshairSubscription();
     }
 
     /// <summary>Handles the ChangeScatterObserver operation.</summary>
@@ -94,7 +94,7 @@ public partial class LiveChart
         ExecuteMarkerOnOff();
         ViewModel?.InitializeScatterPlotLines(ScatterObservablesWithTimeStamp);
         ViewModel?.InitializeAxisLines();
-        _crosshairDisposable?.Dispose();
+        DisposeCrosshairSubscription();
     }
 
     /// <summary>Handles the ChangeSignalObserver operation.</summary>
@@ -109,7 +109,7 @@ public partial class LiveChart
         ExecuteMarkerOnOff();
         ViewModel?.InitializeSignalPlotLines(input.Data);
         ViewModel?.InitializeAxisLines();
-        _crosshairDisposable?.Dispose();
+        DisposeCrosshairSubscription();
         _crosshairDisposable = ViewModel
             .WhenAnyValue(x => x.CrossHairEnabled)
             .Subscribe(ApplyCrosshairVisibility);
@@ -126,7 +126,7 @@ public partial class LiveChart
         ExecuteMarkerOnOff();
         ViewModel?.InitializeSignalPlotLines(SignalObservablesWithTimeStamp);
         ViewModel?.InitializeAxisLines();
-        _crosshairDisposable?.Dispose();
+        DisposeCrosshairSubscription();
         _crosshairDisposable = ViewModel
             .WhenAnyValue(x => x.CrossHairEnabled)
             .Subscribe(ApplyCrosshairVisibility);
@@ -144,7 +144,7 @@ public partial class LiveChart
         ExecuteMarkerOnOff();
         ViewModel?.InitializeDataLoggerPlotLinesWithPoints(input.Data);
         ViewModel?.InitializeAxisLines();
-        _crosshairDisposable?.Dispose();
+        DisposeCrosshairSubscription();
     }
 
     /// <summary>Handles the ChangeDataLoggerObserver operation.</summary>
@@ -158,7 +158,7 @@ public partial class LiveChart
         ExecuteMarkerOnOff();
         ViewModel?.InitializeDataLoggerPlotLinesWithPoints(DataLoggerObservablesWithPoints);
         ViewModel?.InitializeAxisLines();
-        _crosshairDisposable?.Dispose();
+        DisposeCrosshairSubscription();
     }
 
     /// <summary>Handles the ChangeSignalData operation.</summary>
@@ -173,7 +173,7 @@ public partial class LiveChart
         ExecuteMarkerOnOff();
         ViewModel?.InitializeSignalPlotLines(input.Data);
         ViewModel?.InitializeAxisLines();
-        _crosshairDisposable?.Dispose();
+        DisposeCrosshairSubscription();
     }
 
     /// <summary>Handles the ChangeSignalData operation.</summary>
@@ -187,7 +187,7 @@ public partial class LiveChart
         ExecuteMarkerOnOff();
         ViewModel?.InitializeSignalPlotLines(DataWithTimeStamp);
         ViewModel?.InitializeAxisLines();
-        _crosshairDisposable?.Dispose();
+        DisposeCrosshairSubscription();
     }
 
     /// <summary>Handles the ChangeSignalDataWithPoints operation.</summary>
@@ -208,7 +208,7 @@ public partial class LiveChart
         ViewModel?.InitializeLinesForSignalPoints(data);
         InitializeControlMenu();
         ViewModel?.InitializeAxisLines();
-        _crosshairDisposable?.Dispose();
+        DisposeCrosshairSubscription();
     }
 
     /// <summary>Handles the ChangeSignalDataWithPoints operation.</summary>
@@ -236,7 +236,7 @@ public partial class LiveChart
             fs: Frequency,
             sampleCount: Convert.ToUInt32(NSamples));
         ViewModel?.InitializeAxisLines();
-        _crosshairDisposable?.Dispose();
+        DisposeCrosshairSubscription();
     }
 
     /// <summary>Handles the ChangeSignalDataObserverWithPoints operation.</summary>
@@ -253,7 +253,7 @@ public partial class LiveChart
             fs: Frequency,
             sampleCount: Convert.ToUInt32(NSamples));
         ViewModel?.InitializeAxisLines();
-        _crosshairDisposable?.Dispose();
+        DisposeCrosshairSubscription();
     }
 
     /// <summary>Handles the ChangeScatterDataWithPoints operation.</summary>
@@ -269,7 +269,7 @@ public partial class LiveChart
         ViewModel?.InitializeLinesForScatterPoints(input.Data);
         InitializeControlMenu();
         ViewModel?.InitializeAxisLines();
-        _crosshairDisposable?.Dispose();
+        DisposeCrosshairSubscription();
     }
 
     /// <summary>Handles the ChangeScatterDataWithPoints operation.</summary>
@@ -284,7 +284,7 @@ public partial class LiveChart
         ViewModel?.InitializeLinesForScatterPoints(ScatterWithPoints);
         InitializeControlMenu();
         ViewModel?.InitializeAxisLines();
-        _crosshairDisposable?.Dispose();
+        DisposeCrosshairSubscription();
     }
 
     /// <summary>Updates crosshair visibility for every active plot line.</summary>

--- a/src/CrissCross.WPF.Plot/Views/LiveChart{Properties}.cs
+++ b/src/CrissCross.WPF.Plot/Views/LiveChart{Properties}.cs
@@ -280,57 +280,27 @@ public partial class LiveChart
     /// <param name="type">The target plot type.</param>
     public void AssignLiveChartData(object source, UserPlotType type)
     {
-        switch (type, source)
-        {
-            case (UserPlotType.SignalEnumObsTicks, SignalEnumObsTicks data):
-            {
-                ChangeSignalObserver(data);
-                break;
-            }
-
-            case (UserPlotType.DataLoggerEnumObsPoints, DataLoggerEnumObsPoints data):
-            {
-                ChangeDataLoggerObserver(data);
-                break;
-            }
-
-            case (UserPlotType.SignalXYTimestamp, SignalXYTimestamp data):
-            {
-                ChangeSignalData(data);
-                break;
-            }
-
-            case (UserPlotType.SignalXYPoints, SignalXYPoints data):
-            {
-                ChangeSignalDataWithPoints(data);
-                break;
-            }
-
-            case (UserPlotType.SignalXYEnumPoints, SignalXYEnumPoints data):
-            {
-                ChangeSignalsDataWithPoints(data);
-                break;
-            }
-
-            case (UserPlotType.StreamerEnumObsPoints, StreamerEnumObsPoints data):
-            {
-                ChangeSignalDataObserverWithPoints(data);
-                break;
-            }
-
-            case (UserPlotType.ScatterEnumObsPoints, ScatterEnumObsPoints data):
-            {
-                ChangeScatterObserver(data);
-                break;
-            }
-
-            case (UserPlotType.ScatterPoints, ScatterPoints data):
-            {
-                ChangeScatterDataWithPoints(data);
-                break;
-            }
-        }
+        var assignment = ResolveLiveChartDataAssignment(source, type);
+        assignment?.Invoke();
     }
+
+    /// <summary>Resolves a live data assignment action for the selected plot type.</summary>
+    /// <param name="source">The source value.</param>
+    /// <param name="type">The target plot type.</param>
+    /// <returns>The assignment action, or <see langword="null"/> when the source does not match the plot type.</returns>
+    private Action? ResolveLiveChartDataAssignment(object source, UserPlotType type) =>
+        (type, source) switch
+        {
+            (UserPlotType.SignalEnumObsTicks, SignalEnumObsTicks data) => () => ChangeSignalObserver(data),
+            (UserPlotType.DataLoggerEnumObsPoints, DataLoggerEnumObsPoints data) => () => ChangeDataLoggerObserver(data),
+            (UserPlotType.SignalXYTimestamp, SignalXYTimestamp data) => () => ChangeSignalData(data),
+            (UserPlotType.SignalXYPoints, SignalXYPoints data) => () => ChangeSignalDataWithPoints(data),
+            (UserPlotType.SignalXYEnumPoints, SignalXYEnumPoints data) => () => ChangeSignalsDataWithPoints(data),
+            (UserPlotType.StreamerEnumObsPoints, StreamerEnumObsPoints data) => () => ChangeSignalDataObserverWithPoints(data),
+            (UserPlotType.ScatterEnumObsPoints, ScatterEnumObsPoints data) => () => ChangeScatterObserver(data),
+            (UserPlotType.ScatterPoints, ScatterPoints data) => () => ChangeScatterDataWithPoints(data),
+            _ => null,
+        };
 
     /// <summary>Provides named observable XY signal series with axis assignments.</summary>
     /// <param name="Data">The Data value.</param>

--- a/src/CrissCross.WPF.Plot/Views/RightPropertiesView.xaml.cs
+++ b/src/CrissCross.WPF.Plot/Views/RightPropertiesView.xaml.cs
@@ -3,14 +3,27 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Runtime.Versioning;
+using System.Windows;
+using System.Windows.Controls;
+#if REACTIVE_SHIM
+using ReactiveUI.Binding.Reactive.Observables;
+using BindingDependencyObjectObservableForProperty = ReactiveUI.Binding.Reactive.Wpf.DependencyObjectObservableForProperty;
+using LinqExpression = System.Linq.Expressions.Expression;
+#else
+using ReactiveUI.Binding.Observables;
+using BindingDependencyObjectObservableForProperty = ReactiveUI.Binding.Wpf.DependencyObjectObservableForProperty;
+using LinqExpression = System.Linq.Expressions.Expression;
+#endif
 #if !REACTIVE_SHIM
 using ReactiveUI;
 #endif
 using ReactiveUI.SourceGenerators;
 
 #if REACTIVELIST_REACTIVE
+using NumberBox = CrissCross.Reactive.WPF.UI.Controls.NumberBox;
 namespace CrissCross.Reactive.WPF.Plot;
 #else
+using NumberBox = CrissCross.WPF.UI.Controls.NumberBox;
 namespace CrissCross.WPF.Plot;
 #endif
 
@@ -39,18 +52,90 @@ public partial class RightPropertiesView
         _ = this.WhenActivated(BindViewModel);
     }
 
+    /// <summary>Gets the item name text box.</summary>
+    public TextBox ItemNameTextBox => textbox1;
+
+    /// <summary>Gets the line-width number box.</summary>
+    public NumberBox LineWidthNumberBox => LineWidth;
+
+    /// <summary>Gets the color combo box.</summary>
+    public ComboBox ColorsComboBox => colorsComboBox;
+
+    /// <summary>Gets the visibility combo box.</summary>
+    public ComboBox VisibilityComboBox => visibilityComboBox;
+
+    /// <summary>Observes a WPF dependency property and invokes an update when the value changes.</summary>
+    /// <param name="target">The dependency object to observe.</param>
+    /// <param name="propertyName">The dependency property name.</param>
+    /// <param name="update">The update action to run when the dependency property changes.</param>
+    /// <returns>A disposable dependency-property observation subscription.</returns>
+    private static IDisposable ObserveDependencyProperty(DependencyObject target, string propertyName, Action update)
+    {
+        BindingDependencyObjectObservableForProperty factory = new();
+        return factory
+            .GetNotificationForProperty(target, LinqExpression.Constant(target), propertyName, false, false)
+            .Subscribe(_ => update());
+    }
+
     /// <summary>Binds the view model to the view controls.</summary>
     /// <param name="disposables">The activation disposables.</param>
-    private void BindViewModel(CompositeDisposable disposables)
+    private void BindViewModel(ActivationDisposable disposables)
     {
         ViewModel = new();
         DataContext = ViewModel;
         _ = this.BindCommand(ViewModel, vm => vm.SaveConfiguration, v => v.SaveBtn).DisposeWith(disposables);
 
-        _ = this.Bind(ViewModel, vm => vm.ItemName, v => v.textbox1.Text).DisposeWith(disposables);
-        _ = this.Bind(ViewModel, vm => vm.LineWidth, v => v.LineWidth.Value).DisposeWith(disposables);
-        _ = this.Bind(ViewModel, vm => vm.LineColor, v => v.colorsComboBox.SelectedItem).DisposeWith(disposables);
-        _ = this.Bind(ViewModel, vm => vm.ItemVisibility, v => v.visibilityComboBox.SelectedItem)
+        _ = new PropertyObservable<string?>(
+                ViewModel,
+                nameof(RightPropertiesViewModel.ItemName),
+                static source => ((RightPropertiesViewModel)source).ItemName,
+                true)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(value => ItemNameTextBox.Text = value)
+            .DisposeWith(disposables);
+        _ = ObserveDependencyProperty(ItemNameTextBox, nameof(TextBox.Text), () => ViewModel.ItemName = ItemNameTextBox.Text)
+            .DisposeWith(disposables);
+
+        _ = new PropertyObservable<double>(
+                ViewModel,
+                nameof(RightPropertiesViewModel.LineWidth),
+                static source => ((RightPropertiesViewModel)source).LineWidth,
+                true)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(value => LineWidthNumberBox.Value = value)
+            .DisposeWith(disposables);
+        _ = ObserveDependencyProperty(
+                LineWidthNumberBox,
+                nameof(NumberBox.Value),
+                () => ViewModel.LineWidth = LineWidthNumberBox.Value ?? 0D)
+            .DisposeWith(disposables);
+
+        _ = new PropertyObservable<string?>(
+                ViewModel,
+                nameof(RightPropertiesViewModel.LineColor),
+                static source => ((RightPropertiesViewModel)source).LineColor,
+                true)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(value => ColorsComboBox.SelectedItem = value)
+            .DisposeWith(disposables);
+        _ = ObserveDependencyProperty(
+                ColorsComboBox,
+                nameof(ComboBox.SelectedItem),
+                () => ViewModel.LineColor = ColorsComboBox.SelectedItem as string)
+            .DisposeWith(disposables);
+
+        _ = new PropertyObservable<string?>(
+                ViewModel,
+                nameof(RightPropertiesViewModel.ItemVisibility),
+                static source => ((RightPropertiesViewModel)source).ItemVisibility,
+                true)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(value => VisibilityComboBox.SelectedItem = value)
+            .DisposeWith(disposables);
+        _ = ObserveDependencyProperty(
+                VisibilityComboBox,
+                nameof(ComboBox.SelectedItem),
+                () => ViewModel.ItemVisibility = VisibilityComboBox.SelectedItem as string)
             .DisposeWith(disposables);
     }
 }

--- a/src/CrissCross.WPF.Plot/WpfReactivePlotAdapter.cs
+++ b/src/CrissCross.WPF.Plot/WpfReactivePlotAdapter.cs
@@ -69,55 +69,13 @@ internal sealed partial class WpfReactivePlotAdapter : IReactivePlotAdapter
         Key = key;
         PlotType = plotType;
 
-        switch (plotType)
-        {
-            case PlotType.Signal:
-            {
-                _signalSubject = new();
-                break;
-            }
-
-            case PlotType.Scatter:
-            {
-                _scatterSubject = new();
-                _ui = new ScatterUI(_chart.WpfPlot1vm!, _scatterSubject, _color);
-                AddUi();
-                break;
-            }
-
-            case PlotType.DataLogger:
-            {
-                _dataLoggerSubject = new();
-                _ui = new DataLoggerUI(_chart.WpfPlot1vm!, _dataLoggerSubject, _color);
-                AddUi();
-                break;
-            }
-
-            case PlotType.Streamer:
-            {
-                _streamerSubject = new();
-                _ui = new StreamerUI(
-                    _chart.WpfPlot1vm!,
-                    _streamerSubject,
-                    fs: 1,
-                    sampleCount: 1,
-                    plottedPointCount: Math.Max(1, _chart.NumberPointsPlotted),
-                    _color);
-                AddUi();
-                break;
-            }
-
-            case PlotType.SignalXY
-            or PlotType.Line
-            or PlotType.StepLine
-            or PlotType.Area
-            or PlotType.Bar
-            or PlotType.Stem
-            or PlotType.Points:
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(plotType), plotType, "Unsupported reactive plot type.");
-        }
+        var initialization = CreateInitialization(plotType);
+        _signalSubject = initialization.SignalSubject;
+        _scatterSubject = initialization.ScatterSubject;
+        _dataLoggerSubject = initialization.DataLoggerSubject;
+        _streamerSubject = initialization.StreamerSubject;
+        _ui = initialization.Ui;
+        AddUiIfPresent();
     }
 
     /// <summary>Gets the key value.</summary>
@@ -160,6 +118,55 @@ internal sealed partial class WpfReactivePlotAdapter : IReactivePlotAdapter
         RemoveSnapshotPlottable();
     }
 
+    /// <summary>Creates plot-type specific adapter state.</summary>
+    /// <param name="plotType">The plot type.</param>
+    /// <returns>The initialized adapter state.</returns>
+    private PlotAdapterInitialization CreateInitialization(PlotType plotType) =>
+        plotType switch
+        {
+            PlotType.Signal => new(new(), null, null, null, null),
+            PlotType.Scatter => CreateScatterInitialization(),
+            PlotType.DataLogger => CreateDataLoggerInitialization(),
+            PlotType.Streamer => CreateStreamerInitialization(),
+            PlotType.SignalXY or PlotType.Line or PlotType.StepLine or PlotType.Area or PlotType.Bar or PlotType.Stem or PlotType.Points => new(null, null, null, null, null),
+            _ => throw new ArgumentOutOfRangeException(nameof(plotType), plotType, "Unsupported reactive plot type."),
+        };
+
+    /// <summary>Creates scatter adapter state.</summary>
+    /// <returns>The initialized adapter state.</returns>
+    private PlotAdapterInitialization CreateScatterInitialization()
+    {
+        Signal<(string? Name, IList<double>? X, IList<double> Y, int Axis)> scatterSubject = new();
+        return new(null, scatterSubject, null, null, new ScatterUI(_chart.WpfPlot1vm!, scatterSubject, _color));
+    }
+
+    /// <summary>Creates data logger adapter state.</summary>
+    /// <returns>The initialized adapter state.</returns>
+    private PlotAdapterInitialization CreateDataLoggerInitialization()
+    {
+        Signal<(string? Name, IList<double>? Value, int Axis, int nPoints)> dataLoggerSubject = new();
+        return new(null, null, dataLoggerSubject, null, new DataLoggerUI(_chart.WpfPlot1vm!, dataLoggerSubject, _color));
+    }
+
+    /// <summary>Creates streamer adapter state.</summary>
+    /// <returns>The initialized adapter state.</returns>
+    private PlotAdapterInitialization CreateStreamerInitialization()
+    {
+        Signal<(string? Name, IList<double>? Y, IList<double> X, int Axis)> streamerSubject = new();
+        return new(
+            null,
+            null,
+            null,
+            streamerSubject,
+            new StreamerUI(
+                _chart.WpfPlot1vm!,
+                streamerSubject,
+                fs: 1,
+                sampleCount: 1,
+                plottedPointCount: Math.Max(1, _chart.NumberPointsPlotted),
+                _color));
+    }
+
     /// <summary>Ensures the shared chart X axis matches the incoming series.</summary>
     /// <param name="axisKind">The incoming X-axis interpretation.</param>
     private void ConfigureXAxis(PlotXAxisKind axisKind)
@@ -184,86 +191,48 @@ internal sealed partial class WpfReactivePlotAdapter : IReactivePlotAdapter
 
     /// <summary>Throws when the adapter has been disposed.</summary>
     private void EnsureNotDisposed() =>
-        _ = _disposed ? throw new ObjectDisposedException(nameof(WpfReactivePlotAdapter)) : false;
+        ThrowHelper.ThrowIfDisposed(_disposed, this);
 
     /// <summary>Applies clear semantics for clear and replace updates.</summary>
     /// <param name="update">The update value.</param>
     /// <returns><see langword="true"/> when the update was a terminal clear.</returns>
-    private bool TryApplyClear(ReactivePlotUpdate update)
-    {
-        switch (update.Kind)
+    private bool TryApplyClear(ReactivePlotUpdate update) =>
+        update.Kind switch
         {
-            case ReactivePlotUpdateKind.Clear:
-            {
-                ApplyClear(update);
-                return true;
-            }
-
-            case ReactivePlotUpdateKind.Replace:
-            {
-                ApplyClear(update);
-                return false;
-            }
-
-            default:
-                return false;
-        }
-    }
+            ReactivePlotUpdateKind.Clear => ApplyClear(update, true),
+            ReactivePlotUpdateKind.Replace => ApplyClear(update, false),
+            _ => false,
+        };
 
     /// <summary>Applies a non-clear plot update.</summary>
     /// <param name="update">The update value.</param>
     private void ApplyPlotUpdate(ReactivePlotUpdate update)
     {
-        switch (PlotType)
-        {
-            case PlotType.Signal:
-            {
-                ApplySignal(update);
-                break;
-            }
-
-            case PlotType.Scatter:
-            {
-                ApplyScatter(update);
-                break;
-            }
-
-            case PlotType.DataLogger:
-            {
-                ApplyDataLogger(update);
-                break;
-            }
-
-            case PlotType.Streamer:
-            {
-                ApplyStreamer(update);
-                break;
-            }
-
-            case PlotType.SignalXY:
-            {
-                ApplySignalXy(PrepareSnapshotUpdate(update));
-                break;
-            }
-
-            case PlotType.Line
-            or PlotType.StepLine
-            or PlotType.Area
-            or PlotType.Bar
-            or PlotType.Stem
-            or PlotType.Points:
-            {
-                ApplySnapshot(update);
-                break;
-            }
-
-            default:
-                throw new ArgumentOutOfRangeException(
-                    nameof(PlotType),
-                    PlotType,
-                    "The plot type is not supported by the WPF adapter.");
-        }
+        var apply = ResolvePlotUpdateApplier();
+        apply(update);
     }
+
+    /// <summary>Resolves the update applier for the current plot type.</summary>
+    /// <returns>The update applier.</returns>
+    private Action<ReactivePlotUpdate> ResolvePlotUpdateApplier() =>
+        PlotType switch
+        {
+            PlotType.Signal => ApplySignal,
+            PlotType.Scatter => ApplyScatter,
+            PlotType.DataLogger => ApplyDataLogger,
+            PlotType.Streamer => ApplyStreamer,
+            PlotType.SignalXY => ApplySignalXySnapshot,
+            PlotType.Line or PlotType.StepLine or PlotType.Area or PlotType.Bar or PlotType.Stem or PlotType.Points => ApplySnapshot,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(PlotType),
+                PlotType,
+                "The plot type is not supported by the WPF adapter."),
+        };
+
+    /// <summary>Applies a signal XY update after preparing snapshot values.</summary>
+    /// <param name="update">The update value.</param>
+    private void ApplySignalXySnapshot(ReactivePlotUpdate update) =>
+        ApplySignalXy(PrepareSnapshotUpdate(update));
 
     /// <summary>Renders a retained snapshot using one of the extended ScottPlot chart types.</summary>
     /// <param name="update">The source update.</param>
@@ -316,31 +285,29 @@ internal sealed partial class WpfReactivePlotAdapter : IReactivePlotAdapter
 
         var color = ResolveColor(style.Color ?? _color);
         _snapshotPlottable.IsVisible = style.LineMode != PlotLineMode.Hidden;
-        switch (_snapshotPlottable)
+        var apply = _snapshotPlottable switch
         {
-            case Scatter scatter:
-            {
-                scatter.LineColor = color;
-                scatter.MarkerColor = color;
-                scatter.LineWidth = style.LineMode == PlotLineMode.MarkersOnly ? 0 : style.LineWidth;
-                scatter.MarkerSize = style.LineMode == PlotLineMode.LineOnly ? 0 : style.MarkerSize;
-                break;
-            }
+            Scatter scatter => new Action(() => ApplyScatterStyle(scatter, color, style)),
+            BarPlot bars => () => bars.Color = color,
+            LollipopPlot stem => () => ApplyStemStyle(stem, color, style),
+            _ => null,
+        };
+        apply?.Invoke();
 
-            case BarPlot bars:
-            {
-                bars.Color = color;
-                break;
-            }
+        static void ApplyScatterStyle(Scatter scatter, Color color, ReactivePlotSeriesStyle style)
+        {
+            scatter.LineColor = color;
+            scatter.MarkerColor = color;
+            scatter.LineWidth = style.LineMode == PlotLineMode.MarkersOnly ? 0 : style.LineWidth;
+            scatter.MarkerSize = style.LineMode == PlotLineMode.LineOnly ? 0 : style.MarkerSize;
+        }
 
-            case LollipopPlot stem:
-            {
-                stem.LineColor = color;
-                stem.MarkerColor = color;
-                stem.LineWidth = style.LineWidth;
-                stem.MarkerSize = style.MarkerSize;
-                break;
-            }
+        static void ApplyStemStyle(LollipopPlot stem, Color color, ReactivePlotSeriesStyle style)
+        {
+            stem.LineColor = color;
+            stem.MarkerColor = color;
+            stem.LineWidth = style.LineWidth;
+            stem.MarkerSize = style.MarkerSize;
         }
     }
 
@@ -481,42 +448,35 @@ internal sealed partial class WpfReactivePlotAdapter : IReactivePlotAdapter
         _chart.WpfPlot1vm?.Refresh();
     }
 
+    /// <summary>Applies a clear operation and returns the requested result.</summary>
+    /// <param name="update">The update value.</param>
+    /// <param name="result">The result to return.</param>
+    /// <returns>The supplied result.</returns>
+    private bool ApplyClear(ReactivePlotUpdate update, bool result)
+    {
+        ApplyClear(update);
+        return result;
+    }
+
     /// <summary>Clears the current UI element.</summary>
     private void ClearUi()
     {
-        switch (_ui)
-        {
-            case SignalXY_UI signalXy:
-            {
-                ClearSignalXy(signalXy);
-                break;
-            }
-
-            case ScatterUI scatter:
-            {
-                scatter.InsertData([], []);
-                break;
-            }
-
-            case SignalUI signal:
-            {
-                signal.ClearData();
-                break;
-            }
-
-            case DataLoggerUI dataLogger:
-            {
-                dataLogger.PlotLine!.Data.Coordinates.Clear();
-                break;
-            }
-
-            case StreamerUI streamer:
-            {
-                ClearStreamer(streamer);
-                break;
-            }
-        }
+        var clear = ResolveClearUiAction();
+        clear?.Invoke();
     }
+
+    /// <summary>Resolves the clear action for the current UI element.</summary>
+    /// <returns>The clear action, or <see langword="null"/> when no UI element is active.</returns>
+    private Action? ResolveClearUiAction() =>
+        _ui switch
+        {
+            SignalXY_UI signalXy => () => ClearSignalXy(signalXy),
+            ScatterUI scatter => () => scatter.InsertData([], []),
+            SignalUI signal => signal.ClearData,
+            DataLoggerUI dataLogger => () => dataLogger.PlotLine!.Data.Coordinates.Clear(),
+            StreamerUI streamer => () => ClearStreamer(streamer),
+            _ => null,
+        };
 
     /// <summary>Clears a streamer UI element.</summary>
     /// <param name="streamer">The streamer UI element.</param>
@@ -578,4 +538,28 @@ internal sealed partial class WpfReactivePlotAdapter : IReactivePlotAdapter
         _chart.WpfPlot1vm?.Plot.Remove(_snapshotPlottable);
         _snapshotPlottable = null;
     }
+
+    /// <summary>Adds the UI element when the current plot type owns one.</summary>
+    private void AddUiIfPresent()
+    {
+        if (_ui is null)
+        {
+            return;
+        }
+
+        AddUi();
+    }
+
+    /// <summary>Stores the constructor output for plot-type specific adapter state.</summary>
+    /// <param name="SignalSubject">The signal subject.</param>
+    /// <param name="ScatterSubject">The scatter subject.</param>
+    /// <param name="DataLoggerSubject">The data logger subject.</param>
+    /// <param name="StreamerSubject">The streamer subject.</param>
+    /// <param name="Ui">The UI plottable.</param>
+    private sealed record PlotAdapterInitialization(
+        Signal<(string? Name, IList<double>? Value, IList<double> X, int Axis)>? SignalSubject,
+        Signal<(string? Name, IList<double>? X, IList<double> Y, int Axis)>? ScatterSubject,
+        Signal<(string? Name, IList<double>? Value, int Axis, int nPoints)>? DataLoggerSubject,
+        Signal<(string? Name, IList<double>? Y, IList<double> X, int Axis)>? StreamerSubject,
+        IPlottableUI? Ui);
 }

--- a/src/CrissCross.WPF.Plot/WpfReactivePlotAdapter{Helpers}.cs
+++ b/src/CrissCross.WPF.Plot/WpfReactivePlotAdapter{Helpers}.cs
@@ -112,32 +112,28 @@ internal sealed partial class WpfReactivePlotAdapter
     private static void SetLegendText(IPlottable plottable, string name, bool showInLegend)
     {
         var legendText = showInLegend ? name : string.Empty;
-        switch (plottable)
+        if (plottable is Scatter scatter)
         {
-            case Scatter scatter:
-            {
-                scatter.LegendText = legendText;
-                break;
-            }
-
-            case BarPlot bars:
-            {
-                bars.LegendText = legendText;
-                break;
-            }
-
-            case LollipopPlot stem:
-            {
-                stem.LegendText = legendText;
-                break;
-            }
-
-            default:
-                throw new ArgumentOutOfRangeException(
-                    nameof(plottable),
-                    plottable,
-                    "The plottable does not support legend text.");
+            scatter.LegendText = legendText;
+            return;
         }
+
+        if (plottable is BarPlot bars)
+        {
+            bars.LegendText = legendText;
+            return;
+        }
+
+        if (plottable is LollipopPlot stem)
+        {
+            stem.LegendText = legendText;
+            return;
+        }
+
+        throw new ArgumentOutOfRangeException(
+            nameof(plottable),
+            plottable,
+            "The plottable does not support legend text.");
     }
 
     /// <summary>Resolves a named or hexadecimal series color.</summary>

--- a/src/CrissCross.WPF.UI.Gallery/ViewModels/AllControlsViewModel.cs
+++ b/src/CrissCross.WPF.UI.Gallery/ViewModels/AllControlsViewModel.cs
@@ -236,16 +236,9 @@ public class AllControlsViewModel : RxObject
     /// <summary>Filters a control item by the current search text.</summary>
     /// <param name="obj">The item to filter.</param>
     /// <returns>true when the item is visible.</returns>
-    private bool FilterPredicate(object obj)
-    {
-        if (obj is not ControlItem item)
-        {
-            return false;
-        }
-
-        return string.IsNullOrWhiteSpace(FilterText)
-            ? true
-            : item.Name.Contains(FilterText, StringComparison.OrdinalIgnoreCase)
-                || (item.Description?.Contains(FilterText, StringComparison.OrdinalIgnoreCase) ?? false);
-    }
+    private bool FilterPredicate(object obj) =>
+        obj is ControlItem item
+        && (string.IsNullOrWhiteSpace(FilterText)
+            || item.Name.Contains(FilterText, StringComparison.OrdinalIgnoreCase)
+            || (item.Description?.Contains(FilterText, StringComparison.OrdinalIgnoreCase) ?? false));
 }

--- a/src/CrissCross.WPF.UI.Gallery/ViewModels/ControlCatalogViewModel.cs
+++ b/src/CrissCross.WPF.UI.Gallery/ViewModels/ControlCatalogViewModel.cs
@@ -2,6 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using CrissCross;
 using ReactiveUI;
 
 namespace CrissCross.WPF.UI.Gallery.ViewModels;
@@ -9,6 +10,42 @@ namespace CrissCross.WPF.UI.Gallery.ViewModels;
 /// <summary>Provides the reactive state for the curated WPF control catalog.</summary>
 public class ControlCatalogViewModel : RxObject
 {
+    /// <summary>Defines the reactor temperature in the gallery example.</summary>
+    private const double ReactorTemperature = 68.4D;
+
+    /// <summary>Defines the temperature maximum in the gallery example.</summary>
+    private const double TemperatureMaximum = 120D;
+
+    /// <summary>Defines the temperature low alarm in the gallery example.</summary>
+    private const double TemperatureLowAlarm = 15D;
+
+    /// <summary>Defines the temperature high alarm in the gallery example.</summary>
+    private const double TemperatureHighAlarm = 95D;
+
+    /// <summary>Defines the line pressure in the gallery example.</summary>
+    private const double LinePressure = 12.8D;
+
+    /// <summary>Defines the pressure maximum in the gallery example.</summary>
+    private const double PressureMaximum = 16D;
+
+    /// <summary>Defines the pressure low alarm in the gallery example.</summary>
+    private const double PressureLowAlarm = 2D;
+
+    /// <summary>Defines the pressure high alarm in the gallery example.</summary>
+    private const double PressureHighAlarm = 12D;
+
+    /// <summary>Defines the flow rate in the gallery example.</summary>
+    private const double FlowRate = 318D;
+
+    /// <summary>Defines the flow maximum in the gallery example.</summary>
+    private const double FlowMaximum = 500D;
+
+    /// <summary>Defines the flow low alarm in the gallery example.</summary>
+    private const double FlowLowAlarm = 50D;
+
+    /// <summary>Defines the flow high alarm in the gallery example.</summary>
+    private const double FlowHighAlarm = 450D;
+
     /// <summary>Initializes a new instance of the <see cref="ControlCatalogViewModel"/> class.</summary>
     public ControlCatalogViewModel()
     {
@@ -18,6 +55,35 @@ public class ControlCatalogViewModel : RxObject
 
     /// <summary>Gets the command that refreshes the deterministic catalog status.</summary>
     public ReactiveCommand<Unit, Unit> RefreshCommand { get; }
+
+    /// <summary>Gets a nominal process value example for industrial readout demos.</summary>
+    public ProcessValueState NormalProcessValue { get; } = new(
+        "Reactor temperature",
+        ReactorTemperature,
+        "deg C",
+        0D,
+        TemperatureMaximum,
+        TemperatureLowAlarm,
+        TemperatureHighAlarm);
+
+    /// <summary>Gets a high-alarm process value example for industrial readout demos.</summary>
+    public ProcessValueState AlarmProcessValue { get; } = new(
+        "Line pressure",
+        LinePressure,
+        "bar",
+        0D,
+        PressureMaximum,
+        PressureLowAlarm,
+        PressureHighAlarm);
+
+    /// <summary>Gets an unavailable process value example for industrial readout demos.</summary>
+    public ProcessValueState BadQualityProcessValue { get; } = new(
+        "Flow rate",
+        FlowRate,
+        "L/min",
+        0D,
+        FlowMaximum,
+        new ProcessValueOptions { LowAlarmLimit = FlowLowAlarm, HighAlarmLimit = FlowHighAlarm, IsGoodQuality = false });
 
     /// <summary>Gets the status shown by the catalog's interactive command example.</summary>
     public string StatusText

--- a/src/CrissCross.WPF.UI.Gallery/Views/ControlCatalogView.xaml
+++ b/src/CrissCross.WPF.UI.Gallery/Views/ControlCatalogView.xaml
@@ -16,27 +16,35 @@
       <ui:Button Width="220" HorizontalAlignment="Left" Command="{Binding RefreshCommand}" Content="Refresh catalog status" />
       <ui:TextBlock Margin="0,6,0,12" Text="{Binding StatusText}" />
 
+      <ui:GroupBox Header="Industrial process values" Margin="0,0,0,12">
+        <WrapPanel Margin="8">
+          <ui:ProcessValueIndicator VerticalAlignment="Top" Width="240" Margin="4" State="{Binding NormalProcessValue}" />
+          <ui:ProcessValueIndicator VerticalAlignment="Top" Width="240" Margin="4" State="{Binding AlarmProcessValue}" />
+          <ui:ProcessValueIndicator VerticalAlignment="Top" Width="240" Margin="4" State="{Binding BadQualityProcessValue}" />
+        </WrapPanel>
+      </ui:GroupBox>
+
       <ui:GroupBox Header="Status, containers and presentation">
         <WrapPanel Margin="8">
-          <ui:AlarmBanner Width="280" Margin="4" IsActive="True" Message="Alarm is active." Severity="Informational" />
-          <ui:Alarms Width="160" Height="48" Margin="4" />
-          <ui:Arc Width="72" Height="72" Margin="4" Stroke="{DynamicResource TextFillColorPrimaryBrush}" StrokeThickness="4" />
-          <ui:Badge Margin="4" Content="Badge" />
-          <ui:Border Width="160" Height="48" Margin="4"><TextBlock Text="WPF UI border" /></ui:Border>
-          <ui:BusyOverlay Width="160" Height="48" Margin="4" Content="BusyOverlay content" />
-          <ui:Calendar Width="260" Margin="4" />
-          <ui:Card Width="180" Margin="4" Content="Card content" />
-          <ui:CardAction Width="160" Margin="4" Content="Card action" />
-          <ui:CardColor Width="160" Height="48" Margin="4" />
-          <ui:CardControl Width="160" Margin="4" Content="Card control" />
-          <ui:CardExpander Width="180" Margin="4" Header="Card expander" IsExpanded="True" Content="Expanded content" />
-          <ui:ClientAreaBorder Width="160" Height="48" Margin="4"><TextBlock Text="Client area border" /></ui:ClientAreaBorder>
-          <ui:ContentDialog Width="180" Margin="4" Content="Content dialog" />
-          <ui:EmptyState Width="180" Margin="4" Content="No items are available." />
-          <ui:InfoBar Width="240" Margin="4" Content="Informational message" />
-          <ui:LoadingScreen Width="180" Height="48" Margin="4" Content="Loading screen" />
-          <ui:RaisedBorder Width="160" Margin="4" Content="Raised border" />
-          <StackPanel Width="360" Margin="4">
+          <ui:AlarmBanner VerticalAlignment="Top" Width="280" Margin="4" IsActive="True" Message="Alarm is active." Severity="Informational" />
+          <ui:Alarms VerticalAlignment="Top" Width="160" Height="48" Margin="4" />
+          <ui:Arc VerticalAlignment="Top" Width="72" Height="72" Margin="4" Stroke="{DynamicResource TextFillColorPrimaryBrush}" StrokeThickness="4" />
+          <ui:Badge VerticalAlignment="Top" Margin="4" Content="Badge" />
+          <ui:Border VerticalAlignment="Top" Width="160" Height="48" Margin="4"><TextBlock Text="WPF UI border" /></ui:Border>
+          <ui:BusyOverlay VerticalAlignment="Top" Width="160" Height="48" Margin="4" Content="BusyOverlay content" />
+          <ui:Calendar VerticalAlignment="Top" Width="260" Margin="4" />
+          <ui:Card VerticalAlignment="Top" Width="180" Margin="4" Content="Card content" />
+          <ui:CardAction VerticalAlignment="Top" Width="160" Margin="4" Content="Card action" />
+          <ui:CardColor VerticalAlignment="Top" Width="160" Height="48" Margin="4" />
+          <ui:CardControl VerticalAlignment="Top" Width="160" Margin="4" Content="Card control" />
+          <ui:CardExpander VerticalAlignment="Top" Width="180" Margin="4" Header="Card expander" IsExpanded="True" Content="Expanded content" />
+          <ui:ClientAreaBorder VerticalAlignment="Top" Width="160" Height="48" Margin="4"><TextBlock Text="Client area border" /></ui:ClientAreaBorder>
+          <ui:ContentDialog VerticalAlignment="Top" Width="180" Margin="4" Content="Content dialog" />
+          <ui:EmptyState VerticalAlignment="Top" Width="180" Margin="4" Content="No items are available." />
+          <ui:InfoBar VerticalAlignment="Top" Width="240" Margin="4" Content="Informational message" />
+          <ui:LoadingScreen VerticalAlignment="Top" Width="180" Height="48" Margin="4" Content="Loading screen" />
+          <ui:RaisedBorder VerticalAlignment="Top" Width="160" Margin="4" Content="Raised border" />
+          <StackPanel VerticalAlignment="Top" Width="360" Margin="4">
             <TextBlock Margin="0,0,0,4" Text="Snackbar presenter" />
             <ui:SnackbarPresenter x:Name="CatalogSnackbarPresenter" Height="120" />
           </StackPanel>
@@ -45,71 +53,71 @@
 
       <ui:GroupBox Margin="0,12,0,0" Header="Input, commands and selection">
         <WrapPanel Margin="8">
-          <ui:Anchor Margin="4" Content="Anchor" />
-          <ui:AsyncCommandButton Margin="4" Content="Async command" />
-          <ui:AutoSuggestBox Width="180" Margin="4" PlaceholderText="Auto suggest" />
-          <ui:BezelButton Margin="4" Content="Bezel button" />
-          <ui:BezelRepeatButton Margin="4" Content="Bezel repeat" />
-          <ui:BezelToggleButton Margin="4" Content="Bezel toggle" />
-          <ui:CheckBoxModern Margin="4" Text="Modern checkbox" />
-          <ui:Chip Margin="4" Text="Chip" />
-          <ui:ChipGroup Width="180" Margin="4"><ui:Chip Text="One" /><ui:Chip Text="Two" /></ui:ChipGroup>
-          <ui:CommandButton Margin="4" Content="Command button" />
-          <ui:DropDownButton Margin="4" Content="Drop down" />
-          <ui:GelButton Width="92" Margin="4" Content="Gel button" />
-          <ui:GelRepeatButton Width="92" Margin="4" Content="Gel repeat" />
-          <ui:GelToggleButton Width="92" Margin="4" Content="Gel toggle" />
-          <ui:HyperlinkButton Margin="4" Content="Hyperlink button" />
-          <ui:NumericPushButton Margin="4" Content="7" />
-          <ui:NumberBox Width="140" Margin="4" Text="42" />
-          <ui:RatingControl Width="180" Margin="4" Value="3" />
-          <ui:SearchBox Width="200" Margin="4" />
-          <ui:SplitButton Margin="4" Content="Split button" />
-          <ui:ThumbRate Width="160" Height="48" Margin="4" />
-          <ui:TimePicker Width="160" Margin="4" />
+          <ui:Anchor VerticalAlignment="Top" Margin="4" Content="Anchor" />
+          <ui:AsyncCommandButton VerticalAlignment="Top" Margin="4" Content="Async command" />
+          <ui:AutoSuggestBox VerticalAlignment="Top" Width="180" Margin="4" PlaceholderText="Auto suggest" />
+          <ui:BezelButton VerticalAlignment="Top" Margin="4" Content="Bezel button" />
+          <ui:BezelRepeatButton VerticalAlignment="Top" Margin="4" Content="Bezel repeat" />
+          <ui:BezelToggleButton VerticalAlignment="Top" Margin="4" Content="Bezel toggle" />
+          <ui:CheckBoxModern VerticalAlignment="Top" Margin="4" Text="Modern checkbox" />
+          <ui:Chip VerticalAlignment="Top" Margin="4" Text="Chip" />
+          <ui:ChipGroup VerticalAlignment="Top" Width="180" Margin="4"><ui:Chip Text="One" /><ui:Chip Text="Two" /></ui:ChipGroup>
+          <ui:CommandButton VerticalAlignment="Top" Margin="4" Content="Command button" />
+          <ui:DropDownButton VerticalAlignment="Top" Margin="4" Content="Drop down" />
+          <ui:GelButton VerticalAlignment="Top" Width="92" Margin="4" Content="Gel button" />
+          <ui:GelRepeatButton VerticalAlignment="Top" Width="92" Margin="4" Content="Gel repeat" />
+          <ui:GelToggleButton VerticalAlignment="Top" Width="92" Margin="4" Content="Gel toggle" />
+          <ui:HyperlinkButton VerticalAlignment="Top" Margin="4" Content="Hyperlink button" />
+          <ui:NumericPushButton VerticalAlignment="Top" Margin="4" Content="7" />
+          <ui:NumberBox VerticalAlignment="Top" Width="140" Margin="4" Text="42" />
+          <ui:RatingControl VerticalAlignment="Top" Width="180" Margin="4" Value="3" />
+          <ui:SearchBox VerticalAlignment="Top" Width="200" Margin="4" />
+          <ui:SplitButton VerticalAlignment="Top" Margin="4" Content="Split button" />
+          <ui:ThumbRate VerticalAlignment="Top" Width="160" Height="48" Margin="4" />
+          <ui:TimePicker VerticalAlignment="Top" Width="160" Margin="4" />
         </WrapPanel>
       </ui:GroupBox>
 
       <ui:GroupBox Margin="0,12,0,0" Header="Data, navigation and layout">
         <WrapPanel Margin="8">
-          <ui:BreadcrumbBar Width="220" Margin="4" />
-          <ui:DataFilterPanel Width="220" Height="64" Margin="4" />
-          <ui:DataGrid Width="240" Height="120" Margin="4" />
-          <ui:DataPager Width="220" Height="64" Margin="4" />
-          <ui:DateTimeRangePicker Width="220" Height="64" Margin="4" />
-          <ui:DynamicScrollBar Width="160" Margin="4" />
-          <ui:FilterBar Width="220" Height="48" Margin="4" />
-          <ui:ListView Width="180" Height="90" Margin="4"><ui:ListView.View><ui:GridView /></ui:ListView.View><ui:ListViewItem Content="List item" /></ui:ListView>
-          <ui:NavigationView Width="280" Height="140" Margin="4" PaneDisplayMode="Left"><ui:NavigationView.MenuItems><ui:NavigationViewItem Content="Catalog item" /></ui:NavigationView.MenuItems></ui:NavigationView>
-          <ui:PropertyGridLite Width="220" Height="64" Margin="4" />
-          <ui:ReactiveFormField Width="220" Margin="4" Content="Reactive form field" />
-          <ui:SegmentedControl Width="220" Height="48" Margin="4" />
-          <ui:Stepper Width="220" Height="48" Margin="4" />
-          <ui:TabView Width="220" Height="90" Margin="4"><ui:TabViewItem Header="Catalog" Content="Tab content" /></ui:TabView>
-          <ui:TreeGrid Width="220" Height="90" Margin="4" />
-          <ui:TreeView Width="180" Height="90" Margin="4"><ui:TreeViewItem Header="Tree item" /></ui:TreeView>
-          <ui:ValidationSummary Width="220" Height="48" Margin="4" />
-          <ui:VirtualizingGridView Width="180" Height="90" Margin="4" />
-          <ui:VirtualizingItemsControl Width="180" Height="48" Margin="4" />
+          <ui:BreadcrumbBar VerticalAlignment="Top" Width="220" Margin="4" />
+          <ui:DataFilterPanel VerticalAlignment="Top" Width="220" Margin="4" />
+          <ui:DataGrid VerticalAlignment="Top" Width="240" Height="120" Margin="4" />
+          <ui:DataPager VerticalAlignment="Top" Width="220" Height="64" Margin="4" />
+          <ui:DateTimeRangePicker VerticalAlignment="Top" Width="420" Margin="4" />
+          <ui:DynamicScrollBar VerticalAlignment="Top" Width="160" Margin="4" />
+          <ui:FilterBar VerticalAlignment="Top" Width="220" Height="48" Margin="4" />
+          <ui:ListView VerticalAlignment="Top" Width="180" Height="90" Margin="4"><ui:ListView.View><ui:GridView /></ui:ListView.View><ui:ListViewItem Content="List item" /></ui:ListView>
+          <ui:NavigationView VerticalAlignment="Top" Width="280" Height="140" Margin="4" PaneDisplayMode="Left"><ui:NavigationView.MenuItems><ui:NavigationViewItem Content="Catalog item" /></ui:NavigationView.MenuItems></ui:NavigationView>
+          <ui:PropertyGridLite VerticalAlignment="Top" Width="220" Margin="4" />
+          <ui:ReactiveFormField VerticalAlignment="Top" Width="220" Margin="4" Content="Reactive form field" />
+          <ui:SegmentedControl VerticalAlignment="Top" Width="220" Height="48" Margin="4" />
+          <ui:Stepper VerticalAlignment="Top" Width="220" Margin="4" />
+          <ui:TabView VerticalAlignment="Top" Width="220" Height="90" Margin="4"><ui:TabViewItem Header="Catalog" Content="Tab content" /></ui:TabView>
+          <ui:TreeGrid VerticalAlignment="Top" Width="220" Height="90" Margin="4" />
+          <ui:TreeView VerticalAlignment="Top" Width="180" Height="90" Margin="4"><ui:TreeViewItem Header="Tree item" /></ui:TreeView>
+          <ui:ValidationSummary VerticalAlignment="Top" Width="220" Margin="4" />
+          <ui:VirtualizingGridView VerticalAlignment="Top" Width="180" Height="90" Margin="4" />
+          <ui:VirtualizingItemsControl VerticalAlignment="Top" Width="180" Height="48" Margin="4" />
         </WrapPanel>
       </ui:GroupBox>
 
       <ui:GroupBox Margin="0,12,0,0" Header="Media, icons and visual indicators">
         <WrapPanel Margin="8">
-          <ui:CircularGauge Width="120" Height="120" Margin="4" Value="42" />
-          <ui:ColorDisplay Width="120" Height="48" Margin="4" />
-          <ui:FontIcon Margin="4" Glyph="&#xE10F;" />
-          <ui:FontIconFallback Width="100" Height="48" Margin="4" />
-          <ui:GifImage Width="100" Height="48" Margin="4" />
-          <ui:Image Width="100" Height="48" Margin="4" />
-          <ui:ImageIcon Width="32" Height="32" Margin="4" />
-          <ui:InfoBadge Margin="4" Value="4" />
-          <ui:PersonPicture Width="72" Height="72" Margin="4" DisplayName="Ada Lovelace" />
-          <ui:ProgressRing Width="56" Height="56" Margin="4" IsActive="True" />
-          <ui:RichTextBox Width="180" Height="72" Margin="4"><FlowDocument><Paragraph>Rich text content</Paragraph></FlowDocument></ui:RichTextBox>
-          <ui:SymbolIcon Margin="4" Symbol="Home20" />
-          <ui:ThemeSwitcher Width="180" Height="48" Margin="4" />
-          <ui:ToggleSwitch Margin="4" Content="Toggle switch" />
+          <ui:CircularGauge VerticalAlignment="Top" Width="120" Height="120" Margin="4" Value="42" />
+          <ui:ColorDisplay VerticalAlignment="Top" Width="120" Height="48" Margin="4" />
+          <ui:FontIcon VerticalAlignment="Top" Margin="4" Glyph="&#xE10F;" />
+          <ui:FontIconFallback VerticalAlignment="Top" Width="100" Height="48" Margin="4" />
+          <ui:GifImage VerticalAlignment="Top" Width="100" Height="48" Margin="4" />
+          <ui:Image VerticalAlignment="Top" Width="100" Height="48" Margin="4" />
+          <ui:ImageIcon VerticalAlignment="Top" Width="32" Height="32" Margin="4" />
+          <ui:InfoBadge VerticalAlignment="Top" Margin="4" Value="4" />
+          <ui:PersonPicture VerticalAlignment="Top" Width="72" Height="72" Margin="4" DisplayName="Ada Lovelace" />
+          <ui:ProgressRing VerticalAlignment="Top" Width="56" Height="56" Margin="4" IsActive="True" />
+          <ui:RichTextBox VerticalAlignment="Top" Width="180" Height="72" Margin="4"><FlowDocument><Paragraph>Rich text content</Paragraph></FlowDocument></ui:RichTextBox>
+          <ui:SymbolIcon VerticalAlignment="Top" Margin="4" Symbol="Home20" />
+          <ui:ThemeSwitcher VerticalAlignment="Top" Width="360" Margin="4" />
+          <ui:ToggleSwitch VerticalAlignment="Top" Margin="4" Content="Toggle switch" />
         </WrapPanel>
       </ui:GroupBox>
     </StackPanel>

--- a/src/CrissCross.WPF.UI.Gallery/Views/MainView.xaml
+++ b/src/CrissCross.WPF.UI.Gallery/Views/MainView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
   x:Class="CrissCross.WPF.UI.Gallery.Views.MainView"
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -25,54 +25,54 @@
         <RowDefinition />
         <RowDefinition />
       </Grid.RowDefinitions>
-      <ui:TextBlock FontSize="20" FontWeight="Medium" Text="Welcome to CrissCross" />
-      <ui:TextBlock
+      <ui:TextBlock TextWrapping="Wrap" FontSize="20" FontWeight="Medium" Text="Welcome to CrissCross" />
+      <ui:TextBlock TextWrapping="Wrap"
         Grid.Row="1"
         FontSize="16"
         FontWeight="Normal"
         Text="Step 1: Add the CrissCross.UI namespace to your XAML file."
       />
-      <ui:TextBlock
+      <ui:TextBlock TextWrapping="Wrap"
         Grid.Row="2"
         FontSize="16"
         FontWeight="Normal"
         Text="xmlns:ui='https://github.com/reactivemarbles/CrissCross.ui'"
       />
-      <ui:TextBlock
+      <ui:TextBlock TextWrapping="Wrap"
         Grid.Row="3"
         FontSize="16"
         FontWeight="Normal"
         Text="Step 2: Use CrissCross UI components in your XAML."
       />
-      <ui:TextBlock Grid.Row="4" FontSize="16" FontWeight="Normal" Text="Example:" />
+      <ui:TextBlock TextWrapping="Wrap" Grid.Row="4" FontSize="16" FontWeight="Normal" Text="Example:" />
       <Border
         Grid.Row="5"
         Padding="10"
         BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}"
         BorderThickness="1"
       >
-        <ui:TextBlock
+        <ui:TextBlock TextWrapping="Wrap"
           FontSize="14"
           FontWeight="Normal"
           Text="&lt;ui:TextBlock FontSize='20' FontWeight='Medium' Text='Welcome to CrissCross' /&gt;"
         />
       </Border>
-      <ui:TextBlock
+      <ui:TextBlock TextWrapping="Wrap"
         Grid.Row="6"
         FontSize="16"
         FontWeight="Normal"
         Text="Step 3: Build and run your application to see the CrissCross UI components in action."
       />
-      <ui:TextBlock
+      <ui:TextBlock TextWrapping="Wrap"
         Grid.Row="7"
         Margin="0,10"
         FontSize="20"
         FontWeight="Medium"
         Text="Project Setup - use the following as a guide for setting up your initial application"
       />
-      <ui:TextBlock x:Name="AppXamlSetup" Grid.Row="8" Margin="0,10" FontSize="12" FontWeight="Normal" />
-      <ui:TextBlock x:Name="MainWindowXamlSetup" Grid.Row="9" Margin="0,10" FontSize="12" FontWeight="Normal" />
-      <ui:TextBlock x:Name="MainWindowXamlCsSetup" Grid.Row="10" Margin="0,10" FontSize="12" FontWeight="Normal" />
+      <ui:TextBlock TextWrapping="Wrap" x:Name="AppXamlSetup" Grid.Row="8" Margin="0,10" FontSize="12" FontWeight="Normal" />
+      <ui:TextBlock TextWrapping="Wrap" x:Name="MainWindowXamlSetup" Grid.Row="9" Margin="0,10" FontSize="12" FontWeight="Normal" />
+      <ui:TextBlock TextWrapping="Wrap" x:Name="MainWindowXamlCsSetup" Grid.Row="10" Margin="0,10" FontSize="12" FontWeight="Normal" />
     </Grid>
   </ui:DynamicScrollViewer>
 </UserControl>

--- a/src/CrissCross.WPF.UI/Animations/TransitionAnimationProvider.cs
+++ b/src/CrissCross.WPF.UI/Animations/TransitionAnimationProvider.cs
@@ -72,42 +72,25 @@ public static class TransitionAnimationProvider
 
         var timespanDuration = new Duration(TimeSpan.FromMilliseconds(duration));
 
-        switch (type)
+        return type switch
         {
-            case Transition.FadeIn:
-            {
-                FadeInTransition(uiElement, timespanDuration);
-                break;
-            }
+            Transition.FadeIn => ApplyTransition(uiElement, timespanDuration, FadeInTransition),
+            Transition.FadeInWithSlide => ApplyTransition(uiElement, timespanDuration, FadeInWithSlideTransition),
+            Transition.SlideBottom => ApplyTransition(uiElement, timespanDuration, SlideBottomTransition),
+            Transition.SlideRight => ApplyTransition(uiElement, timespanDuration, SlideRightTransition),
+            Transition.SlideLeft => ApplyTransition(uiElement, timespanDuration, SlideLeftTransition),
+            _ => false,
+        };
+    }
 
-            case Transition.FadeInWithSlide:
-            {
-                FadeInWithSlideTransition(uiElement, timespanDuration);
-                break;
-            }
-
-            case Transition.SlideBottom:
-            {
-                SlideBottomTransition(uiElement, timespanDuration);
-                break;
-            }
-
-            case Transition.SlideRight:
-            {
-                SlideRightTransition(uiElement, timespanDuration);
-                break;
-            }
-
-            case Transition.SlideLeft:
-            {
-                SlideLeftTransition(uiElement, timespanDuration);
-                break;
-            }
-
-            default:
-                return false;
-        }
-
+    /// <summary>Applies a transition action and returns a handled result.</summary>
+    /// <param name="uiElement">The animated UI element.</param>
+    /// <param name="duration">The animation duration.</param>
+    /// <param name="transition">The transition action.</param>
+    /// <returns><see langword="true"/> after applying the transition.</returns>
+    private static bool ApplyTransition(UIElement uiElement, Duration duration, Action<UIElement, Duration> transition)
+    {
+        transition(uiElement, duration);
         return true;
     }
 

--- a/src/CrissCross.WPF.UI/Appearance/ApplicationThemeManager.cs
+++ b/src/CrissCross.WPF.UI/Appearance/ApplicationThemeManager.cs
@@ -255,9 +255,8 @@ public static class ApplicationThemeManager
         var appApplicationTheme = GetAppTheme();
         var sysTheme = GetSystemTheme();
 
-        return appApplicationTheme != ApplicationTheme.Dark
-            ? false
-            : sysTheme is SystemTheme.Dark or SystemTheme.CapturedMotion or SystemTheme.Glow;
+        return appApplicationTheme == ApplicationTheme.Dark
+            && sysTheme is SystemTheme.Dark or SystemTheme.CapturedMotion or SystemTheme.Glow;
     }
 
     /// <summary>Checks if the application and the operating system are currently working in a light theme.</summary>
@@ -269,9 +268,8 @@ public static class ApplicationThemeManager
         var appApplicationTheme = GetAppTheme();
         var sysTheme = GetSystemTheme();
 
-        return appApplicationTheme != ApplicationTheme.Light
-            ? false
-            : sysTheme is SystemTheme.Light or SystemTheme.Flow or SystemTheme.Sunrise;
+        return appApplicationTheme == ApplicationTheme.Light
+            && sysTheme is SystemTheme.Light or SystemTheme.Flow or SystemTheme.Sunrise;
     }
 
     /// <summary>Tries to guess the currently set application theme.</summary>
@@ -287,21 +285,27 @@ public static class ApplicationThemeManager
 
         var themeUri = themeDictionary.Source.ToString().Trim().ToLower();
 
+        if (themeUri.Contains("hc1")
+            || themeUri.Contains("hc2")
+            || themeUri.Contains("hcblack")
+            || themeUri.Contains("hcwhite")
+            || themeUri.Contains("highcontrast"))
+        {
+            _cachedApplicationTheme = ApplicationTheme.HighContrast;
+            return;
+        }
+
         if (themeUri.Contains("light"))
         {
             _cachedApplicationTheme = ApplicationTheme.Light;
+            return;
         }
 
-        if (themeUri.Contains("dark"))
-        {
-            _cachedApplicationTheme = ApplicationTheme.Dark;
-        }
-
-        if (!themeUri.Contains("highcontrast"))
+        if (!themeUri.Contains("dark"))
         {
             return;
         }
 
-        _cachedApplicationTheme = ApplicationTheme.HighContrast;
+        _cachedApplicationTheme = ApplicationTheme.Dark;
     }
 }

--- a/src/CrissCross.WPF.UI/AssemblyInfo.cs
+++ b/src/CrissCross.WPF.UI/AssemblyInfo.cs
@@ -2,7 +2,10 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
 using System.Windows.Markup;
+
+[assembly: InternalsVisibleTo("CrissCross.WPF.UI.Gallery.Tests")]
 
 #if REACTIVELIST_REACTIVE
 [assembly: XmlnsDefinition("https://github.com/reactivemarbles/CrissCross.ui", "CrissCross.Reactive.WPF.UI")]

--- a/src/CrissCross.WPF.UI/Controls/BBCodeBlock/Core/BbCodeRenderer.cs
+++ b/src/CrissCross.WPF.UI/Controls/BBCodeBlock/Core/BbCodeRenderer.cs
@@ -114,6 +114,17 @@ internal sealed partial class BbCodeRenderer
         return span;
     }
 
+    /// <summary>Adds an inline element and reports the node as handled.</summary>
+    /// <param name="target">The target inline collection.</param>
+    /// <param name="inline">The inline element.</param>
+    /// <returns><see langword="true"/>.</returns>
+    private bool AddInlineAndReturnTrue(InlineCollection target, Inline inline)
+    {
+        _ = _source;
+        target.Add(inline);
+        return true;
+    }
+
     /// <summary>Adds rendered child nodes to an inline collection.</summary>
     /// <param name="target">The target inline collection.</param>
     /// <param name="nodes">The child nodes.</param>
@@ -178,207 +189,63 @@ internal sealed partial class BbCodeRenderer
     /// <param name="target">The target inline collection.</param>
     /// <param name="node">The formatting node.</param>
     /// <returns><see langword="true"/> when the node was handled.</returns>
-    private bool TryAddFormatting(InlineCollection target, BbCodeNode node)
-    {
-        switch (node.Name)
+    private bool TryAddFormatting(InlineCollection target, BbCodeNode node) =>
+        node.Name switch
         {
-            case "b" or "strong":
-            {
-                AddStyledSpan(target, node, static span => span.FontWeight = FontWeights.Bold);
-                return true;
-            }
-
-            case "i"
-            or "em":
-            {
-                AddStyledSpan(target, node, static span => span.FontStyle = FontStyles.Italic);
-                return true;
-            }
-
-            case "u"
-            or "ins":
-            {
-                AddStyledSpan(target, node, static span => span.TextDecorations = TextDecorations.Underline);
-                return true;
-            }
-
-            case "s"
-            or "strike"
-            or "del":
-            {
-                AddStyledSpan(target, node, static span => span.TextDecorations = TextDecorations.Strikethrough);
-                return true;
-            }
-
-            case "sup":
-            {
-                AddStyledSpan(target, node, static span => span.BaselineAlignment = BaselineAlignment.Superscript);
-                return true;
-            }
-
-            case "sub":
-            {
-                AddStyledSpan(target, node, static span => span.BaselineAlignment = BaselineAlignment.Subscript);
-                return true;
-            }
-
-            default:
-            {
-                return TryAddParameterizedFormatting(target, node);
-            }
-        }
-    }
+            "b" or "strong" => AddStyledSpanAndReturnTrue(target, node, static span => span.FontWeight = FontWeights.Bold),
+            "i" or "em" => AddStyledSpanAndReturnTrue(target, node, static span => span.FontStyle = FontStyles.Italic),
+            "u" or "ins" => AddStyledSpanAndReturnTrue(target, node, static span => span.TextDecorations = TextDecorations.Underline),
+            "s" or "strike" or "del" => AddStyledSpanAndReturnTrue(target, node, static span => span.TextDecorations = TextDecorations.Strikethrough),
+            "sup" => AddStyledSpanAndReturnTrue(target, node, static span => span.BaselineAlignment = BaselineAlignment.Superscript),
+            "sub" => AddStyledSpanAndReturnTrue(target, node, static span => span.BaselineAlignment = BaselineAlignment.Subscript),
+            _ => TryAddParameterizedFormatting(target, node),
+        };
 
     /// <summary>Attempts to render formatting that accepts a parameter.</summary>
     /// <param name="target">The target inline collection.</param>
     /// <param name="node">The formatting node.</param>
     /// <returns><see langword="true"/> when the node was handled.</returns>
-    private bool TryAddParameterizedFormatting(InlineCollection target, BbCodeNode node)
-    {
-        switch (node.Name)
+    private bool TryAddParameterizedFormatting(InlineCollection target, BbCodeNode node) =>
+        node.Name switch
         {
-            case "color":
-            {
-                AddStyledSpan(target, node, span => BbCodeRenderHelpers.ApplyColor(span, node.Value));
-                return true;
-            }
-
-            case "font":
-            {
-                AddStyledSpan(target, node, span => BbCodeRenderHelpers.ApplyFont(span, node.Value));
-                return true;
-            }
-
-            case "size":
-            {
-                AddStyledSpan(target, node, span => BbCodeRenderHelpers.ApplySize(span, node.Value));
-                return true;
-            }
-
-            case "style":
-            {
-                AddStyledSpan(target, node, span => BbCodeRenderHelpers.ApplyStyle(span, node));
-                return true;
-            }
-
-            default:
-            {
-                return false;
-            }
-        }
-    }
+            "color" => AddStyledSpanAndReturnTrue(target, node, span => BbCodeRenderHelpers.ApplyColor(span, node.Value)),
+            "font" => AddStyledSpanAndReturnTrue(target, node, span => BbCodeRenderHelpers.ApplyFont(span, node.Value)),
+            "size" => AddStyledSpanAndReturnTrue(target, node, span => BbCodeRenderHelpers.ApplySize(span, node.Value)),
+            "style" => AddStyledSpanAndReturnTrue(target, node, span => BbCodeRenderHelpers.ApplyStyle(span, node)),
+            _ => false,
+        };
 
     /// <summary>Attempts to render an inline or inline-hosted node.</summary>
     /// <param name="target">The target inline collection.</param>
     /// <param name="node">The node.</param>
     /// <returns><see langword="true"/> when the node was handled.</returns>
-    private bool TryAddInlineElement(InlineCollection target, BbCodeNode node)
-    {
-        switch (node.Name)
+    private bool TryAddInlineElement(InlineCollection target, BbCodeNode node) =>
+        node.Name switch
         {
-            case "br":
-            {
-                target.Add(new LineBreak());
-                return true;
-            }
-
-            case "hr"
-            or "line":
-            {
-                target.Add(CreateSeparator());
-                return true;
-            }
-
-            case "url"
-            or "link"
-            or "email"
-            or "mail":
-            {
-                AddHyperlink(target, node);
-                return true;
-            }
-
-            case "img"
-            or "image":
-            {
-                target.Add(CreateImage(node));
-                return true;
-            }
-
-            case "quote"
-            or "q":
-            {
-                target.Add(CreateQuote(node));
-                return true;
-            }
-
-            case "spoiler"
-            or "spoil"
-            or "hide":
-            {
-                target.Add(CreateSpoiler(node));
-                return true;
-            }
-
-            case "blur":
-            {
-                target.Add(CreateBlur(node));
-                return true;
-            }
-
-            case "noparse":
-            {
-                target.Add(new Run(node.GetText()));
-                return true;
-            }
-
-            default:
-            {
-                return false;
-            }
-        }
-    }
+            "br" => AddInlineAndReturnTrue(target, new LineBreak()),
+            "hr" or "line" => AddInlineAndReturnTrue(target, CreateSeparator()),
+            "url" or "link" or "email" or "mail" => AddHyperlinkAndReturnTrue(target, node),
+            "img" or "image" => AddInlineAndReturnTrue(target, CreateImage(node)),
+            "quote" or "q" => AddInlineAndReturnTrue(target, CreateQuote(node)),
+            "spoiler" or "spoil" or "hide" => AddInlineAndReturnTrue(target, CreateSpoiler(node)),
+            "blur" => AddInlineAndReturnTrue(target, CreateBlur(node)),
+            "noparse" => AddInlineAndReturnTrue(target, new Run(node.GetText())),
+            _ => false,
+        };
 
     /// <summary>Attempts to render a block-like node.</summary>
     /// <param name="target">The target inline collection.</param>
     /// <param name="node">The node.</param>
     /// <returns><see langword="true"/> when the node was handled.</returns>
-    private bool TryAddDocumentBlock(InlineCollection target, BbCodeNode node)
-    {
-        switch (node.Name)
+    private bool TryAddDocumentBlock(InlineCollection target, BbCodeNode node) =>
+        node.Name switch
         {
-            case "code" or "c" or "pre" or "nfo":
-            {
-                target.Add(CreateCode(node));
-                return true;
-            }
-
-            case "ul"
-            or "ol"
-            or "list":
-            {
-                target.Add(CreateList(node));
-                return true;
-            }
-
-            case "table":
-            {
-                target.Add(CreateTable(node));
-                return true;
-            }
-
-            case "pipes":
-            {
-                target.Add(CreatePipeTable(node));
-                return true;
-            }
-
-            default:
-            {
-                return false;
-            }
-        }
-    }
+            "code" or "c" or "pre" or "nfo" => AddInlineAndReturnTrue(target, CreateCode(node)),
+            "ul" or "ol" or "list" => AddInlineAndReturnTrue(target, CreateList(node)),
+            "table" => AddInlineAndReturnTrue(target, CreateTable(node)),
+            "pipes" => AddInlineAndReturnTrue(target, CreatePipeTable(node)),
+            _ => false,
+        };
 
     /// <summary>Attempts to render alignment and paragraph blocks.</summary>
     /// <param name="target">The target inline collection.</param>
@@ -449,6 +316,27 @@ internal sealed partial class BbCodeRenderer
         }
 
         AddChildren(target, node.Children);
+        return true;
+    }
+
+    /// <summary>Renders a styled inline span and reports the node as handled.</summary>
+    /// <param name="target">The target inline collection.</param>
+    /// <param name="node">The source node.</param>
+    /// <param name="configure">The style operation.</param>
+    /// <returns><see langword="true"/>.</returns>
+    private bool AddStyledSpanAndReturnTrue(InlineCollection target, BbCodeNode node, Action<Span> configure)
+    {
+        AddStyledSpan(target, node, configure);
+        return true;
+    }
+
+    /// <summary>Renders a hyperlink and reports the node as handled.</summary>
+    /// <param name="target">The target inline collection.</param>
+    /// <param name="node">The link node.</param>
+    /// <returns><see langword="true"/>.</returns>
+    private bool AddHyperlinkAndReturnTrue(InlineCollection target, BbCodeNode node)
+    {
+        AddHyperlink(target, node);
         return true;
     }
 

--- a/src/CrissCross.WPF.UI/Controls/Button/Custom/CommonButtonBase.cs
+++ b/src/CrissCross.WPF.UI/Controls/Button/Custom/CommonButtonBase.cs
@@ -238,7 +238,7 @@ public class CommonButtonBase : System.Windows.Controls.Button
     /// <returns>
     /// true if the dependency property that is supplied should be value-serialized; otherwise, false.
     /// </returns>
-    protected override bool ShouldSerializeProperty(DependencyProperty dp) => dp == StyleProperty ? false : base.ShouldSerializeProperty(dp);
+    protected override bool ShouldSerializeProperty(DependencyProperty dp) => dp != StyleProperty && base.ShouldSerializeProperty(dp);
 
     /// <summary>Provides the CommonButtonBase_IsEnabledChanged member.</summary>
     /// <param name="sender">The event sender.</param>

--- a/src/CrissCross.WPF.UI/Controls/Button/Custom/CommonRepeatButtonBase.cs
+++ b/src/CrissCross.WPF.UI/Controls/Button/Custom/CommonRepeatButtonBase.cs
@@ -238,7 +238,7 @@ public class CommonRepeatButtonBase : RepeatButton
     /// <returns>
     /// true if the dependency property that is supplied should be value-serialized; otherwise, false.
     /// </returns>
-    protected override bool ShouldSerializeProperty(DependencyProperty dp) => dp == StyleProperty ? false : base.ShouldSerializeProperty(dp);
+    protected override bool ShouldSerializeProperty(DependencyProperty dp) => dp != StyleProperty && base.ShouldSerializeProperty(dp);
 
     /// <summary>Provides the CommonButtonBase_IsEnabledChanged member.</summary>
     /// <param name="sender">The event sender.</param>

--- a/src/CrissCross.WPF.UI/Controls/Button/Custom/CommonToggleButtonBase.cs
+++ b/src/CrissCross.WPF.UI/Controls/Button/Custom/CommonToggleButtonBase.cs
@@ -240,7 +240,7 @@ public class CommonToggleButtonBase : System.Windows.Controls.Primitives.ToggleB
     /// <returns>
     /// true if the dependency property that is supplied should be value-serialized; otherwise, false.
     /// </returns>
-    protected override bool ShouldSerializeProperty(DependencyProperty dp) => dp == StyleProperty ? false : base.ShouldSerializeProperty(dp);
+    protected override bool ShouldSerializeProperty(DependencyProperty dp) => dp != StyleProperty && base.ShouldSerializeProperty(dp);
 
     /// <summary>Provides the CommonButtonBase_IsEnabledChanged member.</summary>
     /// <param name="sender">The event sender.</param>

--- a/src/CrissCross.WPF.UI/Controls/Button/Custom/RaisedBorder.cs
+++ b/src/CrissCross.WPF.UI/Controls/Button/Custom/RaisedBorder.cs
@@ -194,7 +194,7 @@ public class RaisedBorder : ContentControl
     /// <returns>
     /// true if the dependency property that is supplied should be value-serialized; otherwise, false.
     /// </returns>
-    protected override bool ShouldSerializeProperty(DependencyProperty dp) => dp == StyleProperty ? false : base.ShouldSerializeProperty(dp);
+    protected override bool ShouldSerializeProperty(DependencyProperty dp) => dp != StyleProperty && base.ShouldSerializeProperty(dp);
 
     /// <summary>Provides the CreateGeometryForPath member.</summary>
     /// <param name="width">The width value.</param>

--- a/src/CrissCross.WPF.UI/Controls/ColorSelector/Behaviors/TextBoxFocusBehavior.cs
+++ b/src/CrissCross.WPF.UI/Controls/ColorSelector/Behaviors/TextBoxFocusBehavior.cs
@@ -61,6 +61,7 @@ public sealed class TextBoxFocusBehavior : Behavior<TextBox>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private string DebuggerDisplay => ToString() ?? GetType().Name;
 
+    /// <inheritdoc />
     protected override void OnAttached()
     {
         base.OnAttached();
@@ -71,6 +72,7 @@ public sealed class TextBoxFocusBehavior : Behavior<TextBox>
         AssociatedObject.KeyUp += AssociatedObject_KeyUp;
     }
 
+    /// <inheritdoc />
     protected override void OnDetaching()
     {
         base.OnDetaching();

--- a/src/CrissCross.WPF.UI/Controls/ColorSelector/UIExtensions/HslColorSlider.cs
+++ b/src/CrissCross.WPF.UI/Controls/ColorSelector/UIExtensions/HslColorSlider.cs
@@ -30,6 +30,7 @@ public sealed class HslColorSlider : PreviewColorSlider
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private string DebuggerDisplay => ToString() ?? GetType().Name;
 
+    /// <inheritdoc />
     protected override void GenerateBackground()
     {
         if (SliderHslType == "H")

--- a/src/CrissCross.WPF.UI/Controls/ColorSelector/UIExtensions/HsvColorSlider.cs
+++ b/src/CrissCross.WPF.UI/Controls/ColorSelector/UIExtensions/HsvColorSlider.cs
@@ -30,6 +30,7 @@ public sealed class HsvColorSlider : PreviewColorSlider
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private string DebuggerDisplay => ToString() ?? GetType().Name;
 
+    /// <inheritdoc />
     protected override void GenerateBackground()
     {
         if (SliderHsvType == "H")

--- a/src/CrissCross.WPF.UI/Controls/ColorSelector/UIExtensions/PreviewColorSlider.cs
+++ b/src/CrissCross.WPF.UI/Controls/ColorSelector/UIExtensions/PreviewColorSlider.cs
@@ -141,6 +141,7 @@ public abstract class PreviewColorSlider : Slider, INotifyPropertyChanged
         }
     } = new();
 
+    /// <inheritdoc />
     public override void EndInit()
     {
         base.EndInit();

--- a/src/CrissCross.WPF.UI/Controls/ColorSelector/UIExtensions/RgbColorSlider.cs
+++ b/src/CrissCross.WPF.UI/Controls/ColorSelector/UIExtensions/RgbColorSlider.cs
@@ -30,6 +30,7 @@ public sealed class RgbColorSlider : PreviewColorSlider
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private string DebuggerDisplay => ToString() ?? GetType().Name;
 
+    /// <inheritdoc />
     protected override void GenerateBackground()
     {
         var colorStart = GetColorForSelectedArgb(MinimumColorChannelValue);

--- a/src/CrissCross.WPF.UI/Controls/EmptyState/EmptyState.xaml
+++ b/src/CrissCross.WPF.UI/Controls/EmptyState/EmptyState.xaml
@@ -55,13 +55,13 @@
           </StackPanel>
           <ControlTemplate.Triggers>
             <DataTrigger
-              Binding="{Binding Model.HasPrimaryAction, RelativeSource={RelativeSource TemplatedParent}}"
+              Binding="{Binding Model.HasPrimaryAction, RelativeSource={RelativeSource TemplatedParent}, FallbackValue=False, TargetNullValue=False}"
               Value="False"
             >
               <Setter TargetName="PrimaryActionButton" Property="Visibility" Value="Collapsed" />
             </DataTrigger>
             <DataTrigger
-              Binding="{Binding Model.HasSecondaryAction, RelativeSource={RelativeSource TemplatedParent}}"
+              Binding="{Binding Model.HasSecondaryAction, RelativeSource={RelativeSource TemplatedParent}, FallbackValue=False, TargetNullValue=False}"
               Value="False"
             >
               <Setter TargetName="SecondaryActionButton" Property="Visibility" Value="Collapsed" />

--- a/src/CrissCross.WPF.UI/Controls/FluentNavigationWindow/FluentNavigationWindow{TViewModel}.cs
+++ b/src/CrissCross.WPF.UI/Controls/FluentNavigationWindow/FluentNavigationWindow{TViewModel}.cs
@@ -29,7 +29,7 @@ public class FluentNavigationWindow<TViewModel> : FluentNavigationWindow, IViewF
     /// <summary>Initializes a new instance of the <see cref="FluentNavigationWindow{TViewModel}"/> class.</summary>
     public FluentNavigationWindow() =>
         this.WhenActivated(
-            (CompositeDisposable _) => ViewModel ??= AppLocator.Current.GetService<TViewModel>() ?? new());
+            (ActivationDisposable _) => ViewModel ??= AppLocator.Current.GetService<TViewModel>() ?? new());
 
     /// <summary>Gets the binding root view model.</summary>
     public TViewModel? BindingRoot => ViewModel;

--- a/src/CrissCross.WPF.UI/Controls/GifImage/Animator.Rendering.cs
+++ b/src/CrissCross.WPF.UI/Controls/GifImage/Animator.Rendering.cs
@@ -182,12 +182,10 @@ public abstract partial class Animator
         var steps = new[] { InterlaceCoarseStep, InterlaceCoarseStep, InterlaceMediumStep, InterlaceFineStep };
         for (var passIndex = 0; passIndex < starts.Length; passIndex++)
         {
-            var y = starts[passIndex];
-            while (y < height)
+            for (var y = starts[passIndex]; y < height; y += steps[passIndex])
             {
                 rows[rowIndex] = y;
                 rowIndex++;
-                y += steps[passIndex];
             }
         }
 

--- a/src/CrissCross.WPF.UI/Controls/GifImage/Decoding/GifColor.cs
+++ b/src/CrissCross.WPF.UI/Controls/GifImage/Decoding/GifColor.cs
@@ -23,5 +23,6 @@ public readonly record struct GifColor(byte R, byte G, byte B)
     /// <summary>Gets the B value.</summary>
     public byte B { get; } = B;
 
+    /// <inheritdoc />
     public override string ToString() => $"#{R:x2}{G:x2}{B:x2}";
 }

--- a/src/CrissCross.WPF.UI/Controls/GifImage/Decompression/LzwDecompressStream.cs
+++ b/src/CrissCross.WPF.UI/Controls/GifImage/Decompression/LzwDecompressStream.cs
@@ -30,26 +30,35 @@ public sealed class LzwDecompressStream(byte[] compressedBuffer, int minimumCode
     /// <summary>Stores the _endOfStream value.</summary>
     private bool _endOfStream;
 
+    /// <inheritdoc />
     public override bool CanRead => true;
 
+    /// <inheritdoc />
     public override bool CanSeek => false;
 
+    /// <inheritdoc />
     public override bool CanWrite => true;
 
+    /// <inheritdoc />
     public override long Length => throw new NotSupportedException();
 
+    /// <inheritdoc />
     public override long Position
     {
         get => throw new NotSupportedException();
         set => throw new NotSupportedException();
     }
 
+    /// <inheritdoc />
     public override void Flush() { }
 
+    /// <inheritdoc />
     public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
 
+    /// <inheritdoc />
     public override void SetLength(long value) => throw new NotSupportedException();
 
+    /// <inheritdoc />
     public override int Read(byte[] buffer, int offset, int count)
     {
         ValidateReadArgs(buffer, offset, count);
@@ -77,6 +86,7 @@ public sealed class LzwDecompressStream(byte[] compressedBuffer, int minimumCode
         return read;
     }
 
+    /// <inheritdoc />
     public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 
     /// <summary>Provides the CopySequenceToBuffer member.</summary>

--- a/src/CrissCross.WPF.UI/Controls/GifImage/Extensions/StreamExtensions.cs
+++ b/src/CrissCross.WPF.UI/Controls/GifImage/Extensions/StreamExtensions.cs
@@ -27,16 +27,14 @@ internal static class StreamExtensions
             int count,
             CancellationToken cancellationToken = default)
         {
-            var totalRead = 0;
-            while (totalRead < count)
+            var n = 0;
+            for (var totalRead = 0; totalRead < count; totalRead += n)
             {
-                var n = await stream.ReadBufferAsync(buffer, offset + totalRead, count - totalRead, cancellationToken);
+                n = await stream.ReadBufferAsync(buffer, offset + totalRead, count - totalRead, cancellationToken);
                 if (n == 0)
                 {
                     throw new EndOfStreamException();
                 }
-
-                totalRead += n;
             }
         }
 
@@ -46,16 +44,14 @@ internal static class StreamExtensions
         /// <param name="count">The count value.</param>
         internal void ReadAll(byte[] buffer, int offset, int count)
         {
-            var totalRead = 0;
-            while (totalRead < count)
+            var n = 0;
+            for (var totalRead = 0; totalRead < count; totalRead += n)
             {
-                var n = stream.Read(buffer, offset + totalRead, count - totalRead);
+                n = stream.Read(buffer, offset + totalRead, count - totalRead);
                 if (n == 0)
                 {
                     throw new EndOfStreamException();
                 }
-
-                totalRead += n;
             }
         }
 

--- a/src/CrissCross.WPF.UI/Controls/GifImage/ImageAnimator.cs
+++ b/src/CrissCross.WPF.UI/Controls/GifImage/ImageAnimator.cs
@@ -96,7 +96,7 @@ internal sealed class ImageAnimator : Animator
     internal static Task<ImageAnimator> CreateAsync(
         Stream sourceStream,
         RepeatBehavior repeatBehavior,
-        System.Windows.Controls.Image image) => CreateAsync(sourceStream, repeatBehavior, image);
+        System.Windows.Controls.Image image) => CreateAsync(sourceStream, repeatBehavior, image, false);
 
     /// <summary>Provides the CreateAsync member.</summary>
     /// <param name="sourceStream">The sourceStream value.</param>

--- a/src/CrissCross.WPF.UI/Controls/MessageBox/MessageBox.cs
+++ b/src/CrissCross.WPF.UI/Controls/MessageBox/MessageBox.cs
@@ -298,31 +298,27 @@ public class MessageBox : System.Windows.Window
 
         ResizeToContentSize(rootElement);
 
-        switch (WindowStartupLocation)
+        if (WindowStartupLocation is WindowStartupLocation.Manual or WindowStartupLocation.CenterScreen)
         {
-            case WindowStartupLocation.Manual or WindowStartupLocation.CenterScreen:
+            CenterWindowOnScreen();
+            return;
+        }
+
+        if (WindowStartupLocation == WindowStartupLocation.CenterOwner)
+        {
+            if (!CanCenterOverWPFOwner() || Owner.WindowState is WindowState.Maximized or WindowState.Minimized)
             {
                 CenterWindowOnScreen();
-                break;
             }
-
-            case WindowStartupLocation.CenterOwner:
+            else
             {
-                if (!CanCenterOverWPFOwner() || Owner.WindowState is WindowState.Maximized or WindowState.Minimized)
-                {
-                    CenterWindowOnScreen();
-                }
-                else
-                {
-                    CenterWindowOnOwner();
-                }
-
-                break;
+                CenterWindowOnOwner();
             }
 
-            default:
-                throw new InvalidOperationException();
+            return;
         }
+
+        throw new InvalidOperationException();
     }
 
     /// <summary>Resizes the MessageBox to fit the content's size, including margins.</summary>

--- a/src/CrissCross.WPF.UI/Controls/MessageBoxAsync/MessageBoxAsync.xaml.cs
+++ b/src/CrissCross.WPF.UI/Controls/MessageBoxAsync/MessageBoxAsync.xaml.cs
@@ -354,48 +354,15 @@ public partial class MessageBoxAsync : IListenForMessages
     /// <summary>Gets the buttons.</summary>
     /// <param name="button">The button.</param>
     /// <returns>A IEnumerable of Buttons.</returns>
-    private List<Button> GetButtons(MessageBoxButton button)
-    {
-        var result = new List<Button>();
-        var owner = this;
-        switch (button)
+    private List<Button> GetButtons(MessageBoxButton button) =>
+        button switch
         {
-            case MessageBoxButton.OK:
-            {
-                result.Add(owner.OkButton);
-                break;
-            }
-
-            case MessageBoxButton.OKCancel:
-            {
-                result.Add(owner.OkButton);
-                result.Add(owner.CancelButton);
-                break;
-            }
-
-            case MessageBoxButton.YesNo:
-            {
-                result.Add(owner.YesButton);
-                result.Add(owner.NoButton);
-                break;
-            }
-
-            case MessageBoxButton.YesNoCancel:
-            {
-                result.Add(owner.YesButton);
-                result.Add(owner.NoButton);
-                result.Add(owner.CancelButton);
-                break;
-            }
-
-            default:
-            {
-                throw new ArgumentOutOfRangeException(nameof(button), button, null);
-            }
-        }
-
-        return result;
-    }
+            MessageBoxButton.OK => [OkButton],
+            MessageBoxButton.OKCancel => [OkButton, CancelButton],
+            MessageBoxButton.YesNo => [YesButton, NoButton],
+            MessageBoxButton.YesNoCancel => [YesButton, NoButton, CancelButton],
+            _ => throw new ArgumentOutOfRangeException(nameof(button), button, null),
+        };
 
     /// <summary>Gets the current custom message box result.</summary>
     /// <returns>The current custom message box result.</returns>

--- a/src/CrissCross.WPF.UI/Controls/ModernWindow/ModernWindow{TViewModel}.cs
+++ b/src/CrissCross.WPF.UI/Controls/ModernWindow/ModernWindow{TViewModel}.cs
@@ -29,7 +29,7 @@ public class ModernWindow<TViewModel> : ModernWindow, IViewFor<TViewModel>
     /// <summary>Initializes a new instance of the <see cref="ModernWindow{TViewModel}"/> class.</summary>
     public ModernWindow() =>
         this.WhenActivated(
-            (CompositeDisposable _) => ViewModel ??= AppLocator.Current.GetService<TViewModel>() ?? new());
+            (ActivationDisposable _) => ViewModel ??= AppLocator.Current.GetService<TViewModel>() ?? new());
 
     /// <summary>Gets the binding root view model.</summary>
     public TViewModel? BindingRoot => ViewModel;

--- a/src/CrissCross.WPF.UI/Controls/NavigationUserControl/NavigationUserControl{TViewModel}.cs
+++ b/src/CrissCross.WPF.UI/Controls/NavigationUserControl/NavigationUserControl{TViewModel}.cs
@@ -31,7 +31,7 @@ public class NavigationUserControl<TViewModel> : NavigationUserControl, IViewFor
     /// <summary>Initializes a new instance of the <see cref="NavigationUserControl{TViewModel}"/> class.</summary>
     public NavigationUserControl() =>
         this.WhenActivated(
-            (CompositeDisposable _) => ViewModel ??= AppLocator.Current.GetService<TViewModel>() ?? new());
+            (ActivationDisposable _) => ViewModel ??= AppLocator.Current.GetService<TViewModel>() ?? new());
 
     /// <summary>Gets the binding root view model.</summary>
     public TViewModel? BindingRoot => ViewModel;

--- a/src/CrissCross.WPF.UI/Controls/NavigationView/NavigationView.Base.cs
+++ b/src/CrissCross.WPF.UI/Controls/NavigationView/NavigationView.Base.cs
@@ -219,7 +219,7 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
         AutoSuggestBoxSymbolButton.Click -= AutoSuggestBoxSymbolButtonOnClick;
     }
 
-    /// <summary>Invoked when an unhandled <see cref="E:System.Windows.Input.Mouse.MouseDown" />�attached event reaches
+    /// <summary>Invoked when an unhandled <see cref="E:System.Windows.Input.Mouse.MouseDown" />Ã¯Â¿Â½attached event reaches
     /// an element in its route that is derived from this class. Implement this method to add class handling for this
     /// event.</summary>
     /// <param name="e">The <see cref="T:System.Windows.Input.MouseButtonEventArgs" /> that contains the event data.
@@ -266,28 +266,22 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
     /// <summary>This virtual method is called when <see cref="PaneDisplayMode"/> is changed.</summary>
     protected virtual void OnPaneDisplayModeChanged()
     {
-        switch (PaneDisplayMode)
+        if (PaneDisplayMode == NavigationViewPaneDisplayMode.LeftFluent)
         {
-            case NavigationViewPaneDisplayMode.LeftFluent:
-            {
-                IsBackButtonVisible = NavigationViewBackButtonVisible.Collapsed;
-                IsPaneToggleVisible = false;
-                break;
-            }
+            IsBackButtonVisible = NavigationViewBackButtonVisible.Collapsed;
+            IsPaneToggleVisible = false;
+            return;
+        }
 
-            case NavigationViewPaneDisplayMode.Left
+        if (PaneDisplayMode is NavigationViewPaneDisplayMode.Left
             or NavigationViewPaneDisplayMode.LeftMinimal
             or NavigationViewPaneDisplayMode.Top
-            or NavigationViewPaneDisplayMode.Bottom:
-            {
-                break;
-            }
-
-            default:
-            {
-                throw new ArgumentOutOfRangeException(nameof(PaneDisplayMode), PaneDisplayMode, null);
-            }
+            or NavigationViewPaneDisplayMode.Bottom)
+        {
+            return;
         }
+
+        throw new ArgumentOutOfRangeException(nameof(PaneDisplayMode), PaneDisplayMode, null);
     }
 
     /// <summary>This virtual method is called when <see cref="ItemTemplate"/> is changed.</summary>
@@ -606,36 +600,35 @@ public partial class NavigationView : System.Windows.Controls.Control, INavigati
     [DebuggerStepThrough]
     private void NavigationStackOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        switch (e.Action)
+        if (e.Action == NotifyCollectionChangedAction.Add)
         {
-            case NotifyCollectionChangedAction.Add:
-            {
-                _breadcrumbBarItems.Add(new((INavigationViewItem)e.NewItems![0]!));
-                break;
-            }
-
-            case NotifyCollectionChangedAction.Remove:
-            {
-                _breadcrumbBarItems.RemoveAt(e.OldStartingIndex);
-                break;
-            }
-
-            case NotifyCollectionChangedAction.Replace:
-            {
-                _breadcrumbBarItems[0] = new((INavigationViewItem)e.NewItems![0]!);
-                break;
-            }
-
-            case NotifyCollectionChangedAction.Move:
-                break;
-            case NotifyCollectionChangedAction.Reset:
-            {
-                _breadcrumbBarItems.Clear();
-                break;
-            }
-
-            default:
-                throw new ArgumentOutOfRangeException();
+            _breadcrumbBarItems.Add(new((INavigationViewItem)e.NewItems![0]!));
+            return;
         }
+
+        if (e.Action == NotifyCollectionChangedAction.Remove)
+        {
+            _breadcrumbBarItems.RemoveAt(e.OldStartingIndex);
+            return;
+        }
+
+        if (e.Action == NotifyCollectionChangedAction.Replace)
+        {
+            _breadcrumbBarItems[0] = new((INavigationViewItem)e.NewItems![0]!);
+            return;
+        }
+
+        if (e.Action == NotifyCollectionChangedAction.Move)
+        {
+            return;
+        }
+
+        if (e.Action == NotifyCollectionChangedAction.Reset)
+        {
+            _breadcrumbBarItems.Clear();
+            return;
+        }
+
+        throw new ArgumentOutOfRangeException();
     }
 }

--- a/src/CrissCross.WPF.UI/Controls/NavigationView/NavigationView.Navigation.cs
+++ b/src/CrissCross.WPF.UI/Controls/NavigationView/NavigationView.Navigation.cs
@@ -62,9 +62,9 @@ public partial class NavigationView
     public bool Navigate(string pageIdOrTargetTag) => Navigate(pageIdOrTargetTag, null);
 
     /// <inheritdoc />
-    public virtual bool Navigate(string pageIdOrTargetTag, object? dataContext) => !_pageIdOrTargetTagNavigationViewsDictionary.TryGetValue(pageIdOrTargetTag, out var navigationViewItem)
-        ? false
-        : NavigateInternal(navigationViewItem, dataContext);
+    public virtual bool Navigate(string pageIdOrTargetTag, object? dataContext) =>
+        _pageIdOrTargetTagNavigationViewsDictionary.TryGetValue(pageIdOrTargetTag, out var navigationViewItem)
+        && NavigateInternal(navigationViewItem, dataContext);
 
     /// <inheritdoc />
     public bool NavigateWithHierarchy(Type pageType) => NavigateWithHierarchy(pageType, null);

--- a/src/CrissCross.WPF.UI/Controls/NumberBox/NumberBox.cs
+++ b/src/CrissCross.WPF.UI/Controls/NumberBox/NumberBox.cs
@@ -213,43 +213,7 @@ public partial class NumberBox : TextBox
             return;
         }
 
-        switch (e?.Key)
-        {
-            case Key.PageUp:
-            {
-                StepValue(LargeChange);
-                break;
-            }
-
-            case Key.PageDown:
-            {
-                StepValue(-LargeChange);
-                break;
-            }
-
-            case Key.Up:
-            {
-                StepValue(SmallChange);
-                break;
-            }
-
-            case Key.Down:
-            {
-                StepValue(-SmallChange);
-                break;
-            }
-
-            case Key.Enter:
-            {
-                if (TextWrapping != TextWrapping.Wrap)
-                {
-                    ValidateInput();
-                    MoveCaretToTextEnd();
-                }
-
-                break;
-            }
-        }
+        _ = HandleKeyUp(e?.Key);
     }
 
     /// <inheritdoc />
@@ -261,28 +225,17 @@ public partial class NumberBox : TextBox
             "CrissCross.WPF.UI.NumberBox");
 #endif
 
-        switch (parameter)
+        if (parameter is "clear")
         {
-            case "clear":
-            {
-                OnClearButtonClick();
-
-                break;
-            }
-
-            case "increment":
-            {
-                StepValue(SmallChange);
-
-                break;
-            }
-
-            case "decrement":
-            {
-                StepValue(-SmallChange);
-
-                break;
-            }
+            OnClearButtonClick();
+        }
+        else if (parameter is "increment")
+        {
+            StepValue(SmallChange);
+        }
+        else if (parameter is "decrement")
+        {
+            StepValue(-SmallChange);
         }
 
         // NOTE: Focus looks and works well with mouse and Clear button. But it sucks for spin buttons
@@ -384,6 +337,43 @@ public partial class NumberBox : TextBox
         throw new ArgumentException(
             $"{nameof(NumberFormatter)} must implement {typeof(INumberParser)}",
             nameof(NumberFormatter));
+    }
+
+    /// <summary>Handles keyboard shortcuts for value stepping and validation.</summary>
+    /// <param name="key">The released key.</param>
+    /// <returns><see langword="true"/> when the key was handled.</returns>
+    private bool HandleKeyUp(Key? key) =>
+        key switch
+        {
+            Key.PageUp => StepValueAndReturnTrue(LargeChange),
+            Key.PageDown => StepValueAndReturnTrue(-LargeChange),
+            Key.Up => StepValueAndReturnTrue(SmallChange),
+            Key.Down => StepValueAndReturnTrue(-SmallChange),
+            Key.Enter => ValidateInputAndReturnHandled(),
+            _ => false,
+        };
+
+    /// <summary>Steps the value and reports the key as handled.</summary>
+    /// <param name="change">The value change.</param>
+    /// <returns><see langword="true"/>.</returns>
+    private bool StepValueAndReturnTrue(double change)
+    {
+        StepValue(change);
+        return true;
+    }
+
+    /// <summary>Validates editable text when enter commits input.</summary>
+    /// <returns><see langword="true"/> when enter committed input.</returns>
+    private bool ValidateInputAndReturnHandled()
+    {
+        if (TextWrapping == TextWrapping.Wrap)
+        {
+            return false;
+        }
+
+        ValidateInput();
+        MoveCaretToTextEnd();
+        return true;
     }
 
     /// <summary>Provides the StepValue member.</summary>

--- a/src/CrissCross.WPF.UI/Controls/NumberPad/NumberPad.xaml.cs
+++ b/src/CrissCross.WPF.UI/Controls/NumberPad/NumberPad.xaml.cs
@@ -158,32 +158,7 @@ public partial class NumberPad : IDisposable
             return;
         }
 
-        var key = button.Tag.ToString();
-        switch (key)
-        {
-            case ".":
-            {
-                var value = Value.Value;
-                if (value is not null)
-                {
-                    _currentValue = $"{(int)value}{key}";
-                }
-
-                break;
-            }
-
-            case "-":
-            {
-                InvertValue(key);
-                break;
-            }
-
-            default:
-            {
-                AddDigit(key);
-                break;
-            }
-        }
+        HandleDigitPress(button.Tag.ToString());
     }
 
     /// <summary>Gets the initial value for the configured range.</summary>
@@ -239,6 +214,36 @@ public partial class NumberPad : IDisposable
                 .Subscribe(_ => SystemThemeWatcher.UnWatch(c))
                 .DisposeWith(c._disposables);
         }
+    }
+
+    /// <summary>Handles keypad digit commands.</summary>
+    /// <param name="key">The selected keypad command or digit.</param>
+    private void HandleDigitPress(string? key)
+    {
+        if (key == ".")
+        {
+            AppendDecimalSeparator(key);
+        }
+        else if (key == "-")
+        {
+            InvertValue(key);
+        }
+        else
+        {
+            AddDigit(key);
+        }
+    }
+
+    /// <summary>Appends a decimal separator to the displayed value when a value exists.</summary>
+    /// <param name="key">The decimal key text.</param>
+    private void AppendDecimalSeparator(string key)
+    {
+        if (Value.Value is not { } value)
+        {
+            return;
+        }
+
+        _currentValue = $"{(int)value}{key}";
     }
 
     /// <summary>Adds the digit.</summary>
@@ -402,42 +407,21 @@ public partial class NumberPad : IDisposable
             return;
         }
 
-        switch (e.Key)
+        if (e.Key is Key.Enter or Key.Return)
         {
-            case Key.Enter or Key.Return:
-            {
-                AcceptResult();
-                break;
-            }
-
-            case Key.Escape:
-            {
-                CloseKeypad();
-                break;
-            }
-
-            case Key.OemMinus:
-            {
-                InvertValue("-");
-                break;
-            }
-
-            case Key.OemPeriod
-            or Key.Decimal:
-            {
-                var value = Value.Value;
-                if (value is not null)
-                {
-                    _currentValue = $"{(int)value}.";
-                }
-
-                break;
-            }
-
-            default:
-            {
-                break;
-            }
+            AcceptResult();
+        }
+        else if (e.Key == Key.Escape)
+        {
+            CloseKeypad();
+        }
+        else if (e.Key == Key.OemMinus)
+        {
+            InvertValue("-");
+        }
+        else if (e.Key is Key.OemPeriod or Key.Decimal)
+        {
+            AppendDecimalSeparator(".");
         }
 
         static string? GetDigitFromKey(Key key)

--- a/src/CrissCross.WPF.UI/Controls/PasswordBox/PasswordBox.cs
+++ b/src/CrissCross.WPF.UI/Controls/PasswordBox/PasswordBox.cs
@@ -160,22 +160,15 @@ public partial class PasswordBox : TextBox
             "CrissCross.WPF.UI.PasswordBox");
 #endif
 
-        switch (parameter)
+        if (parameter is "reveal")
         {
-            case "reveal":
-            {
-                IsPasswordRevealed = !IsPasswordRevealed;
-                _ = Focus();
-                CaretIndex = Text.Length;
-                break;
-            }
-
-            default:
-            {
-                base.OnTemplateButtonClick(parameter);
-                break;
-            }
+            IsPasswordRevealed = !IsPasswordRevealed;
+            _ = Focus();
+            CaretIndex = Text.Length;
+            return;
         }
+
+        base.OnTemplateButtonClick(parameter);
     }
 
     /// <summary>Called when <see cref="Password"/> is changed.</summary>
@@ -277,42 +270,33 @@ public partial class PasswordBox : TextBox
                 isDeleted = true;
             }
 
-            switch (newCharacters.Length)
+            if (newCharacters.Length > 1)
             {
-                case > 1:
-                {
-                    var index = _currentText.IndexOf(newCharacters[0]);
+                var index = _currentText.IndexOf(newCharacters[0]);
 
-                    _newPasswordValue =
-                        index > _newPasswordValue.Length - 1
-                            ? _newPasswordValue + newCharacters
-                            : _newPasswordValue.Insert(index, newCharacters);
-                    break;
-                }
-
-                case 1:
+                _newPasswordValue =
+                    index > _newPasswordValue.Length - 1
+                        ? _newPasswordValue + newCharacters
+                        : _newPasswordValue.Insert(index, newCharacters);
+            }
+            else if (newCharacters.Length == 1)
+            {
+                for (var i = 0; i < _currentText.Length; i++)
                 {
-                    for (var i = 0; i < _currentText.Length; i++)
+                    if (_currentText[i] == passwordChar)
                     {
-                        if (_currentText[i] == passwordChar)
-                        {
-                            continue;
-                        }
-
-                        UpdatePasswordWithInputCharacter(i, _currentText[i].ToString());
-                        break;
+                        continue;
                     }
 
+                    UpdatePasswordWithInputCharacter(i, _currentText[i].ToString());
                     break;
                 }
-
-                case 0 when !isDeleted:
-                {
-                    // The input is a PasswordChar, which is to be inserted at the designated position.
-                    var insertIndex = selectionIndex - 1;
-                    UpdatePasswordWithInputCharacter(insertIndex, passwordChar.ToString());
-                    break;
-                }
+            }
+            else if (!isDeleted)
+            {
+                // The input is a PasswordChar, which is to be inserted at the designated position.
+                var insertIndex = selectionIndex - 1;
+                UpdatePasswordWithInputCharacter(insertIndex, passwordChar.ToString());
             }
 
             return _newPasswordValue;

--- a/src/CrissCross.WPF.UI/Controls/PersonPicture/InitialsGeneratorExtensions.cs
+++ b/src/CrissCross.WPF.UI/Controls/PersonPicture/InitialsGeneratorExtensions.cs
@@ -179,45 +179,10 @@ internal static class InitialsGeneratorExtensions
 
             // In mix-match scenarios, we'll want to follow this order of precedence:
             // Glyph > Symbolic > Roman
-            switch (GetCharacterType(str[i]))
+            var characterType = GetCharacterType(str[i]);
+            if (characterType > result)
             {
-                case CharacterType.Glyph:
-                {
-                    result = CharacterType.Glyph;
-                    break;
-                }
-
-                case CharacterType.Symbolic:
-                {
-                    // Don't override a Glyph state with a Symbolic State.
-                    if (result != CharacterType.Glyph)
-                    {
-                        result = CharacterType.Symbolic;
-                    }
-
-                    break;
-                }
-
-                case CharacterType.Standard:
-                {
-                    // Don't override a Glyph or Symbolic state with a Latin state.
-                    if ((result != CharacterType.Glyph) && (result != CharacterType.Symbolic))
-                    {
-                        result = CharacterType.Standard;
-                    }
-
-                    break;
-                }
-
-                case CharacterType.Other:
-                {
-                    break;
-                }
-
-                default:
-                {
-                    throw new ArgumentOutOfRangeException(nameof(str), str, null);
-                }
+                result = characterType;
             }
         }
 

--- a/src/CrissCross.WPF.UI/Controls/ProcessValueIndicator/ProcessValueIndicator.cs
+++ b/src/CrissCross.WPF.UI/Controls/ProcessValueIndicator/ProcessValueIndicator.cs
@@ -1,0 +1,194 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVELIST_REACTIVE
+using ProcessValueState = CrissCross.Reactive.ProcessValueState;
+using ProcessValueStatus = CrissCross.Reactive.ProcessValueStatus;
+#else
+using ProcessValueState = CrissCross.ProcessValueState;
+using ProcessValueStatus = CrissCross.ProcessValueStatus;
+#endif
+
+#if REACTIVELIST_REACTIVE
+namespace CrissCross.Reactive.WPF.UI.Controls;
+#else
+namespace CrissCross.WPF.UI.Controls;
+#endif
+
+/// <summary>Displays a compact industrial process value with range progress and textual condition.</summary>
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
+public class ProcessValueIndicator : System.Windows.Controls.Control
+{
+    /// <summary>Identifies the <see cref="State"/> dependency property.</summary>
+    public static readonly DependencyProperty StateProperty;
+
+    /// <summary>Identifies the <see cref="Label"/> dependency property.</summary>
+    public static readonly DependencyProperty LabelProperty;
+
+    /// <summary>Identifies the <see cref="DisplayText"/> dependency property.</summary>
+    public static readonly DependencyProperty DisplayTextProperty;
+
+    /// <summary>Identifies the <see cref="StatusText"/> dependency property.</summary>
+    public static readonly DependencyProperty StatusTextProperty;
+
+    /// <summary>Identifies the <see cref="Percentage"/> dependency property.</summary>
+    public static readonly DependencyProperty PercentageProperty;
+
+    /// <summary>Identifies the <see cref="NormalizedValue"/> dependency property.</summary>
+    public static readonly DependencyProperty NormalizedValueProperty;
+
+    /// <summary>Identifies the <see cref="HasValidValue"/> dependency property.</summary>
+    public static readonly DependencyProperty HasValidValueProperty;
+
+    /// <summary>Identifies the <see cref="IsAlarm"/> dependency property.</summary>
+    public static readonly DependencyProperty IsAlarmProperty;
+
+    /// <summary>Identifies the <see cref="Status"/> dependency property.</summary>
+    public static readonly DependencyProperty StatusProperty;
+
+    /// <summary>Fallback state used when no process-value snapshot has been supplied.</summary>
+    private static readonly ProcessValueState EmptyState = new(
+        "Process value",
+        null,
+        string.Empty,
+        0D,
+        100D,
+        new() { IsGoodQuality = false });
+
+    /// <summary>Stores the read-only dependency property key for <see cref="Label"/>.</summary>
+    private static readonly DependencyPropertyKey LabelPropertyKey;
+
+    /// <summary>Stores the read-only dependency property key for <see cref="DisplayText"/>.</summary>
+    private static readonly DependencyPropertyKey DisplayTextPropertyKey;
+
+    /// <summary>Stores the read-only dependency property key for <see cref="StatusText"/>.</summary>
+    private static readonly DependencyPropertyKey StatusTextPropertyKey;
+
+    /// <summary>Stores the read-only dependency property key for <see cref="Percentage"/>.</summary>
+    private static readonly DependencyPropertyKey PercentagePropertyKey;
+
+    /// <summary>Stores the read-only dependency property key for <see cref="NormalizedValue"/>.</summary>
+    private static readonly DependencyPropertyKey NormalizedValuePropertyKey;
+
+    /// <summary>Stores the read-only dependency property key for <see cref="HasValidValue"/>.</summary>
+    private static readonly DependencyPropertyKey HasValidValuePropertyKey;
+
+    /// <summary>Stores the read-only dependency property key for <see cref="IsAlarm"/>.</summary>
+    private static readonly DependencyPropertyKey IsAlarmPropertyKey;
+
+    /// <summary>Stores the read-only dependency property key for <see cref="Status"/>.</summary>
+    private static readonly DependencyPropertyKey StatusPropertyKey;
+
+    /// <summary>Initializes static members of the <see cref="ProcessValueIndicator"/> class.</summary>
+    static ProcessValueIndicator()
+    {
+        StateProperty = DependencyProperty.Register(
+            nameof(State),
+            typeof(ProcessValueState),
+            typeof(ProcessValueIndicator),
+            new FrameworkPropertyMetadata(null, OnStateChanged));
+
+        LabelPropertyKey = CreateReadOnlyProperty(nameof(Label), typeof(string), EmptyState.Label);
+        LabelProperty = LabelPropertyKey.DependencyProperty;
+        DisplayTextPropertyKey = CreateReadOnlyProperty(nameof(DisplayText), typeof(string), EmptyState.DisplayText);
+        DisplayTextProperty = DisplayTextPropertyKey.DependencyProperty;
+        StatusTextPropertyKey = CreateReadOnlyProperty(nameof(StatusText), typeof(string), EmptyState.StatusText);
+        StatusTextProperty = StatusTextPropertyKey.DependencyProperty;
+        PercentagePropertyKey = CreateReadOnlyProperty(nameof(Percentage), typeof(double), EmptyState.Percentage);
+        PercentageProperty = PercentagePropertyKey.DependencyProperty;
+        NormalizedValuePropertyKey = CreateReadOnlyProperty(nameof(NormalizedValue), typeof(double), EmptyState.NormalizedValue);
+        NormalizedValueProperty = NormalizedValuePropertyKey.DependencyProperty;
+        HasValidValuePropertyKey = CreateReadOnlyProperty(nameof(HasValidValue), typeof(bool), EmptyState.HasValidValue);
+        HasValidValueProperty = HasValidValuePropertyKey.DependencyProperty;
+        IsAlarmPropertyKey = CreateReadOnlyProperty(nameof(IsAlarm), typeof(bool), EmptyState.IsAlarm);
+        IsAlarmProperty = IsAlarmPropertyKey.DependencyProperty;
+        StatusPropertyKey = CreateReadOnlyProperty(nameof(Status), typeof(ProcessValueStatus), EmptyState.Status);
+        StatusProperty = StatusPropertyKey.DependencyProperty;
+
+        DefaultStyleKeyProperty.OverrideMetadata(
+            typeof(ProcessValueIndicator),
+            new FrameworkPropertyMetadata(typeof(ProcessValueIndicator)));
+    }
+
+    /// <summary>Gets or sets the immutable process value snapshot displayed by the indicator.</summary>
+    public ProcessValueState? State
+    {
+        get => (ProcessValueState?)GetValue(StateProperty);
+        set => SetValue(StateProperty, value);
+    }
+
+    /// <summary>Gets the measurement label projected from <see cref="State"/>.</summary>
+    public string Label => (string)GetValue(LabelProperty);
+
+    /// <summary>Gets the formatted value and unit projected from <see cref="State"/>.</summary>
+    public string DisplayText => (string)GetValue(DisplayTextProperty);
+
+    /// <summary>Gets the textual status projected from <see cref="State"/>.</summary>
+    public string StatusText => (string)GetValue(StatusTextProperty);
+
+    /// <summary>Gets the clamped range percentage projected from <see cref="State"/>.</summary>
+    public double Percentage => (double)GetValue(PercentageProperty);
+
+    /// <summary>Gets the clamped normalized range position projected from <see cref="State"/>.</summary>
+    public double NormalizedValue => (double)GetValue(NormalizedValueProperty);
+
+    /// <summary>Gets a value indicating whether <see cref="State"/> contains a displayable value.</summary>
+    public bool HasValidValue => (bool)GetValue(HasValidValueProperty);
+
+    /// <summary>Gets a value indicating whether <see cref="State"/> resolves to an alarm status.</summary>
+    public bool IsAlarm => (bool)GetValue(IsAlarmProperty);
+
+    /// <summary>Gets the semantic status projected from <see cref="State"/>.</summary>
+    public ProcessValueStatus Status => (ProcessValueStatus)GetValue(StatusProperty);
+
+    /// <summary>Gets a debugger-friendly textual representation of this instance.</summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private string DebuggerDisplay => string.IsNullOrEmpty(Label) ? GetType().Name : $"{Label}: {DisplayText}";
+
+    /// <summary>Copies the immutable state snapshot into template-bindable dependency properties.</summary>
+    /// <param name="state">The process value state, or <see langword="null"/> for the empty fallback.</param>
+    protected virtual void OnStateChanged(ProcessValueState? state) => ApplyState(state ?? EmptyState);
+
+    /// <summary>Creates a read-only dependency property key with shared owner metadata.</summary>
+    /// <param name="propertyName">The dependency property name.</param>
+    /// <param name="propertyType">The dependency property value type.</param>
+    /// <param name="defaultValue">The dependency property default value.</param>
+    /// <returns>The registered read-only dependency property key.</returns>
+    private static DependencyPropertyKey CreateReadOnlyProperty(
+        string propertyName,
+        Type propertyType,
+        object defaultValue) =>
+        DependencyProperty.RegisterReadOnly(
+            propertyName,
+            propertyType,
+            typeof(ProcessValueIndicator),
+            new FrameworkPropertyMetadata(defaultValue));
+
+    /// <summary>Handles changes to the <see cref="State"/> dependency property.</summary>
+    /// <param name="dependencyObject">The dependency object that received the state.</param>
+    /// <param name="args">The dependency property change data.</param>
+    private static void OnStateChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+    {
+        if (dependencyObject is not ProcessValueIndicator indicator)
+        {
+            return;
+        }
+
+        indicator.OnStateChanged((ProcessValueState?)args.NewValue);
+    }
+
+    /// <summary>Applies the projected values from a process value state.</summary>
+    /// <param name="state">The process value state snapshot.</param>
+    private void ApplyState(ProcessValueState state)
+    {
+        SetValue(LabelPropertyKey, state.Label);
+        SetValue(DisplayTextPropertyKey, state.DisplayText);
+        SetValue(StatusTextPropertyKey, state.StatusText);
+        SetValue(PercentagePropertyKey, state.Percentage);
+        SetValue(NormalizedValuePropertyKey, state.NormalizedValue);
+        SetValue(HasValidValuePropertyKey, state.HasValidValue);
+        SetValue(IsAlarmPropertyKey, state.IsAlarm);
+        SetValue(StatusPropertyKey, state.Status);
+    }
+}

--- a/src/CrissCross.WPF.UI/Controls/ProcessValueIndicator/ProcessValueIndicator.xaml
+++ b/src/CrissCross.WPF.UI/Controls/ProcessValueIndicator/ProcessValueIndicator.xaml
@@ -1,0 +1,45 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="clr-namespace:CrissCross.WPF.UI.Controls">
+  <Style TargetType="{x:Type controls:ProcessValueIndicator}">
+    <Setter Property="Background" Value="{DynamicResource CardBackgroundFillColorSecondaryBrush}" />
+    <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+    <Setter Property="Padding" Value="12" />
+    <Setter Property="MinWidth" Value="220" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type controls:ProcessValueIndicator}">
+          <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding Border.CornerRadius}"
+                  Padding="{TemplateBinding Padding}">
+            <StackPanel>
+              <TextBlock FontSize="14" FontWeight="Bold" Text="{TemplateBinding Label}" TextTrimming="CharacterEllipsis" />
+              <TextBlock Margin="0,6,0,0" FontSize="22" FontWeight="Bold"
+                         Text="{TemplateBinding DisplayText}" TextTrimming="CharacterEllipsis" />
+              <ProgressBar x:Name="PART_RangeBar" Margin="0,6,0,0" Height="8" Minimum="0" Maximum="100"
+                           Background="{DynamicResource SystemFillColorNeutralBackgroundBrush}"
+                           Foreground="{DynamicResource SystemFillColorSuccessBrush}" Value="{TemplateBinding Percentage}" />
+              <TextBlock x:Name="PART_StatusText" Margin="0,6,0,0" FontSize="14"
+                         Foreground="{DynamicResource SystemFillColorSuccessBrush}"
+                         Text="{TemplateBinding StatusText}" TextTrimming="CharacterEllipsis" />
+            </StackPanel>
+          </Border>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsAlarm" Value="True">
+              <Setter TargetName="PART_RangeBar" Property="Foreground" Value="{DynamicResource SystemFillColorCriticalBrush}" />
+              <Setter TargetName="PART_StatusText" Property="Foreground" Value="{DynamicResource SystemFillColorCriticalBrush}" />
+            </Trigger>
+            <Trigger Property="Status" Value="BadQuality">
+              <Setter TargetName="PART_RangeBar" Property="Foreground" Value="{DynamicResource SystemFillColorCautionBrush}" />
+              <Setter TargetName="PART_StatusText" Property="Foreground" Value="{DynamicResource SystemFillColorCautionBrush}" />
+            </Trigger>
+            <Trigger Property="Status" Value="InvalidConfiguration">
+              <Setter TargetName="PART_RangeBar" Property="Foreground" Value="{DynamicResource SystemFillColorNeutralBrush}" />
+              <Setter TargetName="PART_StatusText" Property="Foreground" Value="{DynamicResource SystemFillColorNeutralBrush}" />
+            </Trigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+</ResourceDictionary>

--- a/src/CrissCross.WPF.UI/Controls/RatingControl/RatingControl.cs
+++ b/src/CrissCross.WPF.UI/Controls/RatingControl/RatingControl.cs
@@ -359,29 +359,8 @@ public class RatingControl : System.Windows.Controls.ContentControl
             return;
         }
 
-        switch (starValue)
-        {
-            case StarValue.HalfFilled:
-            {
-                selectedIcon.Filled = false;
-                selectedIcon.Symbol = StarHalfSymbol;
-                break;
-            }
-
-            case StarValue.Filled:
-            {
-                selectedIcon.Filled = true;
-                selectedIcon.Symbol = StarSymbol;
-                break;
-            }
-
-            default:
-            {
-                selectedIcon.Filled = false;
-                selectedIcon.Symbol = StarSymbol;
-                break;
-            }
-        }
+        selectedIcon.Filled = starValue == StarValue.Filled;
+        selectedIcon.Symbol = starValue == StarValue.HalfFilled ? StarHalfSymbol : StarSymbol;
     }
 
     /// <summary>Provides the ExtractValueFromOffset member.</summary>

--- a/src/CrissCross.WPF.UI/Controls/Snackbar/SnackbarPresenter.cs
+++ b/src/CrissCross.WPF.UI/Controls/Snackbar/SnackbarPresenter.cs
@@ -27,20 +27,6 @@ public class SnackbarPresenter : System.Windows.Controls.ContentPresenter, IDisp
             self.OnUnloaded();
         };
 
-    /// <summary>Gets the Gets or sets the content. value.</summary>
-    /// <value>
-    /// The content.
-    /// </value>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "WpfAnalyzers.DependencyProperty",
-        "WPF0012:CLR property type should match registered type",
-        Justification = "seems harmless")]
-    public new Snackbar? Content
-    {
-        get => (Snackbar?)GetValue(ContentProperty);
-        protected set => SetValue(ContentProperty, value);
-    }
-
     /// <summary>Gets the queue.</summary>
     /// <value>
     /// The queue.
@@ -57,13 +43,20 @@ public class SnackbarPresenter : System.Windows.Controls.ContentPresenter, IDisp
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private string DebuggerDisplay => ToString() ?? GetType().Name;
 
+    /// <summary>Gets or sets the currently displayed snackbar.</summary>
+    private Snackbar? CurrentSnackbar
+    {
+        get => GetValue(ContentProperty) as Snackbar;
+        set => SetValue(ContentProperty, value);
+    }
+
     /// <summary>Adds to que.</summary>
     /// <param name="snackbar">The snackbar.</param>
     public virtual void AddToQue(Snackbar snackbar)
     {
         Queue.Enqueue(snackbar);
 
-        if (Content is not null)
+        if (CurrentSnackbar is not null)
         {
             return;
         }
@@ -91,13 +84,13 @@ public class SnackbarPresenter : System.Windows.Controls.ContentPresenter, IDisp
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public virtual async Task HideCurrent()
     {
-        if (Content is null)
+        if (CurrentSnackbar is not { } snackbar)
         {
             return;
         }
 
         await CancelCurrentAsync();
-        await HidSnackbar(Content);
+        await HidSnackbar(snackbar);
         ResetCancellationTokenSource();
     }
 
@@ -152,13 +145,13 @@ public class SnackbarPresenter : System.Windows.Controls.ContentPresenter, IDisp
     /// <summary>Provides the ImmediatelyHideCurrent member.</summary>
     private void ImmediatelyHideCurrent()
     {
-        if (Content is null)
+        if (CurrentSnackbar is not { } snackbar)
         {
             return;
         }
 
         CancellationTokenSource.Cancel();
-        ImmediatelyHidSnackbar(Content);
+        ImmediatelyHidSnackbar(snackbar);
     }
 
     /// <summary>Provides the ImmediatelyHidSnackbar member.</summary>
@@ -166,7 +159,7 @@ public class SnackbarPresenter : System.Windows.Controls.ContentPresenter, IDisp
     private void ImmediatelyHidSnackbar(Snackbar snackbar)
     {
         snackbar.SetCurrentValue(Snackbar.IsShownProperty, false);
-        Content = null;
+        CurrentSnackbar = null;
     }
 
     /// <summary>Provides the ShowQueuedSnackbars member.</summary>
@@ -186,7 +179,7 @@ public class SnackbarPresenter : System.Windows.Controls.ContentPresenter, IDisp
     /// <returns>The result.</returns>
     private async Task ShowSnackbar(Snackbar snackbar)
     {
-        Content = snackbar;
+        CurrentSnackbar = snackbar;
 
         snackbar.SetCurrentValue(Snackbar.IsShownProperty, true);
 
@@ -211,6 +204,6 @@ public class SnackbarPresenter : System.Windows.Controls.ContentPresenter, IDisp
 
         await Task.Delay(HideTransitionDurationMilliseconds);
 
-        Content = null;
+        CurrentSnackbar = null;
     }
 }

--- a/src/CrissCross.WPF.UI/Controls/TitleBar/TitleBar.cs
+++ b/src/CrissCross.WPF.UI/Controls/TitleBar/TitleBar.cs
@@ -540,43 +540,50 @@ public class TitleBar : Control, IThemeControl
 
     /// <summary>Provides the OnTemplateButtonClick member.</summary>
     /// <param name="buttonType">The buttonType value.</param>
-    private void OnTemplateButtonClick(TitleBarButtonType buttonType)
-    {
-        switch (buttonType)
+    private void OnTemplateButtonClick(TitleBarButtonType buttonType) =>
+        _ = buttonType switch
         {
-            case TitleBarButtonType.Maximize or TitleBarButtonType.Restore:
-            {
-                RaiseEvent(new(MaximizeClickedEvent, this));
-                MaximizeWindow();
-                break;
-            }
+            TitleBarButtonType.Maximize or TitleBarButtonType.Restore => RaiseMaximizeAndReturnTrue(),
+            TitleBarButtonType.Close => RaiseCloseAndReturnTrue(),
+            TitleBarButtonType.Minimize => RaiseMinimizeAndReturnTrue(),
+            TitleBarButtonType.Help => RaiseHelpAndReturnTrue(),
+            TitleBarButtonType.Unknown => false,
+            _ => throw new ArgumentOutOfRangeException(nameof(buttonType), buttonType, null),
+        };
 
-            case TitleBarButtonType.Close:
-            {
-                RaiseEvent(new(CloseClickedEvent, this));
-                CloseWindow();
-                break;
-            }
+    /// <summary>Raises the maximize command and reports the button as handled.</summary>
+    /// <returns><see langword="true"/>.</returns>
+    private bool RaiseMaximizeAndReturnTrue()
+    {
+        RaiseEvent(new(MaximizeClickedEvent, this));
+        MaximizeWindow();
+        return true;
+    }
 
-            case TitleBarButtonType.Minimize:
-            {
-                RaiseEvent(new(MinimizeClickedEvent, this));
-                MinimizeWindow();
-                break;
-            }
+    /// <summary>Raises the close command and reports the button as handled.</summary>
+    /// <returns><see langword="true"/>.</returns>
+    private bool RaiseCloseAndReturnTrue()
+    {
+        RaiseEvent(new(CloseClickedEvent, this));
+        CloseWindow();
+        return true;
+    }
 
-            case TitleBarButtonType.Help:
-            {
-                RaiseEvent(new(HelpClickedEvent, this));
-                break;
-            }
+    /// <summary>Raises the minimize command and reports the button as handled.</summary>
+    /// <returns><see langword="true"/>.</returns>
+    private bool RaiseMinimizeAndReturnTrue()
+    {
+        RaiseEvent(new(MinimizeClickedEvent, this));
+        MinimizeWindow();
+        return true;
+    }
 
-            case TitleBarButtonType.Unknown:
-                break;
-
-            default:
-                throw new ArgumentOutOfRangeException(nameof(buttonType), buttonType, null);
-        }
+    /// <summary>Raises the help command and reports the button as handled.</summary>
+    /// <returns><see langword="true"/>.</returns>
+    private bool RaiseHelpAndReturnTrue()
+    {
+        RaiseEvent(new(HelpClickedEvent, this));
+        return true;
     }
 
     /// <summary>Listening window hooks after rendering window content to SizeToContent support.</summary>
@@ -615,26 +622,25 @@ public class TitleBar : Control, IThemeControl
 
         var isMouseOverHeaderContent = IsMouseOverHeaderContent(message, longParameter);
 
-        switch (message)
+        return message switch
         {
-            case User32.WM.NCHITTEST when CloseWindowByDoubleClickOnIcon && _icon.IsMouseOverElement(longParameter):
-            {
-                handled = true;
+            User32.WM.NCHITTEST when CloseWindowByDoubleClickOnIcon && _icon.IsMouseOverElement(longParameter) =>
+                HandleTitleBarHitTest(ref handled, User32.WM_NCHITTEST.HTSYSMENU),
+            User32.WM.NCHITTEST when this.IsMouseOverElement(longParameter) && !isMouseOverHeaderContent =>
+                HandleTitleBarHitTest(ref handled, User32.WM_NCHITTEST.HTCAPTION),
+            _ => IntPtr.Zero,
+        };
+    }
 
-                // Ideally, clicking on the icon should open the system menu, but when the system menu is opened
-                // manually, double-clicking on the icon does not close the window
-                return (IntPtr)User32.WM_NCHITTEST.HTSYSMENU;
-            }
-
-            case User32.WM.NCHITTEST when this.IsMouseOverElement(longParameter) && !isMouseOverHeaderContent:
-            {
-                handled = true;
-                return (IntPtr)User32.WM_NCHITTEST.HTCAPTION;
-            }
-
-            default:
-                return IntPtr.Zero;
-        }
+    /// <summary>Marks a title bar hit test as handled and returns the native result.</summary>
+    /// <param name="handled">The handled flag.</param>
+    /// <param name="hitTestResult">The native hit test result.</param>
+    /// <returns>The native hit test result pointer.</returns>
+    private IntPtr HandleTitleBarHitTest(ref bool handled, User32.WM_NCHITTEST hitTestResult)
+    {
+        _ = _buttons;
+        handled = true;
+        return (IntPtr)hitTestResult;
     }
 
     /// <summary>Determines whether the mouse is over title/header content.</summary>

--- a/src/CrissCross.WPF.UI/Controls/TitleBar/TitleBarButton.cs
+++ b/src/CrissCross.WPF.UI/Controls/TitleBar/TitleBarButton.cs
@@ -164,43 +164,15 @@ public class TitleBarButton : Button
     {
         returnIntPtr = IntPtr.Zero;
 
-        switch (msg)
+        return msg switch
         {
-            case User32.WM.NCHITTEST:
-            {
-                if (this.IsMouseOverElement(messageParameter))
-                {
-                    Hover();
-                    returnIntPtr = (IntPtr)_returnValue;
-                    return true;
-                }
-
-                RemoveHover();
-                return false;
-            }
-
-            case User32.WM.NCMOUSELEAVE: // Mouse leaves the window
-            {
-                RemoveHover();
-                return false;
-            }
-
-            case User32.WM.NCLBUTTONDOWN when this.IsMouseOverElement(messageParameter): // Left button clicked down
-            {
-                _isClickedDown = true;
-                return true;
-            }
-
-            // Left button clicked up.
-            case User32.WM.NCLBUTTONUP when _isClickedDown && this.IsMouseOverElement(messageParameter):
-            {
-                InvokeClick();
-                return true;
-            }
-
-            default:
-                return false;
-        }
+            User32.WM.NCHITTEST when this.IsMouseOverElement(messageParameter) =>
+                HoverAndReturnHitTest(out returnIntPtr),
+            User32.WM.NCHITTEST or User32.WM.NCMOUSELEAVE => RemoveHoverAndReturnFalse(),
+            User32.WM.NCLBUTTONDOWN when this.IsMouseOverElement(messageParameter) => SetClickedDownAndReturnTrue(),
+            User32.WM.NCLBUTTONUP when _isClickedDown && this.IsMouseOverElement(messageParameter) => ClickAndReturnTrue(),
+            _ => false,
+        };
     }
 
     /// <summary>Provides the ButtonTypePropertyCallback member.</summary>
@@ -210,6 +182,40 @@ public class TitleBarButton : Button
     {
         var titleBarButton = (TitleBarButton)d;
         titleBarButton.UpdateReturnValue((TitleBarButtonType)e.NewValue);
+    }
+
+    /// <summary>Applies hover state and returns a hit-test result.</summary>
+    /// <param name="returnIntPtr">The native hit-test return pointer.</param>
+    /// <returns><see langword="true"/>.</returns>
+    private bool HoverAndReturnHitTest(out IntPtr returnIntPtr)
+    {
+        Hover();
+        returnIntPtr = (IntPtr)_returnValue;
+        return true;
+    }
+
+    /// <summary>Removes hover state and reports the message as unhandled.</summary>
+    /// <returns><see langword="false"/>.</returns>
+    private bool RemoveHoverAndReturnFalse()
+    {
+        RemoveHover();
+        return false;
+    }
+
+    /// <summary>Stores the native mouse-down state.</summary>
+    /// <returns><see langword="true"/>.</returns>
+    private bool SetClickedDownAndReturnTrue()
+    {
+        _isClickedDown = true;
+        return true;
+    }
+
+    /// <summary>Invokes the click command.</summary>
+    /// <returns><see langword="true"/>.</returns>
+    private bool ClickAndReturnTrue()
+    {
+        InvokeClick();
+        return true;
     }
 
     /// <summary>Provides the TitleBarButton_Unloaded member.</summary>

--- a/src/CrissCross.WPF.UI/Controls/TreeView/ReactiveTreeView.xaml.cs
+++ b/src/CrissCross.WPF.UI/Controls/TreeView/ReactiveTreeView.xaml.cs
@@ -36,7 +36,7 @@ public partial class ReactiveTreeView
 
     /// <summary>Connects the tree items to the active view model.</summary>
     /// <param name="disposables">The activation disposables.</param>
-    private void OnActivated(CompositeDisposable disposables) =>
+    private void OnActivated(ActivationDisposable disposables) =>
         this.WhenAnyValue(v => v.ViewModel)
             .Where(static vm => vm is not null)
             .Select(static vm => vm!.WhenAnyValue(x => x.Children))

--- a/src/CrissCross.WPF.UI/Controls/VirtualizingWrapPanel/VirtualizingPanelBase.cs
+++ b/src/CrissCross.WPF.UI/Controls/VirtualizingWrapPanel/VirtualizingPanelBase.cs
@@ -325,19 +325,23 @@ public abstract class VirtualizingPanelBase : VirtualizingPanel, IScrollInfo
     /// <inheritdoc />
     protected override void OnItemsChanged(object sender, ItemsChangedEventArgs args)
     {
-        switch (args?.Action)
+        if (args is null)
         {
-            case NotifyCollectionChangedAction.Remove or NotifyCollectionChangedAction.Replace:
-            {
-                RemoveInternalChildRange(args.Position.Index, args.ItemUICount);
-                break;
-            }
+            return;
+        }
 
-            case NotifyCollectionChangedAction.Move:
-            {
-                RemoveInternalChildRange(args.OldPosition.Index, args.ItemUICount);
-                break;
-            }
+        _ = args.Action switch
+        {
+            NotifyCollectionChangedAction.Remove or NotifyCollectionChangedAction.Replace =>
+                RemoveInternalChildRangeAndReturnTrue(args.Position.Index, args.ItemUICount),
+            NotifyCollectionChangedAction.Move => RemoveInternalChildRangeAndReturnTrue(args.OldPosition.Index, args.ItemUICount),
+            _ => false,
+        };
+
+        bool RemoveInternalChildRangeAndReturnTrue(int index, int count)
+        {
+            RemoveInternalChildRange(index, count);
+            return true;
         }
     }
 

--- a/src/CrissCross.WPF.UI/Controls/VirtualizingWrapPanel/VirtualizingWrapPanel.cs
+++ b/src/CrissCross.WPF.UI/Controls/VirtualizingWrapPanel/VirtualizingWrapPanel.cs
@@ -150,36 +150,13 @@ public class VirtualizingWrapPanel : VirtualizingPanelBase
         var totalItemsWidth = Math.Min(GetWidth(childSize) * ItemsPerRowCount, finalWidth);
         var unusedWidth = finalWidth - totalItemsWidth;
 
-        switch (SpacingMode)
+        (innerSpacing, outerSpacing) = SpacingMode switch
         {
-            case SpacingMode.Uniform:
-            {
-                innerSpacing = unusedWidth / (ItemsPerRowCount + 1);
-                outerSpacing = innerSpacing;
-                break;
-            }
-
-            case SpacingMode.BetweenItemsOnly:
-            {
-                innerSpacing = unusedWidth / Math.Max(ItemsPerRowCount - 1, 1);
-                outerSpacing = 0;
-                break;
-            }
-
-            case SpacingMode.StartAndEndOnly:
-            {
-                innerSpacing = 0;
-                outerSpacing = unusedWidth / OuterEdgeCount;
-                break;
-            }
-
-            default:
-            {
-                innerSpacing = 0;
-                outerSpacing = 0;
-                break;
-            }
-        }
+            SpacingMode.Uniform => (unusedWidth / (ItemsPerRowCount + 1), unusedWidth / (ItemsPerRowCount + 1)),
+            SpacingMode.BetweenItemsOnly => (unusedWidth / Math.Max(ItemsPerRowCount - 1, 1), 0),
+            SpacingMode.StartAndEndOnly => (0, unusedWidth / OuterEdgeCount),
+            _ => (0, 0),
+        };
     }
 
     /// <inheritdoc />

--- a/src/CrissCross.WPF.UI/Controls/Window/WindowBackdrop.cs
+++ b/src/CrissCross.WPF.UI/Controls/Window/WindowBackdrop.cs
@@ -45,7 +45,7 @@ public static class WindowBackdrop
         {
             var windowHandle = new WindowInteropHelper(window).Handle;
 
-            return windowHandle == IntPtr.Zero ? false : ApplyBackdrop(windowHandle, backdropType);
+            return windowHandle != IntPtr.Zero && ApplyBackdrop(windowHandle, backdropType);
         }
 
         window.Loaded += (sender, eventArgs) =>
@@ -93,19 +93,9 @@ public static class WindowBackdrop
         _ = UnsafeNativeMethods.RemoveWindowCaption(windowHandle);
 
         // 22H1
-        if (!Win32.Utilities.IsOSWindows11Insider1OrNewer)
-        {
-            return backdropType != WindowBackdropType.None ? ApplyLegacyMicaBackdrop(windowHandle) : false;
-        }
-
-        return backdropType switch
-        {
-            WindowBackdropType.Auto => ApplyDwmwWindowAttrubute(windowHandle, Dwmapi.DWMSBT.DWMSBT_AUTO),
-            WindowBackdropType.Mica => ApplyDwmwWindowAttrubute(windowHandle, Dwmapi.DWMSBT.DWMSBT_MAINWINDOW),
-            WindowBackdropType.Acrylic => ApplyDwmwWindowAttrubute(windowHandle, Dwmapi.DWMSBT.DWMSBT_TRANSIENTWINDOW),
-            WindowBackdropType.Tabbed => ApplyDwmwWindowAttrubute(windowHandle, Dwmapi.DWMSBT.DWMSBT_TABBEDWINDOW),
-            _ => ApplyDwmwWindowAttrubute(windowHandle, Dwmapi.DWMSBT.DWMSBT_DISABLE),
-        };
+        return Win32.Utilities.IsOSWindows11Insider1OrNewer
+            ? ApplyWindows11Backdrop(windowHandle, backdropType)
+            : backdropType != WindowBackdropType.None && ApplyLegacyMicaBackdrop(windowHandle);
     }
 
     /// <summary>Tries to remove backdrop effects if they have been applied to the <see cref="Window" />.</summary>
@@ -234,6 +224,20 @@ public static class WindowBackdrop
 
         return true;
     }
+
+    /// <summary>Applies a Windows 11 backdrop effect to the selected handle.</summary>
+    /// <param name="windowHandle">The window handle.</param>
+    /// <param name="backdropType">Type of the backdrop.</param>
+    /// <returns>The result.</returns>
+    private static bool ApplyWindows11Backdrop(IntPtr windowHandle, WindowBackdropType backdropType) =>
+        backdropType switch
+        {
+            WindowBackdropType.Auto => ApplyDwmwWindowAttrubute(windowHandle, Dwmapi.DWMSBT.DWMSBT_AUTO),
+            WindowBackdropType.Mica => ApplyDwmwWindowAttrubute(windowHandle, Dwmapi.DWMSBT.DWMSBT_MAINWINDOW),
+            WindowBackdropType.Acrylic => ApplyDwmwWindowAttrubute(windowHandle, Dwmapi.DWMSBT.DWMSBT_TRANSIENTWINDOW),
+            WindowBackdropType.Tabbed => ApplyDwmwWindowAttrubute(windowHandle, Dwmapi.DWMSBT.DWMSBT_TABBEDWINDOW),
+            _ => ApplyDwmwWindowAttrubute(windowHandle, Dwmapi.DWMSBT.DWMSBT_DISABLE),
+        };
 
     /// <summary>Provides the ApplyDwmwWindowAttrubute member.</summary>
     /// <param name="windowHandle">The window handle.</param>

--- a/src/CrissCross.WPF.UI/Converters/BoolToInvertedBoolConverter.cs
+++ b/src/CrissCross.WPF.UI/Converters/BoolToInvertedBoolConverter.cs
@@ -25,7 +25,7 @@ public sealed class BoolToInvertedBoolConverter : IValueConverter
     /// <param name="parameter">The parameter.</param>
     /// <param name="culture">The culture value.</param>
     /// <returns>The result.</returns>
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => value is not bool boolValue ? false : !boolValue;
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => value is bool boolValue && !boolValue;
 
     /// <summary>Provides the ConvertBack member.</summary>
     /// <param name="value">The value.</param>

--- a/src/CrissCross.WPF.UI/CrissCross.WPF.UI.csproj
+++ b/src/CrissCross.WPF.UI/CrissCross.WPF.UI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(CrissCrossWinTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
@@ -22,7 +22,6 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EnablePackageValidation>true</EnablePackageValidation>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <NoWarn>$(NoWarn);CA1812</NoWarn>
   </PropertyGroup>
 
   <!-- Release specific optimizations -->

--- a/src/CrissCross.WPF.UI/Interop/UnsafeNativeMethods.cs
+++ b/src/CrissCross.WPF.UI/Interop/UnsafeNativeMethods.cs
@@ -421,6 +421,9 @@ public static class UnsafeNativeMethods
         return true;
     }
 
+    /// <summary>Removes the standard non-client caption from the specified window.</summary>
+    /// <param name="window">The window to update.</param>
+    /// <returns><see langword="true"/> if the native window theme attribute was applied.</returns>
     public static bool RemoveWindowCaption(Window window)
     {
         if (window is null)
@@ -433,6 +436,9 @@ public static class UnsafeNativeMethods
         return RemoveWindowCaption(windowHandle);
     }
 
+    /// <summary>Removes the standard non-client caption from the specified window handle.</summary>
+    /// <param name="hWnd">The window handle to update.</param>
+    /// <returns><see langword="true"/> if the native window theme attribute was applied.</returns>
     public static bool RemoveWindowCaption(IntPtr hWnd)
     {
         if (hWnd == IntPtr.Zero)
@@ -460,6 +466,9 @@ public static class UnsafeNativeMethods
         return true;
     }
 
+    /// <summary>Extends the client rendering area into the title bar for the specified window.</summary>
+    /// <param name="window">The window to update.</param>
+    /// <returns><see langword="true"/> if the native frame changes were applied.</returns>
     public static bool ExtendClientAreaIntoTitleBar(Window window)
     {
         if (window is null)
@@ -472,6 +481,9 @@ public static class UnsafeNativeMethods
         return ExtendClientAreaIntoTitleBar(windowHandle);
     }
 
+    /// <summary>Extends the client rendering area into the title bar for the specified window handle.</summary>
+    /// <param name="hWnd">The window handle to update.</param>
+    /// <returns><see langword="true"/> if the native frame changes were applied.</returns>
     public static bool ExtendClientAreaIntoTitleBar(IntPtr hWnd)
     {
         // !! EXPERIMENTAl

--- a/src/CrissCross.WPF.UI/Resources/CrissCross.Ui.xaml
+++ b/src/CrissCross.WPF.UI/Resources/CrissCross.Ui.xaml
@@ -125,6 +125,7 @@
     <ResourceDictionary Source="pack://application:,,,/CrissCross.WPF.UI;component/Controls/CheckBoxModern/CheckBoxModern.xaml" />
     <ResourceDictionary Source="pack://application:,,,/CrissCross.WPF.UI;component/Controls/Alarms/Alarms.xaml" />
     <ResourceDictionary Source="pack://application:,,,/CrissCross.WPF.UI;component/Controls/AlarmBanner/AlarmBanner.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/CrissCross.WPF.UI;component/Controls/ProcessValueIndicator/ProcessValueIndicator.xaml" />
     <ResourceDictionary Source="pack://application:,,,/CrissCross.WPF.UI;component/Controls/Gauges/CircularGauge.xaml" />
   </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/src/CrissCross.WPF.UI/Resources/Theme/HC1.xaml
+++ b/src/CrissCross.WPF.UI/Resources/Theme/HC1.xaml
@@ -644,114 +644,114 @@
   />
 
   <!--  Colors  -->
-  <!--  Colors copied from Default theme to match list of keys. Should not be using these keys. These are set to Red to notify that.  -->
-  <Color x:Key="TextFillColorPrimary">#FF0000</Color>
-  <Color x:Key="TextFillColorSecondary">#FF0000</Color>
-  <Color x:Key="TextFillColorTertiary">#FF0000</Color>
-  <Color x:Key="TextFillColorDisabled">#FF0000</Color>
-  <Color x:Key="TextPlaceholderColor">#FF0000</Color>
-  <Color x:Key="TextFillColorInverse">#FF0000</Color>
+  <!--  Color values support consumers that build brushes directly; keep them consistent with the high-contrast palette.  -->
+  <Color x:Key="TextFillColorPrimary">#FFFFFF</Color>
+  <Color x:Key="TextFillColorSecondary">#FFFFFF</Color>
+  <Color x:Key="TextFillColorTertiary">#FFFFFF</Color>
+  <Color x:Key="TextFillColorDisabled">#A6A6A6</Color>
+  <Color x:Key="TextPlaceholderColor">#A6A6A6</Color>
+  <Color x:Key="TextFillColorInverse">#FFFFFF</Color>
 
-  <Color x:Key="AccentTextFillColorDisabled">#FF0000</Color>
-  <Color x:Key="TextOnAccentFillColorSelectedText">#FF0000</Color>
-  <Color x:Key="TextOnAccentFillColorPrimary">#FF0000</Color>
-  <Color x:Key="TextOnAccentFillColorSecondary">#FF0000</Color>
-  <Color x:Key="TextOnAccentFillColorDisabled">#FF0000</Color>
+  <Color x:Key="AccentTextFillColorDisabled">#FFFFFF</Color>
+  <Color x:Key="TextOnAccentFillColorSelectedText">#FFFFFF</Color>
+  <Color x:Key="TextOnAccentFillColorPrimary">#FFFFFF</Color>
+  <Color x:Key="TextOnAccentFillColorSecondary">#FFFFFF</Color>
+  <Color x:Key="TextOnAccentFillColorDisabled">#A6A6A6</Color>
 
-  <Color x:Key="ControlFillColorDefault">#FF0000</Color>
-  <Color x:Key="ControlFillColorSecondary">#FF0000</Color>
-  <Color x:Key="ControlFillColorTertiary">#FF0000</Color>
-  <Color x:Key="ControlFillColorDisabled">#FF0000</Color>
-  <Color x:Key="ControlFillColorTransparent">#FF0000</Color>
-  <Color x:Key="ControlFillColorInputActive">#FF0000</Color>
+  <Color x:Key="ControlFillColorDefault">#2D3236</Color>
+  <Color x:Key="ControlFillColorSecondary">#2D3236</Color>
+  <Color x:Key="ControlFillColorTertiary">#2D3236</Color>
+  <Color x:Key="ControlFillColorDisabled">#2D3236</Color>
+  <Color x:Key="ControlFillColorTransparent">Transparent</Color>
+  <Color x:Key="ControlFillColorInputActive">#2D3236</Color>
 
-  <Color x:Key="ControlStrongFillColorDefault">#FF0000</Color>
-  <Color x:Key="ControlStrongFillColorDisabled">#FF0000</Color>
+  <Color x:Key="ControlStrongFillColorDefault">#2D3236</Color>
+  <Color x:Key="ControlStrongFillColorDisabled">#2D3236</Color>
 
-  <Color x:Key="ControlSolidFillColorDefault">#FF0000</Color>
+  <Color x:Key="ControlSolidFillColorDefault">#2D3236</Color>
 
-  <Color x:Key="SubtleFillColorTransparent">#FF0000</Color>
-  <Color x:Key="SubtleFillColorSecondary">#FF0000</Color>
-  <Color x:Key="SubtleFillColorTertiary">#FF0000</Color>
-  <Color x:Key="SubtleFillColorDisabled">#FF0000</Color>
+  <Color x:Key="SubtleFillColorTransparent">Transparent</Color>
+  <Color x:Key="SubtleFillColorSecondary">#2D3236</Color>
+  <Color x:Key="SubtleFillColorTertiary">#2D3236</Color>
+  <Color x:Key="SubtleFillColorDisabled">#2D3236</Color>
 
-  <Color x:Key="ControlAltFillColorTransparent">#FF0000</Color>
-  <Color x:Key="ControlAltFillColorSecondary">#FF0000</Color>
-  <Color x:Key="ControlAltFillColorTertiary">#FF0000</Color>
-  <Color x:Key="ControlAltFillColorQuarternary">#FF0000</Color>
-  <Color x:Key="ControlAltFillColorDisabled">#FF0000</Color>
+  <Color x:Key="ControlAltFillColorTransparent">Transparent</Color>
+  <Color x:Key="ControlAltFillColorSecondary">#2D3236</Color>
+  <Color x:Key="ControlAltFillColorTertiary">#2D3236</Color>
+  <Color x:Key="ControlAltFillColorQuarternary">#2D3236</Color>
+  <Color x:Key="ControlAltFillColorDisabled">#2D3236</Color>
 
-  <Color x:Key="ControlOnImageFillColorDefault">#FF0000</Color>
-  <Color x:Key="ControlOnImageFillColorSecondary">#FF0000</Color>
-  <Color x:Key="ControlOnImageFillColorTertiary">#FF0000</Color>
-  <Color x:Key="ControlOnImageFillColorDisabled">#FF0000</Color>
+  <Color x:Key="ControlOnImageFillColorDefault">#2D3236</Color>
+  <Color x:Key="ControlOnImageFillColorSecondary">#2D3236</Color>
+  <Color x:Key="ControlOnImageFillColorTertiary">#2D3236</Color>
+  <Color x:Key="ControlOnImageFillColorDisabled">#2D3236</Color>
 
-  <Color x:Key="AccentFillColorDisabled">#FF0000</Color>
+  <Color x:Key="AccentFillColorDisabled">#2D3236</Color>
 
-  <Color x:Key="ControlStrokeColorDefault">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorSecondary">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorTertiary">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorOnAccentDefault">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorOnAccentSecondary">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorOnAccentTertiary">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorOnAccentDisabled">#FF0000</Color>
+  <Color x:Key="ControlStrokeColorDefault">#B6F6F0</Color>
+  <Color x:Key="ControlStrokeColorSecondary">#B6F6F0</Color>
+  <Color x:Key="ControlStrokeColorTertiary">#B6F6F0</Color>
+  <Color x:Key="ControlStrokeColorOnAccentDefault">#B6F6F0</Color>
+  <Color x:Key="ControlStrokeColorOnAccentSecondary">#B6F6F0</Color>
+  <Color x:Key="ControlStrokeColorOnAccentTertiary">#B6F6F0</Color>
+  <Color x:Key="ControlStrokeColorOnAccentDisabled">#B6F6F0</Color>
 
-  <Color x:Key="ControlStrokeColorForStrongFillWhenOnImage">#FF0000</Color>
+  <Color x:Key="ControlStrokeColorForStrongFillWhenOnImage">#B6F6F0</Color>
 
-  <Color x:Key="CardStrokeColorDefault">#FF0000</Color>
-  <Color x:Key="CardStrokeColorDefaultSolid">#FF0000</Color>
+  <Color x:Key="CardStrokeColorDefault">#FFFFFF</Color>
+  <Color x:Key="CardStrokeColorDefaultSolid">#FFFFFF</Color>
 
-  <Color x:Key="ControlStrongStrokeColorDefault">#FF0000</Color>
-  <Color x:Key="ControlStrongStrokeColorDisabled">#FF0000</Color>
+  <Color x:Key="ControlStrongStrokeColorDefault">#B6F6F0</Color>
+  <Color x:Key="ControlStrongStrokeColorDisabled">#B6F6F0</Color>
 
-  <Color x:Key="SurfaceStrokeColorDefault">#FF0000</Color>
-  <Color x:Key="SurfaceStrokeColorFlyout">#FF0000</Color>
-  <Color x:Key="SurfaceStrokeColorInverse">#FF0000</Color>
+  <Color x:Key="SurfaceStrokeColorDefault">#FFFFFF</Color>
+  <Color x:Key="SurfaceStrokeColorFlyout">#FFFFFF</Color>
+  <Color x:Key="SurfaceStrokeColorInverse">#FFFFFF</Color>
 
-  <Color x:Key="DividerStrokeColorDefault">#FF0000</Color>
+  <Color x:Key="DividerStrokeColorDefault">#FFFFFF</Color>
 
-  <Color x:Key="FocusStrokeColorOuter">#FF0000</Color>
-  <Color x:Key="FocusStrokeColorInner">#FF0000</Color>
+  <Color x:Key="FocusStrokeColorOuter">#FFFFFF</Color>
+  <Color x:Key="FocusStrokeColorInner">#2D3236</Color>
 
-  <Color x:Key="CardBackgroundFillColorDefault">#FF0000</Color>
-  <Color x:Key="CardBackgroundFillColorSecondary">#FF0000</Color>
+  <Color x:Key="CardBackgroundFillColorDefault">#2D3236</Color>
+  <Color x:Key="CardBackgroundFillColorSecondary">#2D3236</Color>
 
-  <Color x:Key="SmokeFillColorDefault">#FF0000</Color>
+  <Color x:Key="SmokeFillColorDefault">#2D3236</Color>
 
-  <Color x:Key="LayerFillColorDefault">#FF0000</Color>
-  <Color x:Key="LayerFillColorAlt">#FF0000</Color>
-  <Color x:Key="LayerOnAcrylicFillColorDefault">#FF0000</Color>
-  <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#FF0000</Color>
+  <Color x:Key="LayerFillColorDefault">#2D3236</Color>
+  <Color x:Key="LayerFillColorAlt">#2D3236</Color>
+  <Color x:Key="LayerOnAcrylicFillColorDefault">#2D3236</Color>
+  <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#2D3236</Color>
 
   <!--  Fallback color for missing Acrylic used for e.g. Flyouts  -->
-  <Color x:Key="AcrylicBackgroundFillColorDefault">#FF0000</Color>
+  <Color x:Key="AcrylicBackgroundFillColorDefault">#2D3236</Color>
 
-  <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#FF0000</Color>
-  <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#FF0000</Color>
-  <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#FF0000</Color>
-  <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#FF0000</Color>
+  <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#2D3236</Color>
+  <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#2D3236</Color>
+  <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#2D3236</Color>
+  <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#2D3236</Color>
 
-  <Color x:Key="SolidBackgroundFillColorBase">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorSecondary">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorTertiary">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorQuarternary">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorTransparent">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorBaseAlt">#FF0000</Color>
+  <Color x:Key="SolidBackgroundFillColorBase">#2D3236</Color>
+  <Color x:Key="SolidBackgroundFillColorSecondary">#2D3236</Color>
+  <Color x:Key="SolidBackgroundFillColorTertiary">#2D3236</Color>
+  <Color x:Key="SolidBackgroundFillColorQuarternary">#2D3236</Color>
+  <Color x:Key="SolidBackgroundFillColorTransparent">Transparent</Color>
+  <Color x:Key="SolidBackgroundFillColorBaseAlt">#2D3236</Color>
 
-  <Color x:Key="SystemFillColorAttention">#FF0000</Color>
-  <Color x:Key="SystemFillColorInformational">#FF0000</Color>
-  <Color x:Key="SystemFillColorSuccess">#FF0000</Color>
-  <Color x:Key="SystemFillColorCaution">#FF0000</Color>
-  <Color x:Key="SystemFillColorCritical">#FF0000</Color>
-  <Color x:Key="SystemFillColorNeutral">#FF0000</Color>
-  <Color x:Key="SystemFillColorSolidNeutral">#FF0000</Color>
-  <Color x:Key="SystemFillColorAttentionBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorSuccessBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorCautionBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorCriticalBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorNeutralBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorSolidAttentionBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorSolidNeutralBackground">#FF0000</Color>
+  <Color x:Key="SystemFillColorAttention">#ABCFF2</Color>
+  <Color x:Key="SystemFillColorInformational">#FFFFFF</Color>
+  <Color x:Key="SystemFillColorSuccess">#00FF00</Color>
+  <Color x:Key="SystemFillColorCaution">#FFFF00</Color>
+  <Color x:Key="SystemFillColorCritical">#FF00FF</Color>
+  <Color x:Key="SystemFillColorNeutral">#FFFFFF</Color>
+  <Color x:Key="SystemFillColorSolidNeutral">#FFFFFF</Color>
+  <Color x:Key="SystemFillColorAttentionBackground">#2D3236</Color>
+  <Color x:Key="SystemFillColorSuccessBackground">#2D3236</Color>
+  <Color x:Key="SystemFillColorCautionBackground">#2D3236</Color>
+  <Color x:Key="SystemFillColorCriticalBackground">#2D3236</Color>
+  <Color x:Key="SystemFillColorNeutralBackground">#2D3236</Color>
+  <Color x:Key="SystemFillColorSolidAttentionBackground">#2D3236</Color>
+  <Color x:Key="SystemFillColorSolidNeutralBackground">#2D3236</Color>
 
   <!--  default accent colors and brushes  -->
   <SolidColorBrush x:Key="Accent" Color="{DynamicResource SystemAccentColor}" />

--- a/src/CrissCross.WPF.UI/Resources/Theme/HC2.xaml
+++ b/src/CrissCross.WPF.UI/Resources/Theme/HC2.xaml
@@ -644,114 +644,114 @@
   />
 
   <!--  Colors  -->
-  <!--  Colors copied from Default theme to match list of keys. Should not be using these keys. These are set to Red to notify that.  -->
-  <Color x:Key="TextFillColorPrimary">#FF0000</Color>
-  <Color x:Key="TextFillColorSecondary">#FF0000</Color>
-  <Color x:Key="TextFillColorTertiary">#FF0000</Color>
-  <Color x:Key="TextFillColorDisabled">#FF0000</Color>
-  <Color x:Key="TextPlaceholderColor">#FF0000</Color>
-  <Color x:Key="TextFillColorInverse">#FF0000</Color>
+  <!--  Color values support consumers that build brushes directly; keep them consistent with the high-contrast palette.  -->
+  <Color x:Key="TextFillColorPrimary">#FFFFFF</Color>
+  <Color x:Key="TextFillColorSecondary">#FFFFFF</Color>
+  <Color x:Key="TextFillColorTertiary">#FFFFFF</Color>
+  <Color x:Key="TextFillColorDisabled">#A6A6A6</Color>
+  <Color x:Key="TextPlaceholderColor">#A6A6A6</Color>
+  <Color x:Key="TextFillColorInverse">#FFFFFF</Color>
 
-  <Color x:Key="AccentTextFillColorDisabled">#FF0000</Color>
-  <Color x:Key="TextOnAccentFillColorSelectedText">#FF0000</Color>
-  <Color x:Key="TextOnAccentFillColorPrimary">#FF0000</Color>
-  <Color x:Key="TextOnAccentFillColorSecondary">#FF0000</Color>
-  <Color x:Key="TextOnAccentFillColorDisabled">#FF0000</Color>
+  <Color x:Key="AccentTextFillColorDisabled">#FFFFFF</Color>
+  <Color x:Key="TextOnAccentFillColorSelectedText">#FFFFFF</Color>
+  <Color x:Key="TextOnAccentFillColorPrimary">#FFFFFF</Color>
+  <Color x:Key="TextOnAccentFillColorSecondary">#FFFFFF</Color>
+  <Color x:Key="TextOnAccentFillColorDisabled">#A6A6A6</Color>
 
-  <Color x:Key="ControlFillColorDefault">#FF0000</Color>
-  <Color x:Key="ControlFillColorSecondary">#FF0000</Color>
-  <Color x:Key="ControlFillColorTertiary">#FF0000</Color>
-  <Color x:Key="ControlFillColorDisabled">#FF0000</Color>
-  <Color x:Key="ControlFillColorTransparent">#FF0000</Color>
-  <Color x:Key="ControlFillColorInputActive">#FF0000</Color>
+  <Color x:Key="ControlFillColorDefault">#000000</Color>
+  <Color x:Key="ControlFillColorSecondary">#000000</Color>
+  <Color x:Key="ControlFillColorTertiary">#000000</Color>
+  <Color x:Key="ControlFillColorDisabled">#000000</Color>
+  <Color x:Key="ControlFillColorTransparent">Transparent</Color>
+  <Color x:Key="ControlFillColorInputActive">#000000</Color>
 
-  <Color x:Key="ControlStrongFillColorDefault">#FF0000</Color>
-  <Color x:Key="ControlStrongFillColorDisabled">#FF0000</Color>
+  <Color x:Key="ControlStrongFillColorDefault">#000000</Color>
+  <Color x:Key="ControlStrongFillColorDisabled">#000000</Color>
 
-  <Color x:Key="ControlSolidFillColorDefault">#FF0000</Color>
+  <Color x:Key="ControlSolidFillColorDefault">#000000</Color>
 
-  <Color x:Key="SubtleFillColorTransparent">#FF0000</Color>
-  <Color x:Key="SubtleFillColorSecondary">#FF0000</Color>
-  <Color x:Key="SubtleFillColorTertiary">#FF0000</Color>
-  <Color x:Key="SubtleFillColorDisabled">#FF0000</Color>
+  <Color x:Key="SubtleFillColorTransparent">Transparent</Color>
+  <Color x:Key="SubtleFillColorSecondary">#000000</Color>
+  <Color x:Key="SubtleFillColorTertiary">#000000</Color>
+  <Color x:Key="SubtleFillColorDisabled">#000000</Color>
 
-  <Color x:Key="ControlAltFillColorTransparent">#FF0000</Color>
-  <Color x:Key="ControlAltFillColorSecondary">#FF0000</Color>
-  <Color x:Key="ControlAltFillColorTertiary">#FF0000</Color>
-  <Color x:Key="ControlAltFillColorQuarternary">#FF0000</Color>
-  <Color x:Key="ControlAltFillColorDisabled">#FF0000</Color>
+  <Color x:Key="ControlAltFillColorTransparent">Transparent</Color>
+  <Color x:Key="ControlAltFillColorSecondary">#000000</Color>
+  <Color x:Key="ControlAltFillColorTertiary">#000000</Color>
+  <Color x:Key="ControlAltFillColorQuarternary">#000000</Color>
+  <Color x:Key="ControlAltFillColorDisabled">#000000</Color>
 
-  <Color x:Key="ControlOnImageFillColorDefault">#FF0000</Color>
-  <Color x:Key="ControlOnImageFillColorSecondary">#FF0000</Color>
-  <Color x:Key="ControlOnImageFillColorTertiary">#FF0000</Color>
-  <Color x:Key="ControlOnImageFillColorDisabled">#FF0000</Color>
+  <Color x:Key="ControlOnImageFillColorDefault">#000000</Color>
+  <Color x:Key="ControlOnImageFillColorSecondary">#000000</Color>
+  <Color x:Key="ControlOnImageFillColorTertiary">#000000</Color>
+  <Color x:Key="ControlOnImageFillColorDisabled">#000000</Color>
 
-  <Color x:Key="AccentFillColorDisabled">#FF0000</Color>
+  <Color x:Key="AccentFillColorDisabled">#000000</Color>
 
-  <Color x:Key="ControlStrokeColorDefault">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorSecondary">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorTertiary">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorOnAccentDefault">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorOnAccentSecondary">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorOnAccentTertiary">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorOnAccentDisabled">#FF0000</Color>
+  <Color x:Key="ControlStrokeColorDefault">#FFEE32</Color>
+  <Color x:Key="ControlStrokeColorSecondary">#FFEE32</Color>
+  <Color x:Key="ControlStrokeColorTertiary">#FFEE32</Color>
+  <Color x:Key="ControlStrokeColorOnAccentDefault">#FFEE32</Color>
+  <Color x:Key="ControlStrokeColorOnAccentSecondary">#FFEE32</Color>
+  <Color x:Key="ControlStrokeColorOnAccentTertiary">#FFEE32</Color>
+  <Color x:Key="ControlStrokeColorOnAccentDisabled">#FFEE32</Color>
 
-  <Color x:Key="ControlStrokeColorForStrongFillWhenOnImage">#FF0000</Color>
+  <Color x:Key="ControlStrokeColorForStrongFillWhenOnImage">#FFEE32</Color>
 
-  <Color x:Key="CardStrokeColorDefault">#FF0000</Color>
-  <Color x:Key="CardStrokeColorDefaultSolid">#FF0000</Color>
+  <Color x:Key="CardStrokeColorDefault">#FFFFFF</Color>
+  <Color x:Key="CardStrokeColorDefaultSolid">#FFFFFF</Color>
 
-  <Color x:Key="ControlStrongStrokeColorDefault">#FF0000</Color>
-  <Color x:Key="ControlStrongStrokeColorDisabled">#FF0000</Color>
+  <Color x:Key="ControlStrongStrokeColorDefault">#FFEE32</Color>
+  <Color x:Key="ControlStrongStrokeColorDisabled">#FFEE32</Color>
 
-  <Color x:Key="SurfaceStrokeColorDefault">#FF0000</Color>
-  <Color x:Key="SurfaceStrokeColorFlyout">#FF0000</Color>
-  <Color x:Key="SurfaceStrokeColorInverse">#FF0000</Color>
+  <Color x:Key="SurfaceStrokeColorDefault">#FFFFFF</Color>
+  <Color x:Key="SurfaceStrokeColorFlyout">#FFFFFF</Color>
+  <Color x:Key="SurfaceStrokeColorInverse">#FFFFFF</Color>
 
-  <Color x:Key="DividerStrokeColorDefault">#FF0000</Color>
+  <Color x:Key="DividerStrokeColorDefault">#FFFFFF</Color>
 
-  <Color x:Key="FocusStrokeColorOuter">#FF0000</Color>
-  <Color x:Key="FocusStrokeColorInner">#FF0000</Color>
+  <Color x:Key="FocusStrokeColorOuter">#FFFFFF</Color>
+  <Color x:Key="FocusStrokeColorInner">#000000</Color>
 
-  <Color x:Key="CardBackgroundFillColorDefault">#FF0000</Color>
-  <Color x:Key="CardBackgroundFillColorSecondary">#FF0000</Color>
+  <Color x:Key="CardBackgroundFillColorDefault">#000000</Color>
+  <Color x:Key="CardBackgroundFillColorSecondary">#000000</Color>
 
-  <Color x:Key="SmokeFillColorDefault">#FF0000</Color>
+  <Color x:Key="SmokeFillColorDefault">#000000</Color>
 
-  <Color x:Key="LayerFillColorDefault">#FF0000</Color>
-  <Color x:Key="LayerFillColorAlt">#FF0000</Color>
-  <Color x:Key="LayerOnAcrylicFillColorDefault">#FF0000</Color>
-  <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#FF0000</Color>
+  <Color x:Key="LayerFillColorDefault">#000000</Color>
+  <Color x:Key="LayerFillColorAlt">#000000</Color>
+  <Color x:Key="LayerOnAcrylicFillColorDefault">#000000</Color>
+  <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#000000</Color>
 
   <!--  Fallback color for missing Acrylic used for e.g. Flyouts  -->
-  <Color x:Key="AcrylicBackgroundFillColorDefault">#FF0000</Color>
+  <Color x:Key="AcrylicBackgroundFillColorDefault">#000000</Color>
 
-  <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#FF0000</Color>
-  <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#FF0000</Color>
-  <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#FF0000</Color>
-  <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#FF0000</Color>
+  <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#000000</Color>
+  <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#000000</Color>
+  <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#000000</Color>
+  <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#000000</Color>
 
-  <Color x:Key="SolidBackgroundFillColorBase">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorSecondary">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorTertiary">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorQuarternary">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorTransparent">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorBaseAlt">#FF0000</Color>
+  <Color x:Key="SolidBackgroundFillColorBase">#000000</Color>
+  <Color x:Key="SolidBackgroundFillColorSecondary">#000000</Color>
+  <Color x:Key="SolidBackgroundFillColorTertiary">#000000</Color>
+  <Color x:Key="SolidBackgroundFillColorQuarternary">#000000</Color>
+  <Color x:Key="SolidBackgroundFillColorTransparent">Transparent</Color>
+  <Color x:Key="SolidBackgroundFillColorBaseAlt">#000000</Color>
 
-  <Color x:Key="SystemFillColorAttention">#FF0000</Color>
-  <Color x:Key="SystemFillColorInformational">#FF0000</Color>
-  <Color x:Key="SystemFillColorSuccess">#FF0000</Color>
-  <Color x:Key="SystemFillColorCaution">#FF0000</Color>
-  <Color x:Key="SystemFillColorCritical">#FF0000</Color>
-  <Color x:Key="SystemFillColorNeutral">#FF0000</Color>
-  <Color x:Key="SystemFillColorSolidNeutral">#FF0000</Color>
-  <Color x:Key="SystemFillColorAttentionBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorSuccessBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorCautionBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorCriticalBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorNeutralBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorSolidAttentionBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorSolidNeutralBackground">#FF0000</Color>
+  <Color x:Key="SystemFillColorAttention">#D6B4FD</Color>
+  <Color x:Key="SystemFillColorInformational">#FFFFFF</Color>
+  <Color x:Key="SystemFillColorSuccess">#00FF00</Color>
+  <Color x:Key="SystemFillColorCaution">#FFFF00</Color>
+  <Color x:Key="SystemFillColorCritical">#FF00FF</Color>
+  <Color x:Key="SystemFillColorNeutral">#FFFFFF</Color>
+  <Color x:Key="SystemFillColorSolidNeutral">#FFFFFF</Color>
+  <Color x:Key="SystemFillColorAttentionBackground">#000000</Color>
+  <Color x:Key="SystemFillColorSuccessBackground">#000000</Color>
+  <Color x:Key="SystemFillColorCautionBackground">#000000</Color>
+  <Color x:Key="SystemFillColorCriticalBackground">#000000</Color>
+  <Color x:Key="SystemFillColorNeutralBackground">#000000</Color>
+  <Color x:Key="SystemFillColorSolidAttentionBackground">#000000</Color>
+  <Color x:Key="SystemFillColorSolidNeutralBackground">#000000</Color>
 
   <!--  default accent colors and brushes  -->
   <SolidColorBrush x:Key="Accent" Color="{DynamicResource SystemAccentColor}" />

--- a/src/CrissCross.WPF.UI/Resources/Theme/HCBlack.xaml
+++ b/src/CrissCross.WPF.UI/Resources/Theme/HCBlack.xaml
@@ -644,114 +644,114 @@
   />
 
   <!--  Colors  -->
-  <!--  Colors copied from Default theme to match list of keys. Should not be using these keys. These are set to Red to notify that.  -->
-  <Color x:Key="TextFillColorPrimary">#FF0000</Color>
-  <Color x:Key="TextFillColorSecondary">#FF0000</Color>
-  <Color x:Key="TextFillColorTertiary">#FF0000</Color>
-  <Color x:Key="TextFillColorDisabled">#FF0000</Color>
-  <Color x:Key="TextPlaceholderColor">#FF0000</Color>
-  <Color x:Key="TextFillColorInverse">#FF0000</Color>
+  <!--  Color values support consumers that build brushes directly; keep them consistent with the high-contrast palette.  -->
+  <Color x:Key="TextFillColorPrimary">#FFFFFF</Color>
+  <Color x:Key="TextFillColorSecondary">#FFFFFF</Color>
+  <Color x:Key="TextFillColorTertiary">#FFFFFF</Color>
+  <Color x:Key="TextFillColorDisabled">#A6A6A6</Color>
+  <Color x:Key="TextPlaceholderColor">#A6A6A6</Color>
+  <Color x:Key="TextFillColorInverse">#FFFFFF</Color>
 
-  <Color x:Key="AccentTextFillColorDisabled">#FF0000</Color>
-  <Color x:Key="TextOnAccentFillColorSelectedText">#FF0000</Color>
-  <Color x:Key="TextOnAccentFillColorPrimary">#FF0000</Color>
-  <Color x:Key="TextOnAccentFillColorSecondary">#FF0000</Color>
-  <Color x:Key="TextOnAccentFillColorDisabled">#FF0000</Color>
+  <Color x:Key="AccentTextFillColorDisabled">#FFFFFF</Color>
+  <Color x:Key="TextOnAccentFillColorSelectedText">#FFFFFF</Color>
+  <Color x:Key="TextOnAccentFillColorPrimary">#FFFFFF</Color>
+  <Color x:Key="TextOnAccentFillColorSecondary">#FFFFFF</Color>
+  <Color x:Key="TextOnAccentFillColorDisabled">#A6A6A6</Color>
 
-  <Color x:Key="ControlFillColorDefault">#FF0000</Color>
-  <Color x:Key="ControlFillColorSecondary">#FF0000</Color>
-  <Color x:Key="ControlFillColorTertiary">#FF0000</Color>
-  <Color x:Key="ControlFillColorDisabled">#FF0000</Color>
-  <Color x:Key="ControlFillColorTransparent">#FF0000</Color>
-  <Color x:Key="ControlFillColorInputActive">#FF0000</Color>
+  <Color x:Key="ControlFillColorDefault">#202020</Color>
+  <Color x:Key="ControlFillColorSecondary">#202020</Color>
+  <Color x:Key="ControlFillColorTertiary">#202020</Color>
+  <Color x:Key="ControlFillColorDisabled">#202020</Color>
+  <Color x:Key="ControlFillColorTransparent">Transparent</Color>
+  <Color x:Key="ControlFillColorInputActive">#202020</Color>
 
-  <Color x:Key="ControlStrongFillColorDefault">#FF0000</Color>
-  <Color x:Key="ControlStrongFillColorDisabled">#FF0000</Color>
+  <Color x:Key="ControlStrongFillColorDefault">#202020</Color>
+  <Color x:Key="ControlStrongFillColorDisabled">#202020</Color>
 
-  <Color x:Key="ControlSolidFillColorDefault">#FF0000</Color>
+  <Color x:Key="ControlSolidFillColorDefault">#202020</Color>
 
-  <Color x:Key="SubtleFillColorTransparent">#FF0000</Color>
-  <Color x:Key="SubtleFillColorSecondary">#FF0000</Color>
-  <Color x:Key="SubtleFillColorTertiary">#FF0000</Color>
-  <Color x:Key="SubtleFillColorDisabled">#FF0000</Color>
+  <Color x:Key="SubtleFillColorTransparent">Transparent</Color>
+  <Color x:Key="SubtleFillColorSecondary">#202020</Color>
+  <Color x:Key="SubtleFillColorTertiary">#202020</Color>
+  <Color x:Key="SubtleFillColorDisabled">#202020</Color>
 
-  <Color x:Key="ControlAltFillColorTransparent">#FF0000</Color>
-  <Color x:Key="ControlAltFillColorSecondary">#FF0000</Color>
-  <Color x:Key="ControlAltFillColorTertiary">#FF0000</Color>
-  <Color x:Key="ControlAltFillColorQuarternary">#FF0000</Color>
-  <Color x:Key="ControlAltFillColorDisabled">#FF0000</Color>
+  <Color x:Key="ControlAltFillColorTransparent">Transparent</Color>
+  <Color x:Key="ControlAltFillColorSecondary">#202020</Color>
+  <Color x:Key="ControlAltFillColorTertiary">#202020</Color>
+  <Color x:Key="ControlAltFillColorQuarternary">#202020</Color>
+  <Color x:Key="ControlAltFillColorDisabled">#202020</Color>
 
-  <Color x:Key="ControlOnImageFillColorDefault">#FF0000</Color>
-  <Color x:Key="ControlOnImageFillColorSecondary">#FF0000</Color>
-  <Color x:Key="ControlOnImageFillColorTertiary">#FF0000</Color>
-  <Color x:Key="ControlOnImageFillColorDisabled">#FF0000</Color>
+  <Color x:Key="ControlOnImageFillColorDefault">#202020</Color>
+  <Color x:Key="ControlOnImageFillColorSecondary">#202020</Color>
+  <Color x:Key="ControlOnImageFillColorTertiary">#202020</Color>
+  <Color x:Key="ControlOnImageFillColorDisabled">#202020</Color>
 
-  <Color x:Key="AccentFillColorDisabled">#FF0000</Color>
+  <Color x:Key="AccentFillColorDisabled">#202020</Color>
 
-  <Color x:Key="ControlStrokeColorDefault">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorSecondary">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorTertiary">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorOnAccentDefault">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorOnAccentSecondary">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorOnAccentTertiary">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorOnAccentDisabled">#FF0000</Color>
+  <Color x:Key="ControlStrokeColorDefault">#FFFFFF</Color>
+  <Color x:Key="ControlStrokeColorSecondary">#FFFFFF</Color>
+  <Color x:Key="ControlStrokeColorTertiary">#FFFFFF</Color>
+  <Color x:Key="ControlStrokeColorOnAccentDefault">#FFFFFF</Color>
+  <Color x:Key="ControlStrokeColorOnAccentSecondary">#FFFFFF</Color>
+  <Color x:Key="ControlStrokeColorOnAccentTertiary">#FFFFFF</Color>
+  <Color x:Key="ControlStrokeColorOnAccentDisabled">#FFFFFF</Color>
 
-  <Color x:Key="ControlStrokeColorForStrongFillWhenOnImage">#FF0000</Color>
+  <Color x:Key="ControlStrokeColorForStrongFillWhenOnImage">#FFFFFF</Color>
 
-  <Color x:Key="CardStrokeColorDefault">#FF0000</Color>
-  <Color x:Key="CardStrokeColorDefaultSolid">#FF0000</Color>
+  <Color x:Key="CardStrokeColorDefault">#FFFFFF</Color>
+  <Color x:Key="CardStrokeColorDefaultSolid">#FFFFFF</Color>
 
-  <Color x:Key="ControlStrongStrokeColorDefault">#FF0000</Color>
-  <Color x:Key="ControlStrongStrokeColorDisabled">#FF0000</Color>
+  <Color x:Key="ControlStrongStrokeColorDefault">#FFFFFF</Color>
+  <Color x:Key="ControlStrongStrokeColorDisabled">#FFFFFF</Color>
 
-  <Color x:Key="SurfaceStrokeColorDefault">#FF0000</Color>
-  <Color x:Key="SurfaceStrokeColorFlyout">#FF0000</Color>
-  <Color x:Key="SurfaceStrokeColorInverse">#FF0000</Color>
+  <Color x:Key="SurfaceStrokeColorDefault">#FFFFFF</Color>
+  <Color x:Key="SurfaceStrokeColorFlyout">#FFFFFF</Color>
+  <Color x:Key="SurfaceStrokeColorInverse">#FFFFFF</Color>
 
-  <Color x:Key="DividerStrokeColorDefault">#FF0000</Color>
+  <Color x:Key="DividerStrokeColorDefault">#FFFFFF</Color>
 
-  <Color x:Key="FocusStrokeColorOuter">#FF0000</Color>
-  <Color x:Key="FocusStrokeColorInner">#FF0000</Color>
+  <Color x:Key="FocusStrokeColorOuter">#FFFFFF</Color>
+  <Color x:Key="FocusStrokeColorInner">#202020</Color>
 
-  <Color x:Key="CardBackgroundFillColorDefault">#FF0000</Color>
-  <Color x:Key="CardBackgroundFillColorSecondary">#FF0000</Color>
+  <Color x:Key="CardBackgroundFillColorDefault">#202020</Color>
+  <Color x:Key="CardBackgroundFillColorSecondary">#202020</Color>
 
-  <Color x:Key="SmokeFillColorDefault">#FF0000</Color>
+  <Color x:Key="SmokeFillColorDefault">#202020</Color>
 
-  <Color x:Key="LayerFillColorDefault">#FF0000</Color>
-  <Color x:Key="LayerFillColorAlt">#FF0000</Color>
-  <Color x:Key="LayerOnAcrylicFillColorDefault">#FF0000</Color>
-  <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#FF0000</Color>
+  <Color x:Key="LayerFillColorDefault">#202020</Color>
+  <Color x:Key="LayerFillColorAlt">#202020</Color>
+  <Color x:Key="LayerOnAcrylicFillColorDefault">#202020</Color>
+  <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#202020</Color>
 
   <!--  Fallback color for missing Acrylic used for e.g. Flyouts  -->
-  <Color x:Key="AcrylicBackgroundFillColorDefault">#FF0000</Color>
+  <Color x:Key="AcrylicBackgroundFillColorDefault">#202020</Color>
 
-  <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#FF0000</Color>
-  <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#FF0000</Color>
-  <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#FF0000</Color>
-  <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#FF0000</Color>
+  <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#202020</Color>
+  <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#202020</Color>
+  <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#202020</Color>
+  <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#202020</Color>
 
-  <Color x:Key="SolidBackgroundFillColorBase">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorSecondary">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorTertiary">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorQuarternary">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorTransparent">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorBaseAlt">#FF0000</Color>
+  <Color x:Key="SolidBackgroundFillColorBase">#202020</Color>
+  <Color x:Key="SolidBackgroundFillColorSecondary">#202020</Color>
+  <Color x:Key="SolidBackgroundFillColorTertiary">#202020</Color>
+  <Color x:Key="SolidBackgroundFillColorQuarternary">#202020</Color>
+  <Color x:Key="SolidBackgroundFillColorTransparent">Transparent</Color>
+  <Color x:Key="SolidBackgroundFillColorBaseAlt">#202020</Color>
 
-  <Color x:Key="SystemFillColorAttention">#FF0000</Color>
-  <Color x:Key="SystemFillColorInformational">#FF0000</Color>
-  <Color x:Key="SystemFillColorSuccess">#FF0000</Color>
-  <Color x:Key="SystemFillColorCaution">#FF0000</Color>
-  <Color x:Key="SystemFillColorCritical">#FF0000</Color>
-  <Color x:Key="SystemFillColorNeutral">#FF0000</Color>
-  <Color x:Key="SystemFillColorSolidNeutral">#FF0000</Color>
-  <Color x:Key="SystemFillColorAttentionBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorSuccessBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorCautionBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorCriticalBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorNeutralBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorSolidAttentionBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorSolidNeutralBackground">#FF0000</Color>
+  <Color x:Key="SystemFillColorAttention">#8EE3F0</Color>
+  <Color x:Key="SystemFillColorInformational">#FFFFFF</Color>
+  <Color x:Key="SystemFillColorSuccess">#00FF00</Color>
+  <Color x:Key="SystemFillColorCaution">#FFFF00</Color>
+  <Color x:Key="SystemFillColorCritical">#FF00FF</Color>
+  <Color x:Key="SystemFillColorNeutral">#FFFFFF</Color>
+  <Color x:Key="SystemFillColorSolidNeutral">#FFFFFF</Color>
+  <Color x:Key="SystemFillColorAttentionBackground">#202020</Color>
+  <Color x:Key="SystemFillColorSuccessBackground">#202020</Color>
+  <Color x:Key="SystemFillColorCautionBackground">#202020</Color>
+  <Color x:Key="SystemFillColorCriticalBackground">#202020</Color>
+  <Color x:Key="SystemFillColorNeutralBackground">#202020</Color>
+  <Color x:Key="SystemFillColorSolidAttentionBackground">#202020</Color>
+  <Color x:Key="SystemFillColorSolidNeutralBackground">#202020</Color>
 
   <!--  default accent colors and brushes  -->
   <SolidColorBrush x:Key="Accent" Color="{DynamicResource SystemAccentColor}" />

--- a/src/CrissCross.WPF.UI/Resources/Theme/HCWhite.xaml
+++ b/src/CrissCross.WPF.UI/Resources/Theme/HCWhite.xaml
@@ -644,114 +644,114 @@
   />
 
   <!--  Colors  -->
-  <!--  Colors copied from Default theme to match list of keys. Should not be using these keys. These are set to Red to notify that.  -->
-  <Color x:Key="TextFillColorPrimary">#FF0000</Color>
-  <Color x:Key="TextFillColorSecondary">#FF0000</Color>
-  <Color x:Key="TextFillColorTertiary">#FF0000</Color>
-  <Color x:Key="TextFillColorDisabled">#FF0000</Color>
-  <Color x:Key="TextPlaceholderColor">#FF0000</Color>
-  <Color x:Key="TextFillColorInverse">#FF0000</Color>
+  <!--  Color values support consumers that build brushes directly; keep them consistent with the high-contrast palette.  -->
+  <Color x:Key="TextFillColorPrimary">#3D3D3D</Color>
+  <Color x:Key="TextFillColorSecondary">#3D3D3D</Color>
+  <Color x:Key="TextFillColorTertiary">#3D3D3D</Color>
+  <Color x:Key="TextFillColorDisabled">#676767</Color>
+  <Color x:Key="TextPlaceholderColor">#676767</Color>
+  <Color x:Key="TextFillColorInverse">#3D3D3D</Color>
 
-  <Color x:Key="AccentTextFillColorDisabled">#FF0000</Color>
-  <Color x:Key="TextOnAccentFillColorSelectedText">#FF0000</Color>
-  <Color x:Key="TextOnAccentFillColorPrimary">#FF0000</Color>
-  <Color x:Key="TextOnAccentFillColorSecondary">#FF0000</Color>
-  <Color x:Key="TextOnAccentFillColorDisabled">#FF0000</Color>
+  <Color x:Key="AccentTextFillColorDisabled">#3D3D3D</Color>
+  <Color x:Key="TextOnAccentFillColorSelectedText">#3D3D3D</Color>
+  <Color x:Key="TextOnAccentFillColorPrimary">#3D3D3D</Color>
+  <Color x:Key="TextOnAccentFillColorSecondary">#3D3D3D</Color>
+  <Color x:Key="TextOnAccentFillColorDisabled">#676767</Color>
 
-  <Color x:Key="ControlFillColorDefault">#FF0000</Color>
-  <Color x:Key="ControlFillColorSecondary">#FF0000</Color>
-  <Color x:Key="ControlFillColorTertiary">#FF0000</Color>
-  <Color x:Key="ControlFillColorDisabled">#FF0000</Color>
-  <Color x:Key="ControlFillColorTransparent">#FF0000</Color>
-  <Color x:Key="ControlFillColorInputActive">#FF0000</Color>
+  <Color x:Key="ControlFillColorDefault">#FFFAEF</Color>
+  <Color x:Key="ControlFillColorSecondary">#FFFAEF</Color>
+  <Color x:Key="ControlFillColorTertiary">#FFFAEF</Color>
+  <Color x:Key="ControlFillColorDisabled">#FFFAEF</Color>
+  <Color x:Key="ControlFillColorTransparent">Transparent</Color>
+  <Color x:Key="ControlFillColorInputActive">#FFFAEF</Color>
 
-  <Color x:Key="ControlStrongFillColorDefault">#FF0000</Color>
-  <Color x:Key="ControlStrongFillColorDisabled">#FF0000</Color>
+  <Color x:Key="ControlStrongFillColorDefault">#FFFAEF</Color>
+  <Color x:Key="ControlStrongFillColorDisabled">#FFFAEF</Color>
 
-  <Color x:Key="ControlSolidFillColorDefault">#FF0000</Color>
+  <Color x:Key="ControlSolidFillColorDefault">#FFFAEF</Color>
 
-  <Color x:Key="SubtleFillColorTransparent">#FF0000</Color>
-  <Color x:Key="SubtleFillColorSecondary">#FF0000</Color>
-  <Color x:Key="SubtleFillColorTertiary">#FF0000</Color>
-  <Color x:Key="SubtleFillColorDisabled">#FF0000</Color>
+  <Color x:Key="SubtleFillColorTransparent">Transparent</Color>
+  <Color x:Key="SubtleFillColorSecondary">#FFFAEF</Color>
+  <Color x:Key="SubtleFillColorTertiary">#FFFAEF</Color>
+  <Color x:Key="SubtleFillColorDisabled">#FFFAEF</Color>
 
-  <Color x:Key="ControlAltFillColorTransparent">#FF0000</Color>
-  <Color x:Key="ControlAltFillColorSecondary">#FF0000</Color>
-  <Color x:Key="ControlAltFillColorTertiary">#FF0000</Color>
-  <Color x:Key="ControlAltFillColorQuarternary">#FF0000</Color>
-  <Color x:Key="ControlAltFillColorDisabled">#FF0000</Color>
+  <Color x:Key="ControlAltFillColorTransparent">Transparent</Color>
+  <Color x:Key="ControlAltFillColorSecondary">#FFFAEF</Color>
+  <Color x:Key="ControlAltFillColorTertiary">#FFFAEF</Color>
+  <Color x:Key="ControlAltFillColorQuarternary">#FFFAEF</Color>
+  <Color x:Key="ControlAltFillColorDisabled">#FFFAEF</Color>
 
-  <Color x:Key="ControlOnImageFillColorDefault">#FF0000</Color>
-  <Color x:Key="ControlOnImageFillColorSecondary">#FF0000</Color>
-  <Color x:Key="ControlOnImageFillColorTertiary">#FF0000</Color>
-  <Color x:Key="ControlOnImageFillColorDisabled">#FF0000</Color>
+  <Color x:Key="ControlOnImageFillColorDefault">#FFFAEF</Color>
+  <Color x:Key="ControlOnImageFillColorSecondary">#FFFAEF</Color>
+  <Color x:Key="ControlOnImageFillColorTertiary">#FFFAEF</Color>
+  <Color x:Key="ControlOnImageFillColorDisabled">#FFFAEF</Color>
 
-  <Color x:Key="AccentFillColorDisabled">#FF0000</Color>
+  <Color x:Key="AccentFillColorDisabled">#FFFAEF</Color>
 
-  <Color x:Key="ControlStrokeColorDefault">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorSecondary">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorTertiary">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorOnAccentDefault">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorOnAccentSecondary">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorOnAccentTertiary">#FF0000</Color>
-  <Color x:Key="ControlStrokeColorOnAccentDisabled">#FF0000</Color>
+  <Color x:Key="ControlStrokeColorDefault">#202020</Color>
+  <Color x:Key="ControlStrokeColorSecondary">#202020</Color>
+  <Color x:Key="ControlStrokeColorTertiary">#202020</Color>
+  <Color x:Key="ControlStrokeColorOnAccentDefault">#202020</Color>
+  <Color x:Key="ControlStrokeColorOnAccentSecondary">#202020</Color>
+  <Color x:Key="ControlStrokeColorOnAccentTertiary">#202020</Color>
+  <Color x:Key="ControlStrokeColorOnAccentDisabled">#202020</Color>
 
-  <Color x:Key="ControlStrokeColorForStrongFillWhenOnImage">#FF0000</Color>
+  <Color x:Key="ControlStrokeColorForStrongFillWhenOnImage">#202020</Color>
 
-  <Color x:Key="CardStrokeColorDefault">#FF0000</Color>
-  <Color x:Key="CardStrokeColorDefaultSolid">#FF0000</Color>
+  <Color x:Key="CardStrokeColorDefault">#3D3D3D</Color>
+  <Color x:Key="CardStrokeColorDefaultSolid">#3D3D3D</Color>
 
-  <Color x:Key="ControlStrongStrokeColorDefault">#FF0000</Color>
-  <Color x:Key="ControlStrongStrokeColorDisabled">#FF0000</Color>
+  <Color x:Key="ControlStrongStrokeColorDefault">#202020</Color>
+  <Color x:Key="ControlStrongStrokeColorDisabled">#202020</Color>
 
-  <Color x:Key="SurfaceStrokeColorDefault">#FF0000</Color>
-  <Color x:Key="SurfaceStrokeColorFlyout">#FF0000</Color>
-  <Color x:Key="SurfaceStrokeColorInverse">#FF0000</Color>
+  <Color x:Key="SurfaceStrokeColorDefault">#3D3D3D</Color>
+  <Color x:Key="SurfaceStrokeColorFlyout">#3D3D3D</Color>
+  <Color x:Key="SurfaceStrokeColorInverse">#3D3D3D</Color>
 
-  <Color x:Key="DividerStrokeColorDefault">#FF0000</Color>
+  <Color x:Key="DividerStrokeColorDefault">#3D3D3D</Color>
 
-  <Color x:Key="FocusStrokeColorOuter">#FF0000</Color>
-  <Color x:Key="FocusStrokeColorInner">#FF0000</Color>
+  <Color x:Key="FocusStrokeColorOuter">#3D3D3D</Color>
+  <Color x:Key="FocusStrokeColorInner">#FFFAEF</Color>
 
-  <Color x:Key="CardBackgroundFillColorDefault">#FF0000</Color>
-  <Color x:Key="CardBackgroundFillColorSecondary">#FF0000</Color>
+  <Color x:Key="CardBackgroundFillColorDefault">#FFFAEF</Color>
+  <Color x:Key="CardBackgroundFillColorSecondary">#FFFAEF</Color>
 
-  <Color x:Key="SmokeFillColorDefault">#FF0000</Color>
+  <Color x:Key="SmokeFillColorDefault">#FFFAEF</Color>
 
-  <Color x:Key="LayerFillColorDefault">#FF0000</Color>
-  <Color x:Key="LayerFillColorAlt">#FF0000</Color>
-  <Color x:Key="LayerOnAcrylicFillColorDefault">#FF0000</Color>
-  <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#FF0000</Color>
+  <Color x:Key="LayerFillColorDefault">#FFFAEF</Color>
+  <Color x:Key="LayerFillColorAlt">#FFFAEF</Color>
+  <Color x:Key="LayerOnAcrylicFillColorDefault">#FFFAEF</Color>
+  <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#FFFAEF</Color>
 
   <!--  Fallback color for missing Acrylic used for e.g. Flyouts  -->
-  <Color x:Key="AcrylicBackgroundFillColorDefault">#FF0000</Color>
+  <Color x:Key="AcrylicBackgroundFillColorDefault">#FFFAEF</Color>
 
-  <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#FF0000</Color>
-  <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#FF0000</Color>
-  <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#FF0000</Color>
-  <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#FF0000</Color>
+  <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#FFFAEF</Color>
+  <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#FFFAEF</Color>
+  <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#FFFAEF</Color>
+  <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#FFFAEF</Color>
 
-  <Color x:Key="SolidBackgroundFillColorBase">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorSecondary">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorTertiary">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorQuarternary">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorTransparent">#FF0000</Color>
-  <Color x:Key="SolidBackgroundFillColorBaseAlt">#FF0000</Color>
+  <Color x:Key="SolidBackgroundFillColorBase">#FFFAEF</Color>
+  <Color x:Key="SolidBackgroundFillColorSecondary">#FFFAEF</Color>
+  <Color x:Key="SolidBackgroundFillColorTertiary">#FFFAEF</Color>
+  <Color x:Key="SolidBackgroundFillColorQuarternary">#FFFAEF</Color>
+  <Color x:Key="SolidBackgroundFillColorTransparent">Transparent</Color>
+  <Color x:Key="SolidBackgroundFillColorBaseAlt">#FFFAEF</Color>
 
-  <Color x:Key="SystemFillColorAttention">#FF0000</Color>
-  <Color x:Key="SystemFillColorInformational">#FF0000</Color>
-  <Color x:Key="SystemFillColorSuccess">#FF0000</Color>
-  <Color x:Key="SystemFillColorCaution">#FF0000</Color>
-  <Color x:Key="SystemFillColorCritical">#FF0000</Color>
-  <Color x:Key="SystemFillColorNeutral">#FF0000</Color>
-  <Color x:Key="SystemFillColorSolidNeutral">#FF0000</Color>
-  <Color x:Key="SystemFillColorAttentionBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorSuccessBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorCautionBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorCriticalBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorNeutralBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorSolidAttentionBackground">#FF0000</Color>
-  <Color x:Key="SystemFillColorSolidNeutralBackground">#FF0000</Color>
+  <Color x:Key="SystemFillColorAttention">#903909</Color>
+  <Color x:Key="SystemFillColorInformational">#3D3D3D</Color>
+  <Color x:Key="SystemFillColorSuccess">#006400</Color>
+  <Color x:Key="SystemFillColorCaution">#6B5000</Color>
+  <Color x:Key="SystemFillColorCritical">#B00020</Color>
+  <Color x:Key="SystemFillColorNeutral">#3D3D3D</Color>
+  <Color x:Key="SystemFillColorSolidNeutral">#3D3D3D</Color>
+  <Color x:Key="SystemFillColorAttentionBackground">#FFFAEF</Color>
+  <Color x:Key="SystemFillColorSuccessBackground">#FFFAEF</Color>
+  <Color x:Key="SystemFillColorCautionBackground">#FFFAEF</Color>
+  <Color x:Key="SystemFillColorCriticalBackground">#FFFAEF</Color>
+  <Color x:Key="SystemFillColorNeutralBackground">#FFFAEF</Color>
+  <Color x:Key="SystemFillColorSolidAttentionBackground">#FFFAEF</Color>
+  <Color x:Key="SystemFillColorSolidNeutralBackground">#FFFAEF</Color>
 
   <!--  default accent colors and brushes  -->
   <SolidColorBrush x:Key="Accent" Color="{DynamicResource SystemAccentColor}" />

--- a/src/CrissCross.WPF.UI/TaskBarService.cs
+++ b/src/CrissCross.WPF.UI/TaskBarService.cs
@@ -42,7 +42,7 @@ public class TaskBarService : ITaskBarService
     }
 
     /// <inheritdoc />
-    public virtual bool SetState(Window? window, TaskBarProgressState taskBarProgressState) => window is null ? false : TaskBarProgress.SetState(window, taskBarProgressState);
+    public virtual bool SetState(Window? window, TaskBarProgressState taskBarProgressState) => window is not null && TaskBarProgress.SetState(window, taskBarProgressState);
 
     /// <inheritdoc />
     public virtual bool SetState(IntPtr windowHandle, TaskBarProgressState taskBarProgressState) =>

--- a/src/CrissCross.WPF.UI/Taskbar/TaskBarProgressState.cs
+++ b/src/CrissCross.WPF.UI/Taskbar/TaskBarProgressState.cs
@@ -9,10 +9,7 @@ namespace CrissCross.WPF.UI.TaskBar;
 #endif
 
 /// <summary>Specifies the state of the progress indicator in the Windows task bar.</summary>
-[System.Diagnostics.CodeAnalysis.SuppressMessage(
-    "Design",
-    "CA1027:Mark enums with FlagsAttribute",
-    Justification = "Not Required.")]
+[Flags]
 public enum TaskBarProgressState
 {
     /// <summary>No progress indicator is displayed in the task bar area.</summary>

--- a/src/CrissCross.WPF.WebView2/AssemblyInfo.cs
+++ b/src/CrissCross.WPF.WebView2/AssemblyInfo.cs
@@ -2,8 +2,11 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Markup;
+
+[assembly: InternalsVisibleTo("CrissCross.WPF.UI.Gallery.Tests")]
 
 #if REACTIVELIST_REACTIVE
 [assembly: XmlnsDefinition("https://github.com/reactivemarbles/CrissCross", "CrissCross.Reactive")]

--- a/src/CrissCross.WPF.WebView2/WebView2Wpf.cs
+++ b/src/CrissCross.WPF.WebView2/WebView2Wpf.cs
@@ -349,6 +349,15 @@ public class WebView2Wpf : ContentControl, IWebView2
         set => SetValue(AutoDisposeProperty, value);
     }
 
+    /// <summary>Gets a value indicating whether the overlay window host is loaded.</summary>
+    internal bool IsOverlayHostLoaded => _windowHost is not null;
+
+    /// <summary>Gets a value indicating whether the parent window reference is assigned.</summary>
+    internal bool IsParentWindowAssigned => _parentWindow is not null;
+
+    /// <summary>Gets a value indicating whether this instance has been disposed.</summary>
+    internal bool IsDisposed => _disposedValue;
+
     /// <summary>Releases managed and unmanaged resources.</summary>
     public void Dispose()
     {
@@ -458,9 +467,17 @@ public class WebView2Wpf : ContentControl, IWebView2
 
         if (disposing)
         {
+            if (_parentWindow is not null)
+            {
+                _parentWindow.Loaded -= ParentWindow_Loaded;
+            }
+
+            _webBrowser.Unloaded -= OnWebBrowserUnloaded;
             _webBrowser.Dispose();
             _windowHost?.Close();
             _windowHost?.Dispose();
+            _windowHost = null;
+            _parentWindow = null;
         }
 
         _disposedValue = true;

--- a/src/CrissCross.WPF/NavigationWindow.cs
+++ b/src/CrissCross.WPF/NavigationWindow.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Windows;
 using ReactiveUI;
 
@@ -45,6 +46,9 @@ public class NavigationWindow : Window, ISetNavigation, IUseNavigation, IActivat
         typeof(NavigationWindow),
         new(TransitionType.Fade));
 
+    /// <summary>Stores the navigation Host Name value.</summary>
+    private string? _navigationHostName;
+
     /// <summary>Initializes a new instance of the <see cref="NavigationWindow"/> class.</summary>
     public NavigationWindow() => DefaultStyleKey = typeof(NavigationWindow);
 
@@ -53,6 +57,22 @@ public class NavigationWindow : Window, ISetNavigation, IUseNavigation, IActivat
     /// The can navigate back.
     /// </value>
     public IObservable<bool?> CanNavigateBack => NavigationFrame.CanNavigateBackObservable;
+
+    /// <summary>Gets or sets the stable routed navigation host name.</summary>
+    public string? HostName
+    {
+        get => _navigationHostName ?? Name;
+        set
+        {
+            _navigationHostName = string.IsNullOrWhiteSpace(value) ? null : value;
+            if (NavigationFrame is null)
+            {
+                return;
+            }
+
+            ConfigureNavigationHost(NavigationFrame);
+        }
+    }
 
     /// <summary>Gets or sets a value indicating whether [navigate back is enabled].</summary>
     /// <value>
@@ -85,6 +105,12 @@ public class NavigationWindow : Window, ISetNavigation, IUseNavigation, IActivat
     }
 
     /// <inheritdoc/>
+    string? ISetNavigation.Name => HostName;
+
+    /// <inheritdoc/>
+    string? IUseNavigation.Name => HostName;
+
+    /// <inheritdoc/>
     public override void OnApplyTemplate()
     {
         base.OnApplyTemplate();
@@ -93,7 +119,43 @@ public class NavigationWindow : Window, ISetNavigation, IUseNavigation, IActivat
             ?? throw new InvalidOperationException(
                 $"{$"{nameof(NavigationFrame)} as a {nameof(ViewModelRoutedViewHost)} "}is missing from the Style template.");
 
-        NavigationFrame.HostName = Name;
-        this.SetMainNavigationHost(NavigationFrame);
+        ConfigureNavigationHost(NavigationFrame);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnClosed(EventArgs e)
+    {
+        NavigationFrame?.Dispose();
+        base.OnClosed(e);
+    }
+
+    /// <summary>Runs the configure Navigation Host operation.</summary>
+    /// <param name="host">The navigation host.</param>
+    private void ConfigureNavigationHost(ViewModelRoutedViewHost host)
+    {
+        var hostName = ResolveNavigationHostName();
+        _navigationHostName = hostName;
+        host.HostName = hostName;
+
+        if (string.IsNullOrWhiteSpace(host.Name))
+        {
+            host.Name = hostName;
+        }
+
+        this.SetMainNavigationHost(host);
+    }
+
+    /// <summary>Runs the resolve Navigation Host Name operation.</summary>
+    /// <returns>The resolved host name.</returns>
+    private string ResolveNavigationHostName()
+    {
+        if (!string.IsNullOrWhiteSpace(_navigationHostName))
+        {
+            return _navigationHostName!;
+        }
+
+        return !string.IsNullOrWhiteSpace(Name)
+            ? Name
+            : $"__crisscross_navhost_{nameof(NavigationWindow)}_{RuntimeHelpers.GetHashCode(this):X8}";
     }
 }

--- a/src/CrissCross.WPF/NavigationWindow{TViewModel}.cs
+++ b/src/CrissCross.WPF/NavigationWindow{TViewModel}.cs
@@ -2,6 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
 using System.Windows;
 using ReactiveUI;
 using Splat;
@@ -33,7 +34,7 @@ public class NavigationWindow<TViewModel> : NavigationWindow, IViewFor<TViewMode
     /// <summary>Initializes a new instance of the <see cref="NavigationWindow{TViewModel}"/> class.</summary>
     public NavigationWindow() =>
         this.WhenActivated(
-            (CompositeDisposable _) => ViewModel ??= AppLocator.Current.GetService<TViewModel>() ?? new());
+            (Action<IDisposable> _) => ViewModel ??= AppLocator.Current.GetService<TViewModel>() ?? new());
 
     /// <summary>Gets the binding root view model.</summary>
     public TViewModel? BindingRoot => ViewModel;

--- a/src/CrissCross.WPF/ViewModelRoutedViewHost.cs
+++ b/src/CrissCross.WPF/ViewModelRoutedViewHost.cs
@@ -73,6 +73,9 @@ public class ViewModelRoutedViewHost : TransitioningContentControl, IResolvedVie
     /// <summary>Stores the disposed value.</summary>
     private bool _disposedValue;
 
+    /// <summary>Stores the navigation result subscription.</summary>
+    private IDisposable? _navigationResultSubscription;
+
     /// <summary>Initializes a new instance of the <see cref="ViewModelRoutedViewHost"/> class.</summary>
     public ViewModelRoutedViewHost()
     {
@@ -153,7 +156,7 @@ public class ViewModelRoutedViewHost : TransitioningContentControl, IResolvedVie
     /// <value>
     /// <c>true</c> if [requires setup]; otherwise, <c>false</c>.
     /// </value>
-    public bool RequiresSetup => false;
+    public bool RequiresSetup => true;
 
     /// <summary>Clears the history.</summary>
     public void ClearHistory() => NavigationStack.Clear();
@@ -318,7 +321,7 @@ public class ViewModelRoutedViewHost : TransitioningContentControl, IResolvedVie
             }
             else
             {
-                ViewModelRoutedViewHostMixins.ResultNavigating[HostName].OnNext(ea);
+                PublishNavigating(ea);
             }
         }
 
@@ -368,9 +371,15 @@ public class ViewModelRoutedViewHost : TransitioningContentControl, IResolvedVie
         }
 #endif
 
+        if (!ViewModelRoutedViewHostMixins.ResultNavigating.TryGetValue(HostName, out var resultNavigating))
+        {
+            return;
+        }
+
+        _navigationResultSubscription?.Dispose();
+
         // requested should return result here
-        _ = ViewModelRoutedViewHostMixins
-            .ResultNavigating[HostName]
+        _navigationResultSubscription = resultNavigating
             .DistinctUntilChanged()
             .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(HandleNavigating);
@@ -394,6 +403,8 @@ public class ViewModelRoutedViewHost : TransitioningContentControl, IResolvedVie
 
         if (disposing)
         {
+            ViewModelRoutedViewHostMixins.UnregisterNavigationHost(this);
+            _navigationResultSubscription?.Dispose();
             _canNavigateBackSubject.Dispose();
             _currentViewModel.Dispose();
         }
@@ -475,7 +486,7 @@ public class ViewModelRoutedViewHost : TransitioningContentControl, IResolvedVie
             return;
         }
 
-        targetViewModel?.WhenNavigatedTo(eventArgs, ViewModelRoutedViewHostMixins.CurrentViewDisposable[HostName]);
+        targetViewModel?.WhenNavigatedTo(eventArgs, GetCurrentViewDisposable());
     }
 
     /// <summary>Updates the navigation stack and active view model.</summary>
@@ -553,13 +564,14 @@ public class ViewModelRoutedViewHost : TransitioningContentControl, IResolvedVie
             _currentView,
             HostName,
             parameter);
+
         if (_currentView is INotifiyNavigation { ISetupNavigating: true })
         {
             ViewModelRoutedViewHostMixins.SetWhenNavigating.OnNext(ea);
         }
         else
         {
-            ViewModelRoutedViewHostMixins.ResultNavigating[HostName].OnNext(ea);
+            PublishNavigating(ea);
         }
     }
 
@@ -587,13 +599,14 @@ public class ViewModelRoutedViewHost : TransitioningContentControl, IResolvedVie
             _currentView,
             HostName,
             parameter);
+
         if (_currentView is INotifiyNavigation { ISetupNavigating: true })
         {
             ViewModelRoutedViewHostMixins.SetWhenNavigating.OnNext(ea);
         }
         else
         {
-            ViewModelRoutedViewHostMixins.ResultNavigating[HostName].OnNext(ea);
+            PublishNavigating(ea);
         }
     }
 
@@ -615,13 +628,40 @@ public class ViewModelRoutedViewHost : TransitioningContentControl, IResolvedVie
             _currentView,
             HostName,
             parameter);
+
         if (_currentView is INotifiyNavigation { ISetupNavigating: true })
         {
             ViewModelRoutedViewHostMixins.SetWhenNavigating.OnNext(ea);
         }
         else
         {
-            ViewModelRoutedViewHostMixins.ResultNavigating[HostName].OnNext(ea);
+            PublishNavigating(ea);
         }
+    }
+
+    /// <summary>Gets the disposable collection for this navigation host.</summary>
+    /// <returns>The host disposable collection.</returns>
+    private CompositeDisposable GetCurrentViewDisposable()
+    {
+        if (ViewModelRoutedViewHostMixins.CurrentViewDisposable.TryGetValue(HostName, out var disposable))
+        {
+            return disposable;
+        }
+
+        disposable = [];
+        ViewModelRoutedViewHostMixins.CurrentViewDisposable[HostName] = disposable;
+        return disposable;
+    }
+
+    /// <summary>Publishes pending navigation when this host has been registered.</summary>
+    /// <param name="eventArgs">The pending navigation event.</param>
+    private void PublishNavigating(IViewModelNavigatingEventArgs eventArgs)
+    {
+        if (!ViewModelRoutedViewHostMixins.ResultNavigating.TryGetValue(HostName, out var resultNavigating))
+        {
+            return;
+        }
+
+        resultNavigating.OnNext(eventArgs);
     }
 }

--- a/src/CrissCross.WinForms/NavigationForm.Designer.cs
+++ b/src/CrissCross.WinForms/NavigationForm.Designer.cs
@@ -17,9 +17,10 @@ partial class NavigationForm
     /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
     protected override void Dispose(bool disposing)
     {
-        if (disposing && (components != null))
+        if (disposing)
         {
-            components.Dispose();
+            NavigationFrame.Dispose();
+            components?.Dispose();
         }
         base.Dispose(disposing);
     }

--- a/src/CrissCross.WinForms/NavigationForm.cs
+++ b/src/CrissCross.WinForms/NavigationForm.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 #if REACTIVELIST_REACTIVE
 namespace CrissCross.Reactive.WinForms;
@@ -16,6 +17,9 @@ namespace CrissCross.WinForms;
 /// <seealso cref="IUseNavigation" />
 public partial class NavigationForm : Form, ISetNavigation, IUseNavigation
 {
+    /// <summary>Stores the navigation Host Name value.</summary>
+    private string? _navigationHostName;
+
     /// <summary>Stores the navigation Frame Dock value.</summary>
     private DockStyle _navigationFrameDock = DockStyle.Fill;
 
@@ -69,18 +73,47 @@ public partial class NavigationForm : Form, ISetNavigation, IUseNavigation
     /// </value>
     public IObservable<bool> CanNavigateBack => NavigationFrame.CanNavigateBackObservable.Select(static x => x == true);
 
+    /// <summary>Gets or sets the stable routed navigation host name.</summary>
+    [Category("CrissCross")]
+    [Description("The logical navigation host name.")]
+    [Bindable(true)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    [Localizable(true)]
+    public string? HostName
+    {
+        get => _navigationHostName ?? Name;
+        set
+        {
+            _navigationHostName = string.IsNullOrWhiteSpace(value) ? null : value;
+            NavigationFrame.HostName = ResolveNavigationHostName();
+        }
+    }
+
     /// <summary>Gets the navigation frame.</summary>
     /// <value>
     /// The navigation frame.
     /// </value>
     public ViewModelRoutedViewHost NavigationFrame { get; } = new();
 
+    /// <inheritdoc/>
+    string? ISetNavigation.Name => HostName;
+
+    /// <inheritdoc/>
+    string? IUseNavigation.Name => HostName;
+
     /// <summary>Raises the <see cref="E:System.Windows.Forms.Form.Load" /> event.</summary>
     /// <param name="e">An <see cref="T:System.EventArgs" /> that contains the event data.</param>
     protected override void OnLoad(EventArgs e)
     {
         SuspendLayout();
-        NavigationFrame.HostName = Name;
+        var hostName = ResolveNavigationHostName();
+        _navigationHostName = hostName;
+        NavigationFrame.HostName = hostName;
+        if (string.IsNullOrWhiteSpace(NavigationFrame.Name))
+        {
+            NavigationFrame.Name = hostName;
+        }
+
         if (!DesignMode)
         {
             this.SetMainNavigationHost(NavigationFrame);
@@ -91,5 +124,19 @@ public partial class NavigationForm : Form, ISetNavigation, IUseNavigation
         Controls.Add(NavigationFrame);
         ResumeLayout();
         base.OnLoad(e);
+    }
+
+    /// <summary>Runs the resolve Navigation Host Name operation.</summary>
+    /// <returns>The resolved host name.</returns>
+    private string ResolveNavigationHostName()
+    {
+        if (!string.IsNullOrWhiteSpace(_navigationHostName))
+        {
+            return _navigationHostName!;
+        }
+
+        return !string.IsNullOrWhiteSpace(Name)
+            ? Name
+            : $"__crisscross_navhost_{nameof(NavigationForm)}_{RuntimeHelpers.GetHashCode(this):X8}";
     }
 }

--- a/src/CrissCross.WinForms/ViewModelRoutedViewHost.Designer.cs
+++ b/src/CrissCross.WinForms/ViewModelRoutedViewHost.Designer.cs
@@ -21,11 +21,15 @@ partial class ViewModelRoutedViewHost
     /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
     protected override void Dispose(bool disposing)
     {
-        if (disposing && (components != null))
+        if (disposing && !_disposedValue)
         {
-            components.Dispose();
+            ViewModelRoutedViewHostMixins.UnregisterNavigationHost(this);
+            _navigationResultSubscription?.Dispose();
+            components?.Dispose();
             _canNavigateBackSubject.Dispose();
             _currentViewModel.Dispose();
+            _navigationViews.Clear();
+            _disposedValue = true;
         }
         base.Dispose(disposing);
     }

--- a/src/CrissCross.WinForms/ViewModelRoutedViewHost.cs
+++ b/src/CrissCross.WinForms/ViewModelRoutedViewHost.cs
@@ -55,6 +55,12 @@ public partial class ViewModelRoutedViewHost : UserControl, IResolvedViewModelRo
     /// <summary>Stores the content value.</summary>
     private Control? _content;
 
+    /// <summary>Stores the navigation result subscription.</summary>
+    private IDisposable? _navigationResultSubscription;
+
+    /// <summary>Stores the disposed value.</summary>
+    private bool _disposedValue;
+
     /// <summary>Initializes static members of the <see cref="ViewModelRoutedViewHost"/> class.</summary>
     static ViewModelRoutedViewHost() => _ = RxState.DefaultExceptionHandler;
 
@@ -254,7 +260,7 @@ public partial class ViewModelRoutedViewHost : UserControl, IResolvedViewModelRo
             }
             else
             {
-                ViewModelRoutedViewHostMixins.ResultNavigating[HostName].OnNext(ea);
+                PublishNavigating(ea);
             }
         }
 
@@ -301,9 +307,15 @@ public partial class ViewModelRoutedViewHost : UserControl, IResolvedViewModelRo
         }
 #endif
 
+        if (!ViewModelRoutedViewHostMixins.ResultNavigating.TryGetValue(HostName, out var resultNavigating))
+        {
+            return;
+        }
+
+        _navigationResultSubscription?.Dispose();
+
         // requested should return result here
-        _ = ViewModelRoutedViewHostMixins
-            .ResultNavigating[HostName]
+        _navigationResultSubscription = resultNavigating
             .DistinctUntilChanged()
             .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(HandleNavigationResult);
@@ -442,7 +454,7 @@ public partial class ViewModelRoutedViewHost : UserControl, IResolvedViewModelRo
         {
             targetViewModel?.WhenNavigatedTo(
                 navigationEvent,
-                ViewModelRoutedViewHostMixins.CurrentViewDisposable[HostName]);
+                GetCurrentViewDisposable());
         }
 
         if (!callViewModelNavigatedFrom)
@@ -495,7 +507,7 @@ public partial class ViewModelRoutedViewHost : UserControl, IResolvedViewModelRo
         }
         else
         {
-            ViewModelRoutedViewHostMixins.ResultNavigating[HostName].OnNext(ea);
+            PublishNavigating(ea);
         }
     }
 
@@ -530,7 +542,7 @@ public partial class ViewModelRoutedViewHost : UserControl, IResolvedViewModelRo
         }
         else
         {
-            ViewModelRoutedViewHostMixins.ResultNavigating[HostName].OnNext(ea);
+            PublishNavigating(ea);
         }
     }
 
@@ -558,7 +570,33 @@ public partial class ViewModelRoutedViewHost : UserControl, IResolvedViewModelRo
         }
         else
         {
-            ViewModelRoutedViewHostMixins.ResultNavigating[HostName].OnNext(ea);
+            PublishNavigating(ea);
         }
+    }
+
+    /// <summary>Gets the disposable collection for this navigation host.</summary>
+    /// <returns>The host disposable collection.</returns>
+    private CompositeDisposable GetCurrentViewDisposable()
+    {
+        if (ViewModelRoutedViewHostMixins.CurrentViewDisposable.TryGetValue(HostName, out var disposable))
+        {
+            return disposable;
+        }
+
+        disposable = [];
+        ViewModelRoutedViewHostMixins.CurrentViewDisposable[HostName] = disposable;
+        return disposable;
+    }
+
+    /// <summary>Publishes pending navigation when this host has been registered.</summary>
+    /// <param name="eventArgs">The pending navigation event.</param>
+    private void PublishNavigating(IViewModelNavigatingEventArgs eventArgs)
+    {
+        if (!ViewModelRoutedViewHostMixins.ResultNavigating.TryGetValue(HostName, out var resultNavigating))
+        {
+            return;
+        }
+
+        resultNavigating.OnNext(eventArgs);
     }
 }

--- a/src/CrissCross/PageRequest.cs
+++ b/src/CrissCross/PageRequest.cs
@@ -57,7 +57,8 @@ public sealed class PageRequest
     public int PageSize { get; }
 
     /// <summary>Gets the zero-based offset for data-source skip operations.</summary>
-    public int Offset => PageIndex * PageSize;
+    /// <exception cref="System.OverflowException">The requested offset exceeds <see cref="int.MaxValue"/>.</exception>
+    public int Offset => checked(PageIndex * PageSize);
 
     /// <summary>Gets the explicit sort key, when present.</summary>
     public string? SortKey { get; }
@@ -82,7 +83,7 @@ public sealed class PageRequest
 
     /// <summary>Gets compact user-facing request text for diagnostics.</summary>
     public string DisplayText =>
-        string.Format(CultureInfo.InvariantCulture, DisplayTextFormat, PageIndex + 1, PageSize);
+        string.Format(CultureInfo.InvariantCulture, DisplayTextFormat, (long)PageIndex + 1, PageSize);
 
     /// <summary>Creates the stable key for a filter snapshot.</summary>
     /// <param name="filters">The filters to include.</param>

--- a/src/CrissCross/PaginationState.cs
+++ b/src/CrissCross/PaginationState.cs
@@ -67,7 +67,7 @@ public sealed class PaginationState
     public int FirstItemNumber => HasItems ? (PageIndex * PageSize) + 1 : 0;
 
     /// <summary>Gets the one-based number of the last item displayed on the current page.</summary>
-    public int LastItemNumber => HasItems ? Math.Min(TotalItemCount, (PageIndex + 1) * PageSize) : 0;
+    public int LastItemNumber => HasItems ? (int)Math.Min(TotalItemCount, ((long)PageIndex + 1) * PageSize) : 0;
 
     /// <summary>Gets compact user-facing item range text.</summary>
     public string SummaryText => HasItems

--- a/src/CrissCross/ProcessValueOptions.cs
+++ b/src/CrissCross/ProcessValueOptions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVELIST_REACTIVE
+namespace CrissCross.Reactive;
+#else
+namespace CrissCross;
+#endif
+
+/// <summary>Configures the alarm limits and source quality copied into a process-value snapshot.</summary>
+public sealed class ProcessValueOptions
+{
+    /// <summary>Gets or sets the optional inclusive low alarm limit.</summary>
+    public double? LowAlarmLimit { get; set; }
+
+    /// <summary>Gets or sets the optional inclusive high alarm limit.</summary>
+    public double? HighAlarmLimit { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the source reports good data quality.</summary>
+    public bool IsGoodQuality { get; set; } = true;
+}

--- a/src/CrissCross/ProcessValueState.cs
+++ b/src/CrissCross/ProcessValueState.cs
@@ -1,0 +1,185 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+
+#if REACTIVELIST_REACTIVE
+namespace CrissCross.Reactive;
+#else
+namespace CrissCross;
+#endif
+
+/// <summary>Provides an immutable, platform-neutral snapshot for an industrial process-value indicator.</summary>
+public sealed class ProcessValueState
+{
+    /// <summary>Converts a normalized value to a percentage.</summary>
+    private const double PercentageScale = 100;
+
+    /// <summary>Scales extreme finite endpoints before calculating their difference.</summary>
+    private const double RangeScale = 2;
+
+    /// <inheritdoc />
+    public ProcessValueState(string? label, double? value, string? unit, double minimum, double maximum)
+        : this(label, value, unit, minimum, maximum, null) { }
+
+    /// <summary>Initializes a new instance of the <see cref="ProcessValueState"/> class with alarm limits and good quality.</summary>
+    /// <param name="label">The measurement name.</param>
+    /// <param name="value">The measurement, or null when unavailable.</param>
+    /// <param name="unit">The engineering unit.</param>
+    /// <param name="minimum">The lower display endpoint.</param>
+    /// <param name="maximum">The upper display endpoint.</param>
+    /// <param name="lowAlarmLimit">The optional inclusive low alarm limit.</param>
+    /// <param name="highAlarmLimit">The optional inclusive high alarm limit.</param>
+    public ProcessValueState(string? label, double? value, string? unit, double minimum, double maximum, double? lowAlarmLimit, double? highAlarmLimit)
+        : this(label, value, unit, minimum, maximum, new ProcessValueOptions { LowAlarmLimit = lowAlarmLimit, HighAlarmLimit = highAlarmLimit }) { }
+
+    /// <summary>Initializes a new instance of the <see cref="ProcessValueState"/> class.</summary>
+    /// <param name="label">The measurement name.</param>
+    /// <param name="value">The measured value, or <see langword="null"/> when unavailable.</param>
+    /// <param name="unit">The engineering unit.</param>
+    /// <param name="minimum">The lower display range endpoint.</param>
+    /// <param name="maximum">The upper display range endpoint, strictly greater than the minimum.</param>
+    /// <param name="options">The alarm and quality options copied into this snapshot, or null for defaults.</param>
+    public ProcessValueState(
+        string? label,
+        double? value,
+        string? unit,
+        double minimum,
+        double maximum,
+        ProcessValueOptions? options)
+    {
+        Label = label?.Trim() ?? string.Empty;
+        Value = value;
+        Unit = unit?.Trim() ?? string.Empty;
+        Minimum = minimum;
+        Maximum = maximum;
+        LowAlarmLimit = options?.LowAlarmLimit;
+        HighAlarmLimit = options?.HighAlarmLimit;
+        IsGoodQuality = options?.IsGoodQuality ?? true;
+        Status = ResolveStatus();
+    }
+
+    /// <summary>Gets the measurement name.</summary>
+    public string Label { get; }
+
+    /// <summary>Gets the original measurement, including invalid source values.</summary>
+    public double? Value { get; }
+
+    /// <summary>Gets the engineering unit.</summary>
+    public string Unit { get; }
+
+    /// <summary>Gets the lower display range endpoint.</summary>
+    public double Minimum { get; }
+
+    /// <summary>Gets the upper display range endpoint.</summary>
+    public double Maximum { get; }
+
+    /// <summary>Gets the optional inclusive low alarm limit.</summary>
+    public double? LowAlarmLimit { get; }
+
+    /// <summary>Gets the optional inclusive high alarm limit.</summary>
+    public double? HighAlarmLimit { get; }
+
+    /// <summary>Gets a value indicating whether the source reports good data quality.</summary>
+    public bool IsGoodQuality { get; }
+
+    /// <summary>Gets the resolved condition; invalid configuration takes precedence over data quality and alarms.</summary>
+    public ProcessValueStatus Status { get; }
+
+    /// <summary>Gets a value indicating whether the measurement can be displayed as a valid reading.</summary>
+    public bool HasValidValue => Status is ProcessValueStatus.Normal or ProcessValueStatus.LowAlarm or ProcessValueStatus.HighAlarm;
+
+    /// <summary>Gets a value indicating whether an alarm limit has been reached.</summary>
+    public bool IsAlarm => Status is ProcessValueStatus.LowAlarm or ProcessValueStatus.HighAlarm;
+
+    /// <summary>Gets invariant measurement text, or an em dash when the reading is invalid.</summary>
+    public string ValueText => HasValidValue ? Value!.Value.ToString("0.###", CultureInfo.InvariantCulture) : "—";
+
+    /// <summary>Gets measurement text with its engineering unit.</summary>
+    public string DisplayText => Unit.Length == 0 ? ValueText : $"{ValueText} {Unit}";
+
+    /// <summary>Gets a textual condition so that alarm and quality information never relies on color alone.</summary>
+    public string StatusText => Status switch
+    {
+        ProcessValueStatus.Normal => "Normal",
+        ProcessValueStatus.LowAlarm => "Low alarm",
+        ProcessValueStatus.HighAlarm => "High alarm",
+        ProcessValueStatus.BadQuality => "Bad quality",
+        _ => "Invalid configuration",
+    };
+
+    /// <summary>Gets the clamped position in the display range, from zero to one, or zero for an invalid reading.</summary>
+    public double NormalizedValue
+    {
+        get
+        {
+            if (!HasValidValue || Value!.Value <= Minimum)
+            {
+                return 0;
+            }
+
+            return Value.Value >= Maximum ? 1 : NormalizeWithinRange(Value.Value);
+        }
+    }
+
+    /// <summary>Gets the clamped display range percentage.</summary>
+    public double Percentage => NormalizedValue * PercentageScale;
+
+    /// <summary>Determines whether a number is finite on every supported framework.</summary>
+    /// <param name="value">The number to inspect.</param>
+    /// <returns>Whether the number is neither NaN nor infinity.</returns>
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+
+    /// <summary>Validates an optional finite alarm endpoint.</summary>
+    /// <param name="value">The optional endpoint.</param>
+    /// <returns>Whether the endpoint is absent or finite.</returns>
+    private static bool IsValidLimit(double? value) => !value.HasValue || IsFinite(value.Value);
+
+    /// <summary>Normalizes a valid interior measurement without overflowing wide ranges.</summary>
+    /// <param name="value">The finite interior measurement.</param>
+    /// <returns>The normalized fraction.</returns>
+    private double NormalizeWithinRange(double value)
+    {
+        var span = Maximum - Minimum;
+        return double.IsInfinity(span)
+            ? ((value / RangeScale) - (Minimum / RangeScale)) / ((Maximum / RangeScale) - (Minimum / RangeScale))
+            : (value - Minimum) / span;
+    }
+
+    /// <summary>Validates the range and optional alarm limits.</summary>
+    /// <returns>Whether all configured endpoints are usable.</returns>
+    private bool HasValidConfiguration() =>
+        IsFinite(Minimum) && IsFinite(Maximum) && Maximum > Minimum
+        && IsValidLimit(LowAlarmLimit) && IsValidLimit(HighAlarmLimit)
+        && HasOrderedLimits();
+
+    /// <summary>Validates the order of a pair of alarm limits.</summary>
+    /// <returns>Whether the limits are absent or strictly ordered.</returns>
+    private bool HasOrderedLimits() => !LowAlarmLimit.HasValue || !HighAlarmLimit.HasValue || LowAlarmLimit.Value < HighAlarmLimit.Value;
+
+    /// <summary>Resolves configuration, quality, and inclusive alarm limits.</summary>
+    /// <returns>The displayed condition.</returns>
+    private ProcessValueStatus ResolveStatus()
+    {
+        if (!HasValidConfiguration())
+        {
+            return ProcessValueStatus.InvalidConfiguration;
+        }
+
+        if (!IsGoodQuality || !Value.HasValue || !IsFinite(Value.Value))
+        {
+            return ProcessValueStatus.BadQuality;
+        }
+
+        if (LowAlarmLimit.HasValue && Value.Value <= LowAlarmLimit.Value)
+        {
+            return ProcessValueStatus.LowAlarm;
+        }
+
+        return HighAlarmLimit.HasValue && Value.Value >= HighAlarmLimit.Value
+            ? ProcessValueStatus.HighAlarm
+            : ProcessValueStatus.Normal;
+    }
+}

--- a/src/CrissCross/ProcessValueStatus.cs
+++ b/src/CrissCross/ProcessValueStatus.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVELIST_REACTIVE
+namespace CrissCross.Reactive;
+#else
+namespace CrissCross;
+#endif
+
+/// <summary>Describes the displayed condition of a process measurement.</summary>
+public enum ProcessValueStatus
+{
+    /// <summary>The measurement is valid and within its alarm limits.</summary>
+    Normal,
+
+    /// <summary>The measurement is at or below its low alarm limit.</summary>
+    LowAlarm,
+
+    /// <summary>The measurement is at or above its high alarm limit.</summary>
+    HighAlarm,
+
+    /// <summary>The measurement is unavailable, non-finite, or reported with bad quality.</summary>
+    BadQuality,
+
+    /// <summary>The display range or alarm limits are invalid.</summary>
+    InvalidConfiguration,
+}

--- a/src/CrissCross/ValidationSummaryState.cs
+++ b/src/CrissCross/ValidationSummaryState.cs
@@ -31,30 +31,17 @@ public sealed class ValidationSummaryState
             foreach (var message in messages)
             {
                 messageList.Add(message);
-                switch (message.Severity)
+                if (message.Severity == ValidationSeverity.Error)
                 {
-                    case ValidationSeverity.Error:
-                        {
-                            errorCount++;
-                            break;
-                        }
-
-                    case ValidationSeverity.Warning:
-                        {
-                            warningCount++;
-                            break;
-                        }
-
-                    case ValidationSeverity.Pending:
-                        {
-                            pendingCount++;
-                            break;
-                        }
-
-                    default:
-                        {
-                            break;
-                        }
+                    errorCount++;
+                }
+                else if (message.Severity == ValidationSeverity.Warning)
+                {
+                    warningCount++;
+                }
+                else if (message.Severity == ValidationSeverity.Pending)
+                {
+                    pendingCount++;
                 }
             }
         }

--- a/src/CrissCross/ViewModelRoutedViewHostMixins.Lifecycle.cs
+++ b/src/CrissCross/ViewModelRoutedViewHostMixins.Lifecycle.cs
@@ -1,0 +1,59 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+#if REACTIVELIST_REACTIVE
+namespace CrissCross.Reactive;
+#else
+namespace CrissCross;
+#endif
+
+/// <summary>Provides navigation host lifecycle helpers.</summary>
+public static partial class ViewModelRoutedViewHostMixins
+{
+    /// <summary>Unregisters every navigation host alias still owned by the specified host.</summary>
+    /// <param name="viewHost">The view host being disposed.</param>
+    internal static void UnregisterNavigationHost(IViewModelRoutedViewHost viewHost)
+    {
+        ThrowHelper.ThrowIfNull(viewHost, nameof(viewHost));
+        var hostKeys = new List<string>();
+
+        lock (_lockObject)
+        {
+            foreach (var pair in NavigationHost)
+            {
+                if (ReferenceEquals(pair.Value, viewHost))
+                {
+                    hostKeys.Add(pair.Key);
+                }
+            }
+
+            foreach (var hostKey in hostKeys)
+            {
+                _ = NavigationHost.Remove(hostKey);
+                DisposeAndRemove(CurrentViewDisposable, hostKey);
+                DisposeAndRemove(ResultNavigating, hostKey);
+                DisposeAndRemove(WhenSetupSubjects, hostKey);
+            }
+        }
+    }
+
+    /// <summary>Disposes and removes a disposable dictionary value.</summary>
+    /// <typeparam name="TDisposable">The disposable value type.</typeparam>
+    /// <param name="dictionary">The dictionary to update.</param>
+    /// <param name="key">The key to remove.</param>
+    private static void DisposeAndRemove<TDisposable>(Dictionary<string, TDisposable> dictionary, string key)
+        where TDisposable : IDisposable
+    {
+        if (!dictionary.TryGetValue(key, out var disposable))
+        {
+            return;
+        }
+
+        _ = dictionary.Remove(key);
+        disposable.Dispose();
+    }
+}

--- a/src/CrissCross/ViewModelRoutedViewHostMixins.Navigation.cs
+++ b/src/CrissCross/ViewModelRoutedViewHostMixins.Navigation.cs
@@ -179,12 +179,12 @@ public static partial class ViewModelRoutedViewHostMixins
                                 return;
                             }
 
-                            if (!WhenSetupSubjects.TryGetValue(host.Name, out var whenSetup))
+                            if (!TryGetSetupSubject(navigation.Name, host, out var whenSetup))
                             {
                                 return;
                             }
 
-                            _ = whenSetup.Where(static x => x).Subscribe(observer).DisposeWith(disposable);
+                            _ = whenSetup!.Where(static x => x).Subscribe(observer).DisposeWith(disposable);
                         })
                         .DisposeWith(disposable);
                 });

--- a/src/CrissCross/ViewModelRoutedViewHostMixins.Registration.cs
+++ b/src/CrissCross/ViewModelRoutedViewHostMixins.Registration.cs
@@ -2,6 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -22,6 +23,7 @@ public static partial class ViewModelRoutedViewHostMixins
     {
         var hostKeys = new List<string>();
         AddHostKey(hostKeys, navigation.Name);
+        AddHostKey(hostKeys, viewHost.HostName);
         AddHostKey(hostKeys, viewHost.Name);
 
         if (hostKeys.Count == 0)
@@ -71,6 +73,11 @@ public static partial class ViewModelRoutedViewHostMixins
     /// <param name="hostKeys">The host key list.</param>
     private static void EnsureViewHostName(IViewModelRoutedViewHost viewHost, string hostKey, List<string> hostKeys)
     {
+        if (!string.Equals(viewHost.HostName, hostKey, StringComparison.Ordinal))
+        {
+            viewHost.HostName = hostKey;
+        }
+
         if (!string.IsNullOrWhiteSpace(viewHost.Name))
         {
             return;
@@ -89,6 +96,13 @@ public static partial class ViewModelRoutedViewHostMixins
         {
             foreach (var key in hostKeys)
             {
+                if (NavigationHost.TryGetValue(key, out var existingHost) && !ReferenceEquals(existingHost, viewHost))
+                {
+                    DisposeAndRemove(CurrentViewDisposable, key);
+                    DisposeAndRemove(ResultNavigating, key);
+                    DisposeAndRemove(WhenSetupSubjects, key);
+                }
+
                 NavigationHost[key] = viewHost;
                 AddIfMissing(WhenSetupSubjects, key, new(1));
                 AddIfMissing(CurrentViewDisposable, key, []);

--- a/src/CrissCross/ViewModelRoutedViewHostMixins.Resolution.cs
+++ b/src/CrissCross/ViewModelRoutedViewHostMixins.Resolution.cs
@@ -6,6 +6,12 @@ using System;
 using System.Collections.Generic;
 using Splat;
 
+#if REACTIVE_SHIM
+using BooleanReplaySignal = ReactiveUI.Primitives.Reactive.Signals.ReplaySignal<bool>;
+#else
+using BooleanReplaySignal = ReactiveUI.Primitives.Signals.ReplaySignal<bool>;
+#endif
+
 #if REACTIVELIST_REACTIVE
 namespace CrissCross.Reactive;
 #else
@@ -183,6 +189,26 @@ public static partial class ViewModelRoutedViewHostMixins
 
         var requestedHostName = string.IsNullOrWhiteSpace(hostName) ? "<default>" : hostName;
         throw new KeyNotFoundException($"Navigation host '{requestedHostName}' has not been registered.");
+    }
+
+    /// <summary>Attempts to resolve a setup signal for a host key.</summary>
+    /// <param name="hostName">The requested host name.</param>
+    /// <param name="host">The resolved navigation host.</param>
+    /// <param name="whenSetup">The setup signal.</param>
+    /// <returns><c>true</c> when a setup signal was found; otherwise, <c>false</c>.</returns>
+    private static bool TryGetSetupSubject(
+        string? hostName,
+        IViewModelRoutedViewHost host,
+        out BooleanReplaySignal? whenSetup)
+    {
+        if (hostName is not null && !string.IsNullOrWhiteSpace(hostName) && WhenSetupSubjects.TryGetValue(hostName, out whenSetup))
+        {
+            return true;
+        }
+
+        var logicalHostName = host.HostName;
+        return (logicalHostName is not null && !string.IsNullOrWhiteSpace(logicalHostName) && WhenSetupSubjects.TryGetValue(logicalHostName, out whenSetup))
+            || WhenSetupSubjects.TryGetValue(host.Name, out whenSetup);
     }
 
     /// <summary>Adds an alias for an existing navigation host.</summary>

--- a/src/CrissCross/ViewModelRoutedViewHostMixins.cs
+++ b/src/CrissCross/ViewModelRoutedViewHostMixins.cs
@@ -347,12 +347,12 @@ public static partial class ViewModelRoutedViewHostMixins
                             return;
                         }
 
-                        if (!WhenSetupSubjects.TryGetValue(host.Name, out var whenSetup))
+                        if (!TryGetSetupSubject(hostName, host, out var whenSetup))
                         {
                             return;
                         }
 
-                        _ = whenSetup.Where(static x => x).Subscribe(observer).DisposeWith(disposable);
+                        _ = whenSetup!.Where(static x => x).Subscribe(observer).DisposeWith(disposable);
                     })
                     .DisposeWith(disposable);
                 return disposable;

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,6 @@
     <LangVersion>preview</LangVersion>
     <Configuration>$(TargetFramework)</Configuration>
     <Company>ChrisPulman</Company>
-    <NoWarn>CS1591;CS1701;IDE0190;IDE1006;CA1510</NoWarn>
     <Nullable>enable</Nullable>
     <PackageIcon>CrissCross_500.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -46,7 +45,6 @@
     <TUnitImplicitUsings>false</TUnitImplicitUsings>
     <TUnitAssertionsImplicitUsings>false</TUnitAssertionsImplicitUsings>
     <EnableVSTestReferences>false</EnableVSTestReferences>
-    <NoWarn>$(NoWarn);CS4014</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
@@ -118,6 +116,7 @@
     <Using Include="ReactiveUI.Primitives.Concurrency.ISequencer" Alias="IScheduler" />
     <Using Include="ReactiveUI.Primitives.Concurrency.ImmediateSequencer" Alias="ImmediateScheduler" />
     <Using Include="ReactiveUI.Primitives.Disposables.MultipleDisposable" Alias="CompositeDisposable" />
+    <Using Include="ReactiveUI.Primitives.Disposables.MultipleDisposable" Alias="ActivationDisposable" />
     <Using Include="ReactiveUI.Primitives.Disposables.SwapDisposable" Alias="SerialDisposable" />
     <Using Include="ReactiveUI.Primitives.Signals.Signal" Alias="Observable" />
     <Using Include="ReactiveUI.Primitives.Disposables.Scope" Alias="Disposable" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <AvaloniaVersion>12.1.1</AvaloniaVersion>
+    <AvaloniaVersion>12.1.2</AvaloniaVersion>
     <SplatVersion>20.2.0</SplatVersion>
-    <ReactiveUIVersion>24.1.0</ReactiveUIVersion>
-    <ReactiveUIPrimitivesVersion>7.2.0</ReactiveUIPrimitivesVersion>
-    <WebViewVersion>1.0.4129.50</WebViewVersion>
+    <ReactiveUIVersion>24.2.0</ReactiveUIVersion>
+    <ReactiveUIBindingVersion>4.1.0</ReactiveUIBindingVersion>
+    <ReactiveUIPrimitivesVersion>7.4.0</ReactiveUIPrimitivesVersion>
     <DotNetVersion>10.0.11</DotNetVersion>
     <DotNet11Version>11.0.0-preview.7.26381.103</DotNet11Version>
-    <ExtensionsHostingVersion>4.1.0</ExtensionsHostingVersion>
+    <ExtensionsHostingVersion>5.0.0</ExtensionsHostingVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,6 +26,7 @@
 
     <!-- ReactiveUI Packages -->
     <PackageVersion Include="ReactiveUI" Version="$(ReactiveUIVersion)" />
+    <PackageVersion Include="ReactiveUI.Core" Version="$(ReactiveUIVersion)" />
     <PackageVersion Include="ReactiveUI.Reactive" Version="$(ReactiveUIVersion)" />
     <PackageVersion Include="ReactiveUI.Avalonia" Version="12.1.1" />
     <PackageVersion Include="ReactiveUI.Avalonia.Reactive" Version="12.1.1" />
@@ -35,6 +36,10 @@
     <PackageVersion Include="ReactiveUI.WinForms.Reactive" Version="$(ReactiveUIVersion)" />
     <PackageVersion Include="ReactiveUI.WPF" Version="$(ReactiveUIVersion)" />
     <PackageVersion Include="ReactiveUI.WPF.Reactive" Version="$(ReactiveUIVersion)" />
+    <PackageVersion Include="ReactiveUI.Binding" Version="$(ReactiveUIBindingVersion)" />
+    <PackageVersion Include="ReactiveUI.Binding.Reactive" Version="$(ReactiveUIBindingVersion)" />
+    <PackageVersion Include="ReactiveUI.Binding.Wpf" Version="$(ReactiveUIBindingVersion)" />
+    <PackageVersion Include="ReactiveUI.Binding.Wpf.Reactive" Version="$(ReactiveUIBindingVersion)" />
     <PackageVersion Include="ReactiveUI.Disposables" Version="$(ReactiveUIPrimitivesVersion)" />
     <PackageVersion Include="ReactiveUI.Primitives" Version="$(ReactiveUIPrimitivesVersion)" />
     <PackageVersion Include="ReactiveUI.Primitives.Core" Version="$(ReactiveUIPrimitivesVersion)" />
@@ -43,6 +48,7 @@
     <PackageVersion Include="ReactiveUI.Primitives.Wpf" Version="$(ReactiveUIPrimitivesVersion)" />
     <PackageVersion Include="ReactiveUI.Primitives.WinForms" Version="$(ReactiveUIPrimitivesVersion)" />
     <PackageVersion Include="ReactiveUI.Primitives.Maui" Version="$(ReactiveUIPrimitivesVersion)" />
+    <PackageVersion Include="ReactiveUI.Primitives.ObservableEvents" Version="$(ReactiveUIPrimitivesVersion)" />
 
     <!-- Microsoft Packages -->
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(DotNet11Version)" Condition="$(TargetFramework.StartsWith('net11'))" />
@@ -52,13 +58,13 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="$(DotNet11Version)" Condition="$(TargetFramework.StartsWith('net11'))" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="$(DotNetVersion)" Condition="!$(TargetFramework.StartsWith('net11'))" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="11.0.0-preview.7.26406.9" Condition="$(TargetFramework.StartsWith('net11'))" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.90" Condition="$(TargetFramework.StartsWith('net10'))" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.100" Condition="$(TargetFramework.StartsWith('net10'))" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="9.0.120" Condition="$(TargetFramework.StartsWith('net9'))" />
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="11.0.0-preview.5.26304.4" Condition="$(TargetFramework.StartsWith('net11'))" />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.90" Condition="$(TargetFramework.StartsWith('net10'))" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.100" Condition="$(TargetFramework.StartsWith('net10'))" />
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.120" Condition="$(TargetFramework.StartsWith('net9'))" />
-    <PackageVersion Include="Microsoft.Web.WebView2" Version="$(WebViewVersion)" />
-    <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.142" />
+    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.4191.47" />
+    <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.158" />
     <PackageVersion Include="System.Drawing.Common" Version="$(DotNet11Version)" Condition="$(TargetFramework.StartsWith('net11'))" />
     <PackageVersion Include="System.Drawing.Common" Version="$(DotNetVersion)" Condition="!$(TargetFramework.StartsWith('net11'))" />
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="$(DotNetVersion)" />
@@ -71,7 +77,7 @@
     <PackageVersion Include="ReactiveUI.SourceGenerators" Version="3.2.0" />
 
     <!-- Other UI/Framework Packages -->
-    <PackageVersion Include="AngleSharp" Version="1.7.1" />
+    <PackageVersion Include="AngleSharp" Version="1.8.0" />
     <PackageVersion Include="CP.Extensions.Hosting.ReactiveUI.Wpf" Version="$(ExtensionsHostingVersion)" />
     <PackageVersion Include="CP.Extensions.Hosting.ReactiveUI.Avalonia" Version="$(ExtensionsHostingVersion)" />
     <PackageVersion Include="CP.Extensions.Hosting.ReactiveUI.Maui" Version="$(ExtensionsHostingVersion)" />
@@ -89,18 +95,18 @@
     <PackageVersion Include="Polyfill" Version="11.2.0" Condition="$(TargetFramework.StartsWith('net4'))" />
 
     <!-- Testing Packages -->
-    <PackageVersion Include="TUnit" Version="1.65.0" Condition="$(IsTestProject)" />
-    <PackageVersion Include="Verify.TUnit" Version="31.28.0" Condition="$(IsTestProject)" />
+    <PackageVersion Include="TUnit" Version="1.66.16" Condition="$(IsTestProject)" />
+    <PackageVersion Include="Verify.TUnit" Version="32.0.0" Condition="$(IsTestProject)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" Condition="$(IsTestProject)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0" Condition="$(IsTestProject)" />
     <PackageVersion Include="PublicApiGenerator" Version="11.5.4" Condition="$(IsTestProject)" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.400" Condition="!$(IsTestProject)" />
 
-    <PackageVersion Include="MinVer" Version="7.0.0" />
-    <PackageVersion Include="StyleSharp.Analyzers" Version="3.45.0" />
-    <PackageVersion Include="PerformanceSharp.Analyzers" Version="3.45.0" />
-    <PackageVersion Include="SecuritySharp.Analyzers" Version="3.45.0" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.16.1" />
+    <PackageVersion Include="MinVer" Version="8.0.0" />
+    <PackageVersion Include="StyleSharp.Analyzers" Version="3.46.1" />
+    <PackageVersion Include="PerformanceSharp.Analyzers" Version="3.46.1" />
+    <PackageVersion Include="SecuritySharp.Analyzers" Version="3.46.1" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="5.0.0" />
 
     <!-- Benchmarking -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
@@ -108,7 +114,7 @@
     <!-- Android Specific -->
     <PackageVersion Include="Xamarin.AndroidX.Compose.Runtime.Annotation" Version="1.11.4" />
     <PackageVersion Include="Xamarin.AndroidX.Compose.Runtime.Annotation.Android" Version="1.11.4" />
-    <PackageVersion Include="Xamarin.AndroidX.Compose.Runtime.Annotation.Jvm" Version="1.11.4" />
+    <PackageVersion Include="Xamarin.AndroidX.Compose.Runtime.Annotation.Jvm" Version="1.12.0" />
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.2.0.3" />
     <PackageVersion Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.11.0.1" />
     <PackageVersion Include="Xamarin.AndroidX.Lifecycle.ViewModelSavedState" Version="2.11.0.1" />

--- a/src/ReactiveShim.props
+++ b/src/ReactiveShim.props
@@ -18,6 +18,7 @@
     <Using Include="System.Reactive.Concurrency.ImmediateScheduler" Alias="ImmediateScheduler" />
     <Using Include="System.Reactive.Concurrency" />
     <Using Include="ReactiveUI.Primitives.Disposables.MultipleDisposable" Alias="CompositeDisposable" />
+    <Using Include="ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable" Alias="ActivationDisposable" />
     <Using Include="ReactiveUI.Primitives.Disposables.SwapDisposable" Alias="SerialDisposable" />
     <Using Include="ReactiveUI.Primitives.Disposables.Scope" Alias="Disposable" />
     <Using Include="ReactiveUI.Primitives.Reactive.Signals.Signal" Alias="Observable" />

--- a/src/Tests/CrissCross.NavigationView.Tests/AppBarButtonTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AppBarButtonTests.cs
@@ -9,6 +9,7 @@ using CrissCross.Avalonia.UI.Controls;
 namespace CrissCross.NavigationView.Tests;
 
 /// <summary>Tests the Avalonia AppBarButton public property surface.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
 public class AppBarButtonTests
 {
     /// <summary>The default circular icon surface diameter.</summary>

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaBBCodeBlockTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaBBCodeBlockTests.cs
@@ -14,6 +14,7 @@ using AvaloniaButton = Avalonia.Controls.Button;
 namespace CrissCross.NavigationView.Tests;
 
 /// <summary>Tests the Avalonia BBCodeBlock parser, renderer, interaction, and theme integration.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
 public sealed class AvaloniaBBCodeBlockTests
 {
     /// <summary>The expected number of parsed document children.</summary>

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaButtonAppearanceTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaButtonAppearanceTests.cs
@@ -1,0 +1,206 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.VisualTree;
+using CrissCross.Avalonia.UI.Appearance;
+using Controls = CrissCross.Avalonia.UI.Controls;
+
+namespace CrissCross.NavigationView.Tests;
+
+/// <summary>Verifies appearance and interaction brushes in attached button templates.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
+public sealed class AvaloniaButtonAppearanceTests
+{
+    /// <summary>Verifies every public appearance uses its intended palette across theme changes.</summary>
+    /// <param name="appearance">The requested button appearance.</param>
+    /// <param name="backgroundKey">The semantic background key or literal color.</param>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    [Arguments(Controls.ControlAppearance.Primary, "AccentButtonBackground")]
+    [Arguments(Controls.ControlAppearance.Secondary, "ButtonBackground")]
+    [Arguments(Controls.ControlAppearance.Info, "SystemFillColorAttention")]
+    [Arguments(Controls.ControlAppearance.Success, "SystemFillColorSuccessBrush")]
+    [Arguments(Controls.ControlAppearance.Caution, "SystemFillColorCautionBrush")]
+    [Arguments(Controls.ControlAppearance.Danger, "SystemFillColorCriticalBrush")]
+    [Arguments(Controls.ControlAppearance.Dark, "Black")]
+    [Arguments(Controls.ControlAppearance.Light, "White")]
+    [Arguments(Controls.ControlAppearance.Transparent, "Transparent")]
+    public async Task AppearanceAndInteraction_UseConfiguredBrushes(Controls.ControlAppearance appearance, string backgroundKey)
+    {
+        var button = new InteractionButton { Content = "Operate", Appearance = appearance };
+        var window = new Window { Content = button };
+        try
+        {
+            window.Show();
+            foreach (var variant in new[] { ThemeVariant.Light, ThemeVariant.Dark, ApplicationThemeManager.HighContrastThemeVariant })
+            {
+                window.RequestedThemeVariant = variant;
+                window.UpdateLayout();
+                var expected = ResolveColor(backgroundKey, variant);
+                await Assert.That(GetBrushColor(button.Background)).IsEqualTo(expected);
+                var border = GetRootBorder(button);
+                await Assert.That(GetBrushColor(border.Background)).IsEqualTo(expected);
+
+                button.MouseOverBackground = Brushes.Magenta;
+                button.MouseOverForeground = Brushes.White;
+                button.PressedBackground = Brushes.Cyan;
+                button.PressedForeground = Brushes.Black;
+                button.SetInteractionState(true, false);
+                await Assert.That(GetBrushColor(border.Background)).IsEqualTo(Colors.Magenta);
+                await Assert.That(GetBrushColor(button.Foreground)).IsEqualTo(Colors.White);
+                button.SetInteractionState(true, true);
+                await Assert.That(GetBrushColor(border.Background)).IsEqualTo(Colors.Cyan);
+                await Assert.That(GetBrushColor(button.Foreground)).IsEqualTo(Colors.Black);
+                button.IsEnabled = false;
+                await Assert.That(GetBrushColor(border.Background)).IsEqualTo(ResolveColor("ButtonBackgroundDisabled", variant));
+                button.IsEnabled = true;
+                button.SetInteractionState(false, false);
+                await Assert.That(GetBrushColor(border.Background)).IsEqualTo(expected);
+            }
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies gel controls use contrasting text for each accent palette.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task GelButtons_UseThemeAwareAccentForeground()
+    {
+        const double StandardDisabledOpacity = 0.5;
+        var gel = new Controls.GelButton { Content = "Operate" };
+        var repeat = new Controls.GelRepeatButton { Content = "Repeat" };
+        var toggle = new Controls.GelToggleButton { Content = "Toggle" };
+        var window = new Window { Content = new StackPanel { Children = { gel, repeat, toggle } } };
+        try
+        {
+            window.Show();
+            foreach (var variant in new[] { ThemeVariant.Light, ThemeVariant.Dark, ApplicationThemeManager.HighContrastThemeVariant })
+            {
+                window.RequestedThemeVariant = variant;
+                window.UpdateLayout();
+                var expected = ResolveColor("AccentButtonForeground", variant);
+                await Assert.That(GetBrushColor(gel.Foreground)).IsEqualTo(expected);
+                await Assert.That(GetBrushColor(gel.MouseOverForeground)).IsEqualTo(expected);
+                await Assert.That(GetBrushColor(gel.PressedForeground)).IsEqualTo(expected);
+                await Assert.That(GetBrushColor(repeat.Foreground)).IsEqualTo(expected);
+                await Assert.That(GetBrushColor(toggle.Foreground)).IsEqualTo(expected);
+                gel.IsEnabled = false;
+                repeat.IsEnabled = false;
+                toggle.IsEnabled = false;
+                var expectedOpacity = variant == ApplicationThemeManager.HighContrastThemeVariant ? 1 : StandardDisabledOpacity;
+                await Assert.That(gel.Opacity).IsEqualTo(expectedOpacity);
+                await Assert.That(repeat.Opacity).IsEqualTo(expectedOpacity);
+                await Assert.That(toggle.Opacity).IsEqualTo(expectedOpacity);
+                gel.IsEnabled = true;
+                repeat.IsEnabled = true;
+                toggle.IsEnabled = true;
+            }
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies modern checkbox selection glyphs contrast with their accent background.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task ModernCheckBox_UsesThemeAwareSelectionGlyphs()
+    {
+        const double StandardDisabledOpacity = 0.5;
+        const int SelectionGlyphCount = 2;
+        var checkBox = new Controls.CheckBoxModern { Content = "Selected", IsChecked = true, IsThreeState = true };
+        var window = new Window { Content = checkBox };
+        try
+        {
+            window.Show();
+            foreach (var variant in new[] { ThemeVariant.Light, ThemeVariant.Dark, ApplicationThemeManager.HighContrastThemeVariant })
+            {
+                window.RequestedThemeVariant = variant;
+                window.UpdateLayout();
+                var glyphCount = 0;
+                var expected = ResolveColor("AccentButtonForeground", variant);
+                foreach (var descendant in checkBox.GetVisualDescendants())
+                {
+                    if (descendant is PathIcon { Name: "CheckGlyph" } checkGlyph)
+                    {
+                        await Assert.That(GetBrushColor(checkGlyph.Foreground)).IsEqualTo(expected);
+                        glyphCount++;
+                    }
+                    else if (descendant is Border { Name: "IndeterminateGlyph" } indeterminateGlyph)
+                    {
+                        await Assert.That(GetBrushColor(indeterminateGlyph.Background)).IsEqualTo(expected);
+                        glyphCount++;
+                    }
+                }
+
+                await Assert.That(glyphCount).IsEqualTo(SelectionGlyphCount);
+                checkBox.IsEnabled = false;
+                var expectedOpacity = variant == ApplicationThemeManager.HighContrastThemeVariant ? 1 : StandardDisabledOpacity;
+                await Assert.That(checkBox.Opacity).IsEqualTo(expectedOpacity);
+                checkBox.IsEnabled = true;
+            }
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Resolves a semantic brush or a literal appearance color.</summary>
+    /// <param name="key">The semantic key or color name.</param>
+    /// <param name="variant">The active palette.</param>
+    /// <returns>The resolved color.</returns>
+    private static Color ResolveColor(string key, ThemeVariant variant)
+    {
+        if (Application.Current!.TryGetResource(key, variant, out var resource))
+        {
+            return resource is Color color ? color : GetBrushColor(resource as IBrush);
+        }
+
+        return Color.Parse(key);
+    }
+
+    /// <summary>Reads a rendered solid brush.</summary>
+    /// <param name="brush">The rendered brush.</param>
+    /// <returns>The solid color.</returns>
+    private static Color GetBrushColor(IBrush? brush) =>
+        brush is ISolidColorBrush solid ? solid.Color : throw new InvalidOperationException("The template requires a solid brush.");
+
+    /// <summary>Locates the border that displays the button background.</summary>
+    /// <param name="button">The attached button.</param>
+    /// <returns>The rendered root border.</returns>
+    private static Border GetRootBorder(Control button)
+    {
+        foreach (var descendant in button.GetVisualDescendants())
+        {
+            if (descendant is Border { Name: "RootBorder" } border)
+            {
+                return border;
+            }
+        }
+
+        throw new InvalidOperationException("The button template did not render its root border.");
+    }
+
+    /// <summary>Exposes interaction pseudo-classes for deterministic template verification.</summary>
+    private sealed class InteractionButton : Controls.Button
+    {
+        /// <summary>Sets pointer-over and pressed states without desktop input timing.</summary>
+        /// <param name="pointerOver">Whether the pointer is over the button.</param>
+        /// <param name="pressed">Whether the button is pressed.</param>
+        public void SetInteractionState(bool pointerOver, bool pressed)
+        {
+            PseudoClasses.Set(":pointerover", pointerOver);
+            PseudoClasses.Set(":pressed", pressed);
+        }
+    }
+}

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaControlCoverageTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaControlCoverageTests.cs
@@ -4,16 +4,21 @@
 
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.VisualTree;
 using CrissCross.Avalonia.UI.Controls;
 using CrissCrossExpander = CrissCross.Avalonia.UI.Controls.Expander;
 
 namespace CrissCross.NavigationView.Tests;
 
 /// <summary>Covers the constructible Avalonia control catalog's public initialization paths.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
 public sealed class AvaloniaControlCoverageTests
 {
     /// <summary>The number of controls in the lightweight construction catalog.</summary>
     private const int ControlCount = 14;
+
+    /// <summary>The number of optional actions in the empty-state template.</summary>
+    private const int EmptyStateActionCount = 2;
 
     /// <summary>Verifies lightweight controls can be constructed without a visual host.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
@@ -48,7 +53,7 @@ public sealed class AvaloniaControlCoverageTests
     /// <summary>Verifies every public parameterless Avalonia styled element can be constructed from the UI assembly.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
     [Test]
-    public async Task PublicParameterlessStyledElements_WhenConstructed_ProduceStyledElements()
+    public Task PublicParameterlessStyledElements_WhenConstructed_ProduceStyledElements() => AvaloniaTestUiThread.RunAsync(static async () =>
     {
         var assembly = typeof(AppBar).Assembly;
         var constructedCount = 0;
@@ -56,7 +61,7 @@ public sealed class AvaloniaControlCoverageTests
 
         foreach (var type in assembly.GetExportedTypes())
         {
-            if (type.IsAbstract || !typeof(StyledElement).IsAssignableFrom(type) || type.GetConstructor(Type.EmptyTypes) is null)
+            if (type.IsAbstract || type.ContainsGenericParameters || !typeof(StyledElement).IsAssignableFrom(type) || type.GetConstructor(Type.EmptyTypes) is null)
             {
                 continue;
             }
@@ -80,7 +85,7 @@ public sealed class AvaloniaControlCoverageTests
 
         await Assert.That(constructedCount).IsGreaterThan(ControlCount);
         await Assert.That(roundTrippedPropertyCount).IsGreaterThan(0);
-    }
+    });
 
     /// <summary>Verifies card, badge, and chip public styled properties retain state and derived flags.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
@@ -98,6 +103,45 @@ public sealed class AvaloniaControlCoverageTests
         await Assert.That(chip.Icon).IsEqualTo("icon");
         await Assert.That(chip.IsSelected).IsTrue();
         await Assert.That(chip.IsRemovable).IsTrue();
+    }
+
+    /// <summary>Verifies missing empty-state models never expose blank action buttons.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task EmptyState_WhenModelIsCleared_HidesBothActions()
+    {
+        var control = new EmptyState();
+        var window = new global::Avalonia.Controls.Window { Content = control };
+        try
+        {
+            window.Show();
+            window.UpdateLayout();
+            var actionCount = 0;
+            foreach (var descendant in control.GetVisualDescendants())
+            {
+                if (descendant is global::Avalonia.Controls.Button action)
+                {
+                    await Assert.That(action.IsVisible).IsFalse();
+                    actionCount++;
+                }
+            }
+
+            await Assert.That(actionCount).IsEqualTo(EmptyStateActionCount);
+            control.Model = new("No results");
+            control.Model = null;
+            window.UpdateLayout();
+            foreach (var descendant in control.GetVisualDescendants())
+            {
+                if (descendant is global::Avalonia.Controls.Button action)
+                {
+                    await Assert.That(action.IsVisible).IsFalse();
+                }
+            }
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     /// <summary>Determines whether a property can safely be round-tripped by the construction catalog.</summary>

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaConverterCoverageTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaConverterCoverageTests.cs
@@ -11,6 +11,7 @@ using CrissCross.Avalonia.UI.Extensions;
 namespace CrissCross.NavigationView.Tests;
 
 /// <summary>Exercises converter success and fallback behavior without a visual host.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
 public sealed class AvaloniaConverterCoverageTests
 {
     /// <summary>The fallback value supplied to converters.</summary>

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaExtensionCoverageTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaExtensionCoverageTests.cs
@@ -8,6 +8,7 @@ using CrissCross.Avalonia.UI.Extensions;
 namespace CrissCross.NavigationView.Tests;
 
 /// <summary>Exercises visual-tree helper behavior with an in-memory control tree.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
 public sealed class AvaloniaExtensionCoverageTests
 {
     /// <summary>Verifies child traversal and missing-parent fallback behavior.</summary>

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaGalleryThemeCoverageTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaGalleryThemeCoverageTests.cs
@@ -4,15 +4,17 @@
 
 using Avalonia.Controls;
 using Avalonia.Styling;
+using CrissCross.Avalonia.UI.Appearance;
 using CrissCross.Avalonia.UI.Gallery.Views.Pages;
 
 namespace CrissCross.NavigationView.Tests;
 
 /// <summary>Exercises every gallery page under the supported application theme variants.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
 public sealed class AvaloniaGalleryThemeCoverageTests
 {
     /// <summary>The number of catalog pages rendered for each theme.</summary>
-    private const int GalleryPageCount = 14;
+    private const int GalleryPageCount = 15;
 
     /// <summary>Verifies every gallery page can initialize with the dark variant requested.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
@@ -24,10 +26,15 @@ public sealed class AvaloniaGalleryThemeCoverageTests
     [Test]
     public Task GalleryPages_WhenLightThemeIsRequested_Initialize() => AssertPagesInitializeAsync(ThemeVariant.Light);
 
+    /// <summary>Verifies every gallery page inherits the custom high contrast variant.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task GalleryPages_WhenHighContrastIsRequested_Initialize() => AssertPagesInitializeAsync(ApplicationThemeManager.HighContrastThemeVariant);
+
     /// <summary>Creates and verifies every page for a requested theme variant.</summary>
     /// <param name="themeVariant">The requested theme variant.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    private static async Task AssertPagesInitializeAsync(ThemeVariant themeVariant)
+    private static Task AssertPagesInitializeAsync(ThemeVariant themeVariant) => AvaloniaTestUiThread.RunAsync(async () =>
     {
         Control[] pages =
         [
@@ -40,6 +47,7 @@ public sealed class AvaloniaGalleryThemeCoverageTests
             new DatePickerPageView(),
             new FeaturePlaygroundPageView(),
             new HomePageView(),
+            new IndustrialPageView(),
             new InputPageView(),
             new ProgressPageView(),
             new RadioButtonPageView(),
@@ -50,8 +58,9 @@ public sealed class AvaloniaGalleryThemeCoverageTests
         await Assert.That(pages.Length).IsEqualTo(GalleryPageCount);
         foreach (var page in pages)
         {
-            page.Tag = themeVariant;
-            await Assert.That(page.Tag).IsSameReferenceAs(themeVariant);
+            var scope = new ThemeVariantScope { RequestedThemeVariant = themeVariant, Child = page };
+            await Assert.That(page.ActualThemeVariant).IsSameReferenceAs(themeVariant);
+            scope.Child = null;
         }
-    }
+    });
 }

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaNavigationHostTransitionCoverageTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaNavigationHostTransitionCoverageTests.cs
@@ -2,8 +2,11 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
+using ReactiveUI;
+using Splat;
 using CoreNavigationWindow = CrissCross.Avalonia.NavigationWindow;
 using CoreRoutedViewHost = CrissCross.Avalonia.ViewModelRoutedViewHost;
 using CoreTransitioningContentControl = CrissCross.Avalonia.ReactiveTransitioningContentControl;
@@ -16,6 +19,7 @@ using ReactiveUseNavigation = CrissCross.Reactive.IUseNavigation;
 namespace CrissCross.NavigationView.Tests;
 
 /// <summary>Covers Avalonia navigation window, routed host, transition, and theme resource behavior.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
 public sealed class AvaloniaNavigationHostTransitionCoverageTests
 {
     /// <summary>The explicit host name used by the core navigation window.</summary>
@@ -24,10 +28,56 @@ public sealed class AvaloniaNavigationHostTransitionCoverageTests
     /// <summary>The explicit host name used by the reactive navigation window.</summary>
     private const string ReactiveHostName = "reactive-window-host";
 
+    /// <summary>The expected first-window history count after two navigation requests.</summary>
+    private const int ExpectedSharedVisualHistoryCount = 2;
+
+    /// <summary>Allows the short transition timer to finish on the native dispatcher.</summary>
+    private static readonly TimeSpan AnimationCompletionWait = TimeSpan.FromMilliseconds(300);
+
+    /// <summary>Verifies rapid content replacement completes without blocking or losing the latest visual.</summary>
+    /// <param name="reactive">Whether to exercise the reactive package variant.</param>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task TransitioningControls_RapidReplacementDisplaysTheLatestContent(bool reactive)
+    {
+        ContentControl control = reactive ? new ReactiveTransitioningContentControl() : new CoreTransitioningContentControl();
+        var lifetime = (IDisposable)control;
+        var initial = new TextBlock { Text = "Initial content" };
+        var latest = new TextBlock { Text = "Latest content" };
+        control.Content = initial;
+        var window = new Window { Content = control };
+        var assemblyName = reactive ? "CrissCross.Avalonia.Reactive" : "CrissCross.Avalonia";
+        window.Styles.Add((Styles)LoadStyles($"avares://{assemblyName}/Themes/Index.axaml"));
+        try
+        {
+            window.Show();
+            window.UpdateLayout();
+            await Assert.That(initial.IsEffectivelyVisible).IsTrue();
+            await Assert.That(TopLevel.GetTopLevel(initial)).IsSameReferenceAs(window);
+            control.Content = new TextBlock { Text = "Intermediate content" };
+            control.Content = latest;
+            await Task.Delay(AnimationCompletionWait);
+            window.UpdateLayout();
+            await Assert.That(TopLevel.GetTopLevel(latest)).IsSameReferenceAs(window);
+            await Assert.That(latest.IsEffectivelyVisible).IsTrue();
+            await Assert.That(TopLevel.GetTopLevel(initial)).IsNull();
+            await Assert.That(control is CoreTransitioningContentControl { IsDisposed: false } or ReactiveTransitioningContentControl { IsDisposed: false }).IsTrue();
+            control.Content = new TextBlock { Text = "Dispose during transition" };
+        }
+        finally
+        {
+            lifetime.Dispose();
+            await Task.Delay(AnimationCompletionWait);
+            window.Close();
+        }
+    }
+
     /// <summary>Verifies named core and reactive navigation windows configure their routed frames.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
     [Test]
-    public async Task NavigationWindows_WhenInitializedWithNames_ConfigureMatchingNavigationFrames()
+    public Task NavigationWindows_WhenInitializedWithNames_ConfigureMatchingNavigationFrames() => AvaloniaTestUiThread.RunAsync(static async () =>
     {
         var coreWindow = new TestCoreNavigationWindow { HostName = CoreHostName, NavigateBackIsEnabled = false };
         var reactiveWindow = new TestReactiveNavigationWindow { HostName = ReactiveHostName, NavigateBackIsEnabled = false };
@@ -41,12 +91,12 @@ public sealed class AvaloniaNavigationHostTransitionCoverageTests
         await Assert.That(reactiveWindow.NavigationFrame?.HostName).IsEqualTo(ReactiveHostName);
         await Assert.That(reactiveWindow.NavigationFrame?.Name).IsEqualTo(ReactiveHostName);
         await Assert.That(reactiveWindow.NavigationFrame?.NavigateBackIsEnabled ?? true).IsFalse();
-    }
+    });
 
     /// <summary>Verifies unnamed core and reactive navigation windows allocate stable generated host names.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
     [Test]
-    public async Task NavigationWindows_WhenInitializedWithoutNames_AllocateGeneratedNavigationHostNames()
+    public Task NavigationWindows_WhenInitializedWithoutNames_AllocateGeneratedNavigationHostNames() => AvaloniaTestUiThread.RunAsync(static async () =>
     {
         var coreWindow = new TestCoreNavigationWindow();
         var reactiveWindow = new TestReactiveNavigationWindow();
@@ -61,7 +111,56 @@ public sealed class AvaloniaNavigationHostTransitionCoverageTests
         await Assert.That(reactiveHostName!).StartsWith("__crisscross_navhost_NavigationWindow_", StringComparison.Ordinal);
         await Assert.That(coreWindow.NavigationFrame?.HostName).IsEqualTo(coreHostName);
         await Assert.That(reactiveWindow.NavigationFrame?.HostName).IsEqualTo(reactiveHostName);
-    }
+    });
+
+    /// <summary>Verifies closing one window that shares a visual frame alias keeps the other window's unique host channel registered.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public Task NavigationWindows_WithSharedVisualFrameAlias_CloseOneKeepsOtherHostRegistered() => AvaloniaTestUiThread.RunAsync(static async () =>
+    {
+        const string visualHostName = "mainNavHost";
+        const string firstHostName = "mainNavHost-first";
+        const string secondHostName = "mainNavHost-second";
+        var firstWindow = new TestCoreNavigationWindow { HostName = firstHostName };
+        var secondWindow = new TestCoreNavigationWindow { HostName = secondHostName };
+
+        firstWindow.InitializeForTest();
+        secondWindow.InitializeForTest();
+        var firstFrame = firstWindow.NavigationFrame!;
+        var secondFrame = secondWindow.NavigationFrame!;
+        firstFrame.Name = visualHostName;
+        firstFrame.HostName = visualHostName;
+        secondFrame.Name = visualHostName;
+        secondFrame.HostName = visualHostName;
+
+        var previousMainThreadScheduler = RxSchedulers.MainThreadScheduler;
+        firstFrame.ViewLocator = new WindowNavigationViewLocator();
+        secondFrame.ViewLocator = new WindowNavigationViewLocator();
+        RxSchedulers.MainThreadScheduler = ImmediateScheduler.Instance;
+
+        try
+        {
+            AppLocator.CurrentMutable.UnregisterAll<WindowNavigationViewModel>();
+            AppLocator.CurrentMutable.RegisterConstant(new WindowNavigationViewModel());
+            firstWindow.SetMainNavigationHost(firstFrame);
+            secondWindow.SetMainNavigationHost(secondFrame);
+
+            firstWindow.NavigateToView(new NavigationKeyRequest<WindowNavigationViewModel>());
+            secondWindow.CloseForTest();
+            firstWindow.NavigateToView(new NavigationKeyRequest<WindowNavigationViewModel>());
+            firstWindow.CloseForTest();
+
+            await Assert.That(firstFrame.HostName).IsEqualTo(firstHostName);
+            await Assert.That(secondFrame.HostName).IsEqualTo(secondHostName);
+            await Assert.That(firstFrame.NavigationStack.Count).IsEqualTo(ExpectedSharedVisualHistoryCount);
+            await Assert.That(secondFrame.NavigationStack).IsEmpty();
+        }
+        finally
+        {
+            RxSchedulers.MainThreadScheduler = previousMainThreadScheduler;
+            AppLocator.CurrentMutable.UnregisterAll<WindowNavigationViewModel>();
+        }
+    });
 
     /// <summary>Verifies routed hosts trim history while back navigation is disabled and publish their final state.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
@@ -154,11 +253,63 @@ public sealed class AvaloniaNavigationHostTransitionCoverageTests
     /// <returns>The resource declared by the URI.</returns>
     private static object LoadStyles(string resourceUri) => AvaloniaXamlLoader.Load(new(resourceUri));
 
+    /// <summary>Simple view model used by the public navigation lifecycle regression.</summary>
+    private sealed class WindowNavigationViewModel : RxObject;
+
+    /// <summary>Simple view used by the public navigation lifecycle regression.</summary>
+    private sealed class WindowNavigationView : Control, IViewFor<WindowNavigationViewModel>
+    {
+        /// <summary>Gets or sets the strongly typed view model.</summary>
+        public WindowNavigationViewModel? ViewModel { get; set; }
+
+        /// <summary>Gets or sets the weakly typed view model.</summary>
+        object? IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (WindowNavigationViewModel?)value;
+        }
+    }
+
+    /// <summary>View locator used by the public navigation lifecycle regression.</summary>
+    private sealed class WindowNavigationViewLocator : IViewLocator
+    {
+        /// <inheritdoc/>
+        public IViewFor<TViewModel> ResolveView<TViewModel>()
+            where TViewModel : class => (IViewFor<TViewModel>)(object)ResolveTypedView<TViewModel>();
+
+        /// <inheritdoc/>
+        public IViewFor<TViewModel> ResolveView<TViewModel>(string? contract)
+            where TViewModel : class => (IViewFor<TViewModel>)(object)ResolveTypedView<TViewModel>();
+
+        /// <inheritdoc/>
+        public IViewFor? ResolveView(object? instance) => ResolveUntypedView(instance);
+
+        /// <inheritdoc/>
+        public IViewFor? ResolveView(object? instance, string? contract) => ResolveUntypedView(instance);
+
+        /// <summary>Resolves a typed test view.</summary>
+        /// <typeparam name="TViewModel">The view model type.</typeparam>
+        /// <returns>The resolved view.</returns>
+        private static WindowNavigationView ResolveTypedView<TViewModel>()
+            where TViewModel : class => typeof(TViewModel) == typeof(WindowNavigationViewModel)
+                ? new WindowNavigationView()
+                : throw new InvalidOperationException($"Unsupported view model type {typeof(TViewModel).FullName}.");
+
+        /// <summary>Resolves an untyped test view.</summary>
+        /// <param name="instance">The view model.</param>
+        /// <returns>The resolved view.</returns>
+        private static WindowNavigationView? ResolveUntypedView(object? instance) =>
+            instance is WindowNavigationViewModel ? new WindowNavigationView() : null;
+    }
+
     /// <summary>Exposes protected core navigation-window initialization for verification.</summary>
     private sealed class TestCoreNavigationWindow : CoreNavigationWindow
     {
         /// <summary>Initializes the navigation window.</summary>
         public void InitializeForTest() => OnInitialized();
+
+        /// <summary>Closes the navigation window for lifecycle tests.</summary>
+        public void CloseForTest() => OnClosed(EventArgs.Empty);
     }
 
     /// <summary>Exposes protected reactive navigation-window initialization for verification.</summary>

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaNavigationUserControlRegressionTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaNavigationUserControlRegressionTests.cs
@@ -7,6 +7,7 @@ using AvaloniaNavigationUserControl = CrissCross.Avalonia.NavigationUserControl;
 namespace CrissCross.NavigationView.Tests;
 
 /// <summary>Regression tests for Avalonia navigation host setup.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
 public class AvaloniaNavigationUserControlRegressionTests
 {
     /// <summary>The configured navigation host name.</summary>

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaProcessValueIndicatorTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaProcessValueIndicatorTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using CrissCross.Avalonia.UI.Controls;
+
+namespace CrissCross.NavigationView.Tests;
+
+/// <summary>Verifies Avalonia industrial readouts follow the shared state and reset contract.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
+public sealed class AvaloniaProcessValueIndicatorTests
+{
+    /// <summary>Verifies each condition updates every read-only projection before resetting to the safe fallback.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task StateTransitions_ProjectSharedConditionsAndReset()
+    {
+        const double maximum = 100;
+        const double normal = 50;
+        const double lowLimit = 10;
+        const double highLimit = 90;
+        const string label = "Level";
+        ProcessValueState[] states =
+        [
+            new(label, normal, "%", 0, maximum, lowLimit, highLimit),
+            new(label, 0, "%", 0, maximum, lowLimit, highLimit),
+            new(label, maximum, "%", 0, maximum, lowLimit, highLimit),
+            new(label, null, "%", 0, maximum),
+            new(label, normal, "%", maximum, 0)
+        ];
+        var indicator = new ProcessValueIndicator();
+        indicator.BeginInit();
+        indicator.EndInit();
+        foreach (var state in states)
+        {
+            indicator.State = state;
+            await Assert.That(indicator.Label).IsEqualTo(state.Label);
+            await Assert.That(indicator.DisplayText).IsEqualTo(state.DisplayText);
+            await Assert.That(indicator.StatusText).IsEqualTo(state.StatusText);
+            await Assert.That(indicator.Percentage).IsEqualTo(state.Percentage);
+            await Assert.That(indicator.NormalizedValue).IsEqualTo(state.NormalizedValue);
+            await Assert.That(indicator.HasValidValue).IsEqualTo(state.HasValidValue);
+            await Assert.That(indicator.IsAlarm).IsEqualTo(state.IsAlarm);
+            await Assert.That(indicator.Status).IsEqualTo(state.Status);
+        }
+
+        indicator.State = null;
+        await Assert.That(indicator.Label).IsEqualTo("Process value");
+        await Assert.That(indicator.DisplayText).IsEqualTo("—");
+        await Assert.That(indicator.StatusText).IsEqualTo("Bad quality");
+        await Assert.That(indicator.Percentage).IsEqualTo(0);
+        await Assert.That(indicator.HasValidValue).IsFalse();
+        await Assert.That(indicator.IsAlarm).IsFalse();
+    }
+}

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaServiceCoverageTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaServiceCoverageTests.cs
@@ -8,6 +8,7 @@ using CrissCross.Avalonia.UI.Controls;
 namespace CrissCross.NavigationView.Tests;
 
 /// <summary>Exercises navigation and snackbar service guard behavior without an application host.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
 public sealed class AvaloniaServiceCoverageTests
 {
     /// <summary>Verifies services report absent host controls through their documented guards.</summary>

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaTestAssemblyInitialization.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaTestAssemblyInitialization.cs
@@ -2,19 +2,18 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Avalonia;
-using CrissCross.Avalonia.UI.Gallery;
-using ReactiveUI.Avalonia;
-
 namespace CrissCross.NavigationView.Tests;
 
 /// <summary>Initializes Avalonia and ReactiveUI services for navigation-view tests.</summary>
 public static class AvaloniaTestAssemblyInitialization
 {
     /// <summary>Builds the Avalonia platform and ReactiveUI activation services once for the test assembly.</summary>
+    /// <returns>The initialization task.</returns>
     [Before(HookType.Assembly)]
-    public static void Initialize() => AppBuilder.Configure<App>()
-        .UsePlatformDetect()
-        .UseReactiveUI(static _ => { })
-        .SetupWithoutStarting();
+    public static Task Initialize() => AvaloniaTestUiThread.EnsureStartedAsync();
+
+    /// <summary>Stops the shared Avalonia UI thread after the test assembly completes.</summary>
+    /// <returns>The shutdown task.</returns>
+    [After(HookType.Assembly)]
+    public static Task Shutdown() => AvaloniaTestUiThread.ShutdownAsync();
 }

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaTestUiThread.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaTestUiThread.cs
@@ -1,0 +1,92 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Avalonia;
+using Avalonia.Threading;
+using CrissCross.Avalonia.UI.Gallery;
+using ReactiveUI.Avalonia;
+
+namespace CrissCross.NavigationView.Tests;
+
+/// <summary>Runs Avalonia UI tests on the dispatcher thread that owns the test compositor.</summary>
+internal static class AvaloniaTestUiThread
+{
+    /// <summary>Signals completion of Avalonia platform initialization.</summary>
+    private static readonly TaskCompletionSource Started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>Signals termination of the dispatcher loop.</summary>
+    private static readonly TaskCompletionSource Stopped = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>Starts the dispatcher thread once for the test assembly.</summary>
+    private static readonly Lazy<Task> Startup = new(StartThread);
+
+    /// <summary>Initializes Avalonia on the shared test UI thread.</summary>
+    /// <returns>The platform initialization task.</returns>
+    internal static Task EnsureStartedAsync() => Startup.Value;
+
+    /// <summary>Runs a test action on the shared Avalonia UI thread.</summary>
+    /// <param name="action">The action to run.</param>
+    /// <returns>The dispatched action task.</returns>
+    internal static async Task RunAsync(Func<Task> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        await EnsureStartedAsync();
+        var execution = Dispatcher.UIThread.InvokeAsync(action);
+        var completed = await Task.WhenAny(execution, Stopped.Task);
+        if (ReferenceEquals(completed, Stopped.Task))
+        {
+            await Stopped.Task;
+            throw new InvalidOperationException("The Avalonia dispatcher stopped before the test action completed.");
+        }
+
+        await execution;
+    }
+
+    /// <summary>Stops the shared Avalonia UI thread after the test assembly completes.</summary>
+    /// <returns>The dispatcher shutdown task.</returns>
+    internal static async Task ShutdownAsync()
+    {
+        if (!Startup.IsValueCreated)
+        {
+            return;
+        }
+
+        await Startup.Value;
+        Dispatcher.UIThread.BeginInvokeShutdown(DispatcherPriority.Send);
+        await Stopped.Task;
+    }
+
+    /// <summary>Creates and starts the dedicated STA dispatcher thread.</summary>
+    /// <returns>The platform initialization task.</returns>
+    private static Task StartThread()
+    {
+        var thread = new Thread(RunMessageLoop) { IsBackground = true, Name = "CrissCross Avalonia test UI thread" };
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        return Started.Task;
+    }
+
+    /// <summary>Runs the Avalonia platform setup and native dispatcher loop.</summary>
+    private static void RunMessageLoop()
+    {
+        try
+        {
+            _ = AppBuilder.Configure<App>()
+                .UsePlatformDetect()
+                .UseReactiveUI(static _ => { })
+                .SetupWithoutStarting();
+            Started.SetResult();
+            Dispatcher.UIThread.MainLoop(CancellationToken.None);
+        }
+        catch (Exception exception)
+        {
+            _ = Started.TrySetException(exception);
+            _ = Stopped.TrySetException(exception);
+        }
+        finally
+        {
+            _ = Stopped.TrySetResult();
+        }
+    }
+}

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaThemeResourceReferenceTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaThemeResourceReferenceTests.cs
@@ -1,0 +1,187 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Styling;
+
+namespace CrissCross.NavigationView.Tests;
+
+/// <summary>Verifies Avalonia theme resource references resolve to project or verified Fluent keys.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
+public sealed partial class AvaloniaThemeResourceReferenceTests
+{
+    /// <summary>Provides the Avalonia UI project directory name.</summary>
+    private const string AvaloniaUiProject = "CrissCross.Avalonia.UI";
+
+    /// <summary>Provides the Avalonia UI gallery project directory name.</summary>
+    private const string AvaloniaGalleryProject = "CrissCross.Avalonia.UI.Gallery";
+
+    /// <summary>Provides the markup file search pattern.</summary>
+    private const string MarkupFilePattern = "*.axaml";
+
+    /// <summary>Provides the x namespace used by Avalonia resource dictionaries.</summary>
+    private static readonly XNamespace XamlNamespace = "http://schemas.microsoft.com/winfx/2006/xaml";
+
+    /// <summary>Provides resource keys that are verified in Avalonia.Themes.Fluent.</summary>
+    private static readonly HashSet<string> VerifiedFluentResourceKeys = new(StringComparer.Ordinal) { "SystemAccentColorLight1", "SystemAccentColorLight2" };
+
+    /// <summary>Provides the source root used to locate Avalonia markup files.</summary>
+    private static readonly string SourceRoot = LocateSourceRoot();
+
+    /// <summary>Verifies all Avalonia UI and gallery resource references use defined resource keys.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task AvaloniaMarkupResourceReferences_ResolveToProjectOrVerifiedFluentResources()
+    {
+        var markupFiles = GetMarkupFiles();
+        var definedKeys = ReadDefinedResourceKeys(markupFiles);
+        var unresolvedReferences = GetUnresolvedResourceReferences(markupFiles, definedKeys);
+
+        await Assert.That(unresolvedReferences).IsEmpty();
+    }
+
+    /// <summary>Reads all Avalonia UI and gallery markup files.</summary>
+    /// <returns>The discovered markup files.</returns>
+    private static string[] GetMarkupFiles()
+    {
+        var files = new List<string>();
+        foreach (var projectName in new[] { AvaloniaUiProject, AvaloniaGalleryProject })
+        {
+            files.AddRange(Directory.GetFiles(
+                Path.Combine(SourceRoot, projectName),
+                MarkupFilePattern,
+                SearchOption.AllDirectories));
+        }
+
+        files.Sort(StringComparer.Ordinal);
+        return files.ToArray();
+    }
+
+    /// <summary>Reads every keyed project resource from the markup files.</summary>
+    /// <param name="markupFiles">The markup files to inspect.</param>
+    /// <returns>The defined resource keys.</returns>
+    private static HashSet<string> ReadDefinedResourceKeys(IEnumerable<string> markupFiles)
+    {
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var markupFile in markupFiles)
+        {
+            foreach (var element in XDocument.Load(markupFile).Descendants())
+            {
+                AddAttributeValue(keys, element.Attribute(XamlNamespace + "Key"));
+                AddAttributeValue(keys, element.Attribute("Key"));
+            }
+        }
+
+        return keys;
+    }
+
+    /// <summary>Gets resource references that are not resolved by project or verified Fluent resource keys.</summary>
+    /// <param name="markupFiles">The markup files to inspect.</param>
+    /// <param name="definedKeys">The project-defined resource keys.</param>
+    /// <returns>The unresolved references formatted for assertion output.</returns>
+    private static string[] GetUnresolvedResourceReferences(IEnumerable<string> markupFiles, HashSet<string> definedKeys)
+    {
+        var unresolvedReferences = new List<string>();
+        foreach (var markupFile in markupFiles)
+        {
+            var text = File.ReadAllText(markupFile);
+            var matches = ResourceReferenceExpression().Matches(text);
+            for (var matchIndex = 0; matchIndex < matches.Count; matchIndex++)
+            {
+                var match = (Match)matches[matchIndex];
+                var key = match.Groups[1].Value;
+                if (definedKeys.Contains(key) || VerifiedFluentResourceKeys.Contains(key) || IsNativeControlTheme(key))
+                {
+                    continue;
+                }
+
+                unresolvedReferences.Add($"{Path.GetRelativePath(SourceRoot, markupFile)}:{GetLineNumber(text, match.Index)} uses undefined resource '{key}'.");
+            }
+        }
+
+        unresolvedReferences.Sort(StringComparer.Ordinal);
+        return unresolvedReferences.ToArray();
+    }
+
+    /// <summary>Resolves a typed native control-theme key against the running application's resources.</summary>
+    /// <param name="key">The complete resource key expression.</param>
+    /// <returns>Whether the referenced native theme exists.</returns>
+    private static bool IsNativeControlTheme(string key)
+    {
+        const string typePrefix = "{x:Type ";
+        const string primitivesPrefix = "primitives:";
+        if (!key.StartsWith(typePrefix, StringComparison.Ordinal) || !key.EndsWith('}'))
+        {
+            return false;
+        }
+
+        var typeName = key[typePrefix.Length..^1].Trim();
+        var fullName = typeName.StartsWith(primitivesPrefix, StringComparison.Ordinal)
+            ? $"Avalonia.Controls.Primitives.{typeName[primitivesPrefix.Length..]}"
+            : $"Avalonia.Controls.{typeName}";
+        var type = typeof(Control).Assembly.GetType(fullName);
+        return type is not null
+            && Application.Current!.TryGetResource(type, ThemeVariant.Default, out var resource)
+            && resource is ControlTheme theme
+            && theme.TargetType == type;
+    }
+
+    /// <summary>Adds an attribute value to a resource key set.</summary>
+    /// <param name="keys">The key set.</param>
+    /// <param name="attribute">The attribute to read.</param>
+    private static void AddAttributeValue(HashSet<string> keys, XAttribute? attribute)
+    {
+        if (string.IsNullOrWhiteSpace(attribute?.Value))
+        {
+            return;
+        }
+
+        _ = keys.Add(attribute.Value);
+    }
+
+    /// <summary>Gets the one-based line number for a character index.</summary>
+    /// <param name="text">The complete file text.</param>
+    /// <param name="index">The character index.</param>
+    /// <returns>The one-based line number.</returns>
+    private static int GetLineNumber(string text, int index)
+    {
+        var line = 1;
+        for (var i = 0; i < index; i++)
+        {
+            if (text[i] == '\n')
+            {
+                line++;
+            }
+        }
+
+        return line;
+    }
+
+    /// <summary>Locates the source root while supporting MTP's test working directory.</summary>
+    /// <returns>The source root path.</returns>
+    private static string LocateSourceRoot()
+    {
+        var current = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "CrissCross.slnx")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate CrissCross.slnx from the current test working directory.");
+    }
+
+    /// <summary>Gets the resource reference parser.</summary>
+    /// <returns>The resource reference parser.</returns>
+    [GeneratedRegex(@"\{(?:DynamicResource|StaticResource)\s+(\{x:Type\s+[^\}]+\}|[^\},\s]+)", RegexOptions.CultureInvariant)]
+    private static partial Regex ResourceReferenceExpression();
+}

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaThinWrapperStyleKeyTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaThinWrapperStyleKeyTests.cs
@@ -1,0 +1,243 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.IO;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Controls.Primitives;
+using CrissCrossContextMenu = CrissCross.Avalonia.UI.Controls.ContextMenu;
+using CrissCrossDynamicScrollBar = CrissCross.Avalonia.UI.Controls.DynamicScrollBar;
+using CrissCrossDynamicScrollViewer = CrissCross.Avalonia.UI.Controls.DynamicScrollViewer;
+using CrissCrossExpander = CrissCross.Avalonia.UI.Controls.Expander;
+using CrissCrossGifImage = CrissCross.Avalonia.UI.Controls.GifImage;
+using CrissCrossIconElement = CrissCross.Avalonia.UI.Controls.IconElement;
+using CrissCrossImage = CrissCross.Avalonia.UI.Controls.Image;
+using CrissCrossItemsControl = CrissCross.Avalonia.UI.Controls.ItemsControl;
+using CrissCrossLabel = CrissCross.Avalonia.UI.Controls.Label;
+using CrissCrossListBox = CrissCross.Avalonia.UI.Controls.ListBox;
+using CrissCrossListView = CrissCross.Avalonia.UI.Controls.ListView;
+using CrissCrossMenu = CrissCross.Avalonia.UI.Controls.Menu;
+using CrissCrossMenuItem = CrissCross.Avalonia.UI.Controls.MenuItem;
+using CrissCrossScrollBar = CrissCross.Avalonia.UI.Controls.ScrollBar;
+using CrissCrossScrollViewer = CrissCross.Avalonia.UI.Controls.ScrollViewer;
+using CrissCrossSeparator = CrissCross.Avalonia.UI.Controls.Separator;
+using CrissCrossTabControl = CrissCross.Avalonia.UI.Controls.TabControl;
+using CrissCrossTextBlock = CrissCross.Avalonia.UI.Controls.TextBlock;
+using CrissCrossTreeView = CrissCross.Avalonia.UI.Controls.TreeView;
+using CrissCrossVirtualizingGridView = CrissCross.Avalonia.UI.Controls.VirtualizingGridView;
+using CrissCrossVirtualizingItemsControl = CrissCross.Avalonia.UI.Controls.VirtualizingItemsControl;
+using CrissCrossWindow = CrissCross.Avalonia.UI.Controls.Window;
+using NativeScrollBar = Avalonia.Controls.Primitives.ScrollBar;
+
+namespace CrissCross.NavigationView.Tests;
+
+/// <summary>Verifies thin Avalonia UI wrappers keep their native control themes.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
+public sealed class AvaloniaThinWrapperStyleKeyTests
+{
+    /// <summary>Provides the Avalonia UI project directory name.</summary>
+    private const string AvaloniaUiProject = "CrissCross.Avalonia.UI";
+
+    /// <summary>Provides the themes directory name.</summary>
+    private const string ThemesDirectory = "Themes";
+
+    /// <summary>Provides the CheckBox theme filename.</summary>
+    private const string CheckBoxThemeFile = "CheckBox.axaml";
+
+    /// <summary>Provides the Button theme filename.</summary>
+    private const string ButtonThemeFile = "Button.axaml";
+
+    /// <summary>Provides the RadioButton theme filename.</summary>
+    private const string RadioButtonThemeFile = "RadioButton.axaml";
+
+    /// <summary>Provides the semantic primary foreground brush key.</summary>
+    private const string PrimaryForegroundBinding = "TextFillColorPrimaryBrush";
+
+    /// <summary>Provides the disabled foreground brush key.</summary>
+    private const string DisabledForegroundBinding = "TextFillColorDisabledBrush";
+
+    /// <summary>Provides the button disabled foreground brush key.</summary>
+    private const string ButtonDisabledForegroundBinding = "ButtonForegroundDisabled";
+
+    /// <summary>Provides the attached text foreground binding used by generated string content.</summary>
+    private const string ContentPresenterForegroundBinding = "TextElement.Foreground=\"{TemplateBinding Foreground}\"";
+
+    /// <summary>Provides the checked radio indicator brush binding.</summary>
+    private const string RadioButtonCheckedIndicatorBinding = "RadioButtonOuterEllipseCheckedStroke";
+
+    /// <summary>Provides the transparent control fill brush binding.</summary>
+    private const string TransparentControlFillBinding = "ControlAltFillColorTransparentBrush";
+
+    /// <summary>Provides the disabled control stroke brush binding.</summary>
+    private const string DisabledControlStrokeBinding = "ControlStrongStrokeColorDisabledBrush";
+
+    /// <summary>Provides the obsolete checked radio fill key that is not in the theme dictionaries.</summary>
+    private const string UndefinedRadioButtonCheckedFillBinding = "RadioButtonOuterEllipseFillChecked";
+
+    /// <summary>Provides the obsolete checked radio stroke key that is not in the theme dictionaries.</summary>
+    private const string UndefinedRadioButtonCheckedStrokeBinding = "RadioButtonOuterEllipseStrokeChecked";
+
+    /// <summary>Provides the obsolete pointer-over radio stroke key that is not in the theme dictionaries.</summary>
+    private const string UndefinedRadioButtonPointerOverStrokeBinding = "RadioButtonOuterEllipseStrokePointerOver";
+
+    /// <summary>Provides the legacy theme foreground brush key that does not exist in the Avalonia semantic palette.</summary>
+    private const string LegacyThemeForegroundBinding = "ThemeForegroundBrush";
+
+    /// <summary>Provides the source root used to locate Avalonia UI theme files.</summary>
+    private static readonly string SourceRoot = LocateSourceRoot();
+
+    /// <summary>Verifies the Expander retains native header/content rendering and its own style key.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task Expander_WhenHeaderAndContentAreSet_RendersTheNativeTemplate()
+    {
+        var content = new Button { Content = "Button" };
+        var expander = new CrissCrossExpander { Header = "Basic Controls", Content = content, IsExpanded = true };
+
+        var window = new Window { Content = expander };
+        try
+        {
+            window.Show();
+            window.UpdateLayout();
+            await Assert.That(expander.Header).IsEqualTo("Basic Controls");
+            await Assert.That(expander.Content).IsEqualTo(content);
+            await Assert.That(expander.StyleKey).IsEqualTo(typeof(CrissCrossExpander));
+            await Assert.That(expander.Theme?.TargetType).IsEqualTo(typeof(Expander));
+            await Assert.That(expander.Template).IsNotNull();
+            await Assert.That(content.IsEffectivelyVisible).IsTrue();
+            await Assert.That(TopLevel.GetTopLevel(content)).IsSameReferenceAs(window);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies wrappers keep their custom style keys and reuse native control themes.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public Task ThinWrappers_WhenAttached_ReuseNativeTemplatesWithCustomStyleKeys() => AvaloniaTestUiThread.RunAsync(static async () =>
+    {
+        var cases = new[]
+        {
+            new StyleKeyCase(typeof(CrissCrossContextMenu), typeof(ContextMenu)),
+            new StyleKeyCase(typeof(CrissCrossDynamicScrollBar), typeof(NativeScrollBar)),
+            new StyleKeyCase(typeof(CrissCrossDynamicScrollViewer), typeof(ScrollViewer)),
+            new StyleKeyCase(typeof(CrissCrossGifImage), typeof(Image)),
+            new StyleKeyCase(typeof(CrissCrossImage), typeof(Image)),
+            new StyleKeyCase(typeof(CrissCrossItemsControl), typeof(ItemsControl)),
+            new StyleKeyCase(typeof(CrissCrossLabel), typeof(TextBlock)),
+            new StyleKeyCase(typeof(CrissCrossListBox), typeof(ListBox)),
+            new StyleKeyCase(typeof(CrissCrossListView), typeof(ListBox)),
+            new StyleKeyCase(typeof(CrissCrossMenu), typeof(Menu)),
+            new StyleKeyCase(typeof(CrissCrossMenuItem), typeof(MenuItem)),
+            new StyleKeyCase(typeof(CrissCrossScrollBar), typeof(NativeScrollBar)),
+            new StyleKeyCase(typeof(CrissCrossScrollViewer), typeof(ScrollViewer)),
+            new StyleKeyCase(typeof(CrissCrossSeparator), typeof(Separator)),
+            new StyleKeyCase(typeof(CrissCrossTabControl), typeof(TabControl)),
+            new StyleKeyCase(typeof(CrissCrossTextBlock), typeof(TextBlock)),
+            new StyleKeyCase(typeof(CrissCrossTreeView), typeof(TreeView)),
+            new StyleKeyCase(typeof(CrissCrossVirtualizingGridView), typeof(ListBox)),
+            new StyleKeyCase(typeof(CrissCrossVirtualizingItemsControl), typeof(ItemsControl)),
+            new StyleKeyCase(typeof(CrissCrossWindow), typeof(Window)),
+        };
+
+        foreach (var testCase in cases)
+        {
+            var wrapper = (Control)Activator.CreateInstance(testCase.WrapperType)!;
+            var window = wrapper as Window ?? new Window { Content = wrapper };
+            try
+            {
+                window.Show();
+                window.UpdateLayout();
+                await Assert.That(wrapper.StyleKey).IsEqualTo(testCase.WrapperType);
+                if (wrapper is TemplatedControl templated)
+                {
+                    await Assert.That(templated.Theme?.TargetType).IsEqualTo(testCase.NativeThemeTarget);
+                    await Assert.That(templated.Template).IsNotNull();
+                }
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+    });
+
+    /// <summary>Verifies CheckBox and RadioButton content text binds to semantic foreground resources.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task SelectionControlThemes_WhenStringContentIsUsed_BindContentPresenterForegroundToSemanticTextBrushes()
+    {
+        var checkBoxTheme = await File.ReadAllTextAsync(GetAvaloniaThemePath(CheckBoxThemeFile));
+        var radioButtonTheme = await File.ReadAllTextAsync(GetAvaloniaThemePath(RadioButtonThemeFile));
+
+        await Assert.That(checkBoxTheme).Contains(PrimaryForegroundBinding);
+        await Assert.That(checkBoxTheme).Contains(ContentPresenterForegroundBinding);
+        await Assert.That(checkBoxTheme).Contains(DisabledForegroundBinding);
+        await Assert.That(checkBoxTheme).DoesNotContain(LegacyThemeForegroundBinding);
+
+        await Assert.That(radioButtonTheme).Contains(PrimaryForegroundBinding);
+        await Assert.That(radioButtonTheme).Contains(ContentPresenterForegroundBinding);
+        await Assert.That(radioButtonTheme).Contains(DisabledForegroundBinding);
+    }
+
+    /// <summary>Verifies RadioButton checked and disabled indicators use defined semantic brushes.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task RadioButtonTheme_WhenCheckedOrDisabled_UsesDefinedVisibleIndicatorBrushes()
+    {
+        var radioButtonTheme = await File.ReadAllTextAsync(GetAvaloniaThemePath(RadioButtonThemeFile));
+
+        await Assert.That(radioButtonTheme).Contains(RadioButtonCheckedIndicatorBinding);
+        await Assert.That(radioButtonTheme).Contains(TransparentControlFillBinding);
+        await Assert.That(radioButtonTheme).Contains(DisabledControlStrokeBinding);
+        await Assert.That(radioButtonTheme).DoesNotContain(UndefinedRadioButtonCheckedFillBinding);
+        await Assert.That(radioButtonTheme).DoesNotContain(UndefinedRadioButtonCheckedStrokeBinding);
+        await Assert.That(radioButtonTheme).DoesNotContain(UndefinedRadioButtonPointerOverStrokeBinding);
+    }
+
+    /// <summary>Verifies icon elements inherit text foreground for button-hosted icons.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task IconElementForeground_WhenHostedInButton_UsesInheritedTextForeground()
+    {
+        var buttonTheme = await File.ReadAllTextAsync(GetAvaloniaThemePath(ButtonThemeFile));
+
+        await Assert.That(CrissCrossIconElement.ForegroundProperty.Name).IsEqualTo(nameof(TextElement.Foreground));
+        await Assert.That(CrissCrossIconElement.ForegroundProperty.Inherits).IsTrue();
+        await Assert.That(buttonTheme).Contains(ContentPresenterForegroundBinding);
+        await Assert.That(buttonTheme).Contains(ButtonDisabledForegroundBinding);
+    }
+
+    /// <summary>Gets the path to an Avalonia theme file.</summary>
+    /// <param name="themeFileName">The theme file name.</param>
+    /// <returns>The full theme path.</returns>
+    private static string GetAvaloniaThemePath(string themeFileName) =>
+        Path.Combine(SourceRoot, AvaloniaUiProject, ThemesDirectory, themeFileName);
+
+    /// <summary>Locates the repository source root.</summary>
+    /// <returns>The source root path.</returns>
+    private static string LocateSourceRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, AvaloniaUiProject);
+            if (Directory.Exists(candidate))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException($"Could not locate {AvaloniaUiProject} from {AppContext.BaseDirectory}.");
+    }
+
+    /// <summary>Provides a wrapper type and its expected native Avalonia theme target.</summary>
+    /// <param name="WrapperType">The CrissCross wrapper type.</param>
+    /// <param name="NativeThemeTarget">The native control theme target type.</param>
+    private sealed record StyleKeyCase(Type WrapperType, Type NativeThemeTarget);
+}

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaUiNavigationUserControlTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaUiNavigationUserControlTests.cs
@@ -1,0 +1,282 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Avalonia.Controls;
+using ReactiveUI;
+using Splat;
+using UiNavigationUserControl = CrissCross.Avalonia.UI.Controls.NavigationUserControl;
+
+namespace CrissCross.NavigationView.Tests;
+
+/// <summary>Tests the Avalonia UI navigation user control wrapper.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
+public sealed class AvaloniaUiNavigationUserControlTests
+{
+    /// <summary>The explicit host name used by the UI navigation control.</summary>
+    private const string HostName = "ui-navigation-host";
+
+    /// <summary>The replacement host name used by the UI navigation control.</summary>
+    private const string UpdatedHostName = "ui-navigation-host-updated";
+
+    /// <summary>The expected history count after two navigation requests.</summary>
+    private const int ExpectedNavigationHistoryCount = 2;
+
+    /// <summary>Verifies initialization creates and registers the composed navigation frame.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task OnInitialized_WhenHostNameIsSet_ConfiguresNavigationFrame()
+    {
+        using var control = new TestNavigationUserControl { HostName = HostName, NavigateBackIsEnabled = false };
+
+        control.InitializeForTest();
+
+        await Assert.That(control.NavigationFrame).IsNotNull();
+        await Assert.That(control.NavigationFrame!.HostName).IsEqualTo(HostName);
+        await Assert.That(control.NavigationFrame.Name).IsEqualTo(HostName);
+        await Assert.That(control.NavigationFrame.NavigateBackIsEnabled).IsFalse();
+        await Assert.That(control.Content).IsSameReferenceAs(control.NavigationFrame);
+        await Assert.That(((IUseNavigation)control).Name).IsEqualTo(HostName);
+    }
+
+    /// <summary>Verifies content supplied before initialization is preserved inside the composed frame.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task OnInitialized_WhenConsumerContentExists_MovesContentIntoNavigationFrame()
+    {
+        var consumerContent = new Button { Content = "Existing content" };
+        using var control = new TestNavigationUserControl { HostName = HostName, Content = consumerContent };
+
+        control.InitializeForTest();
+
+        await Assert.That(control.NavigationFrame).IsNotNull();
+        await Assert.That(control.Content).IsSameReferenceAs(control.NavigationFrame);
+        await Assert.That(control.NavigationFrame!.Content).IsSameReferenceAs(consumerContent);
+        await Assert.That(consumerContent.Parent).IsSameReferenceAs(control.NavigationFrame);
+    }
+
+    /// <summary>Verifies default host names are unique for multiple control instances.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task OnInitialized_WhenTwoControlsUseDefaults_GeneratesUniqueHostNames()
+    {
+        using var first = new TestNavigationUserControl();
+        using var second = new TestNavigationUserControl();
+
+        first.InitializeForTest();
+        second.InitializeForTest();
+
+        await Assert.That(first.NavigationFrame).IsNotNull();
+        await Assert.That(second.NavigationFrame).IsNotNull();
+        await Assert.That(first.NavigationFrame!.HostName).IsNotNull();
+        await Assert.That(second.NavigationFrame!.HostName).IsNotNull();
+        await Assert.That(first.NavigationFrame.HostName).IsNotEqualTo(second.NavigationFrame.HostName);
+        await Assert.That(first.Content).IsSameReferenceAs(first.NavigationFrame);
+        await Assert.That(second.Content).IsSameReferenceAs(second.NavigationFrame);
+    }
+
+    /// <summary>Verifies content supplied after initialization is still hosted by the navigation frame.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task Content_WhenSetAfterInitialization_RemainsHostedByNavigationFrame()
+    {
+        var consumerContent = new Button { Content = "Updated content" };
+        using var control = new TestNavigationUserControl { HostName = HostName };
+
+        control.InitializeForTest();
+        control.Content = consumerContent;
+
+        await Assert.That(control.Content).IsSameReferenceAs(control.NavigationFrame);
+        await Assert.That(control.NavigationFrame!.Content).IsSameReferenceAs(consumerContent);
+        await Assert.That(consumerContent.Parent).IsSameReferenceAs(control.NavigationFrame);
+    }
+
+    /// <summary>Verifies host properties update the composed frame after initialization.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task HostProperties_WhenChangedAfterInitialization_UpdateNavigationFrame()
+    {
+        using var control = new TestNavigationUserControl { HostName = HostName };
+
+        control.InitializeForTest();
+        control.HostName = UpdatedHostName;
+        control.NavigateBackIsEnabled = false;
+
+        await Assert.That(control.NavigationFrame!.HostName).IsEqualTo(UpdatedHostName);
+        await Assert.That(control.NavigationFrame.Name).IsEqualTo(HostName);
+        await Assert.That(control.NavigationFrame.NavigateBackIsEnabled).IsFalse();
+        await Assert.That(((IUseNavigation)control).Name).IsEqualTo(UpdatedHostName);
+    }
+
+    /// <summary>Verifies attachment and logical-host changes preserve the styled frame name.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task AttachAndReattach_PreserveTheStyledFrameName()
+    {
+        var content = new Button { Content = "Navigation host ready" };
+        using var control = new UiNavigationUserControl { HostName = HostName, Content = content };
+        var window = new Window { Content = control };
+        try
+        {
+            window.Show();
+            window.UpdateLayout();
+            control.HostName = UpdatedHostName;
+            window.Content = null;
+            window.Content = control;
+            window.UpdateLayout();
+            await Assert.That(control.NavigationFrame!.Name).IsEqualTo(HostName);
+            await Assert.That(control.NavigationFrame.HostName).IsEqualTo(UpdatedHostName);
+            await Assert.That(control.NavigationFrame.Parent).IsSameReferenceAs(control);
+            await Assert.That(control.NavigationFrame.Content).IsSameReferenceAs(content);
+            await Assert.That(TopLevel.GetTopLevel(content)).IsSameReferenceAs(window);
+            await Assert.That(content.IsEffectivelyVisible).IsTrue();
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies the UI navigation control can navigate through the public navigation registry.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task NavigateToView_WhenViewLocatorResolvesViews_UpdatesComposedFrame()
+    {
+        var previousMainThreadScheduler = RxSchedulers.MainThreadScheduler;
+        RxSchedulers.MainThreadScheduler = ImmediateScheduler.Instance;
+        using var control = new TestNavigationUserControl { HostName = HostName };
+
+        try
+        {
+            AppLocator.CurrentMutable.UnregisterAll<FirstViewModel>();
+            AppLocator.CurrentMutable.UnregisterAll<SecondViewModel>();
+            AppLocator.CurrentMutable.RegisterConstant(new FirstViewModel());
+            AppLocator.CurrentMutable.RegisterConstant(new SecondViewModel());
+            control.InitializeForTest();
+            control.NavigationFrame!.ViewLocator = new TestViewLocator();
+
+            control.NavigateToView(new NavigationKeyRequest<FirstViewModel>());
+            control.NavigateToView(new NavigationKeyRequest<SecondViewModel>());
+
+            await Assert.That(control.NavigationFrame.NavigationStack.Count).IsEqualTo(ExpectedNavigationHistoryCount);
+            await Assert.That(control.NavigationFrame.Content).IsTypeOf<SecondView>();
+            await Assert.That(((SecondView)control.NavigationFrame.Content!).ViewModel).IsNotNull();
+            await Assert.That(control.NavigationFrame.CanNavigateBack).IsTrue();
+        }
+        finally
+        {
+            RxSchedulers.MainThreadScheduler = previousMainThreadScheduler;
+            AppLocator.CurrentMutable.UnregisterAll<FirstViewModel>();
+            AppLocator.CurrentMutable.UnregisterAll<SecondViewModel>();
+        }
+    }
+
+    /// <summary>Verifies the typed UI control uses the non-generic XAML view-model property.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task GenericControl_UsesNonGenericViewModelProperty()
+    {
+        using var control = new CrissCross.Avalonia.UI.Controls.NavigationUserControl<FirstViewModel>();
+        var viewModel = new FirstViewModel();
+
+        control.ViewModel = viewModel;
+
+        await Assert.That(UiNavigationUserControl.ViewModelProperty.OwnerType).IsEqualTo(typeof(UiNavigationUserControl));
+        await Assert.That(control.GetValue(UiNavigationUserControl.ViewModelProperty)).IsSameReferenceAs(viewModel);
+        await Assert.That(((IViewFor)control).ViewModel).IsSameReferenceAs(viewModel);
+        await Assert.That(control.BindingRoot).IsSameReferenceAs(viewModel);
+    }
+
+    /// <summary>Verifies disposing the wrapper disposes and clears the composed frame reference.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task Dispose_WhenNavigationFrameExists_ClearsFrameReference()
+    {
+        var control = new TestNavigationUserControl { HostName = HostName };
+
+        control.InitializeForTest();
+        var frame = control.NavigationFrame;
+
+        control.Dispose();
+
+        await Assert.That(frame).IsNotNull();
+        await Assert.That(control.NavigationFrame).IsNull();
+    }
+
+    /// <summary>First test view model.</summary>
+    public sealed class FirstViewModel : RxObject;
+
+    /// <summary>Second test view model.</summary>
+    public sealed class SecondViewModel : RxObject;
+
+    /// <summary>First test view.</summary>
+    private sealed class FirstView : TextBlock, IViewFor<FirstViewModel>
+    {
+        /// <summary>Gets or sets the strongly typed view model.</summary>
+        public FirstViewModel? ViewModel { get; set; }
+
+        /// <inheritdoc/>
+        object? IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (FirstViewModel?)value;
+        }
+    }
+
+    /// <summary>Second test view.</summary>
+    private sealed class SecondView : TextBlock, IViewFor<SecondViewModel>
+    {
+        /// <summary>Gets or sets the strongly typed view model.</summary>
+        public SecondViewModel? ViewModel { get; set; }
+
+        /// <inheritdoc/>
+        object? IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (SecondViewModel?)value;
+        }
+    }
+
+    /// <summary>View locator used by navigation tests.</summary>
+    private sealed class TestViewLocator : IViewLocator
+    {
+        /// <inheritdoc/>
+        public IViewFor<TViewModel> ResolveView<TViewModel>()
+            where TViewModel : class => ResolveView<TViewModel>(contract: null);
+
+        /// <inheritdoc/>
+        public IViewFor<TViewModel> ResolveView<TViewModel>(string? contract)
+            where TViewModel : class
+        {
+            if (typeof(TViewModel) == typeof(FirstViewModel))
+            {
+                return (IViewFor<TViewModel>)(object)new FirstView();
+            }
+
+            if (typeof(TViewModel) == typeof(SecondViewModel))
+            {
+                return (IViewFor<TViewModel>)(object)new SecondView();
+            }
+
+            throw new InvalidOperationException($"Unsupported view model type {typeof(TViewModel).FullName}.");
+        }
+
+        /// <inheritdoc/>
+        public IViewFor? ResolveView(object? instance) => ResolveView(instance, contract: null);
+
+        /// <inheritdoc/>
+        public IViewFor? ResolveView(object? instance, string? contract) => instance switch
+        {
+            FirstViewModel => new FirstView(),
+            SecondViewModel => new SecondView(),
+            _ => null,
+        };
+    }
+
+    /// <summary>Testable UI navigation control.</summary>
+    private sealed class TestNavigationUserControl : UiNavigationUserControl
+    {
+        /// <summary>Initializes the navigation control for tests.</summary>
+        public void InitializeForTest() => OnInitialized();
+    }
+}

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaUiTestExecutor.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaUiTestExecutor.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using TUnit.Core.Interfaces;
+
+namespace CrissCross.NavigationView.Tests;
+
+/// <summary>Runs test bodies on the dispatcher that owns their Avalonia objects.</summary>
+public sealed class AvaloniaUiTestExecutor : ITestExecutor
+{
+    /// <inheritdoc/>
+    public async ValueTask ExecuteTest(TestContext context, Func<ValueTask> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        await AvaloniaTestUiThread.RunAsync(() => action().AsTask());
+    }
+}

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaViewModelPropertyTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaViewModelPropertyTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI;
+using NavigationControl = CrissCross.Avalonia.NavigationUserControl;
+using NavigationWindow = CrissCross.Avalonia.NavigationWindow;
+
+namespace CrissCross.NavigationView.Tests;
+
+/// <summary>Verifies XAML property ownership is shared across closed generic navigation types.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
+public sealed class AvaloniaViewModelPropertyTests
+{
+    /// <summary>Verifies independent generic controls share one non-generic property registration.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task GenericControlsUseNonGenericPropertyOwner()
+    {
+        var first = new CrissCross.Avalonia.NavigationUserControl<FirstViewModel>();
+        var second = new CrissCross.Avalonia.NavigationUserControl<SecondViewModel>();
+        var firstModel = new FirstViewModel();
+        var secondModel = new SecondViewModel();
+        first.ViewModel = firstModel;
+        _ = second.SetValue(NavigationControl.ViewModelProperty, secondModel);
+
+        await Assert.That(NavigationControl.ViewModelProperty.OwnerType).IsEqualTo(typeof(NavigationControl));
+        await Assert.That(ReferenceEquals(first.GetValue(NavigationControl.ViewModelProperty), firstModel)).IsTrue();
+        await Assert.That(ReferenceEquals(second.ViewModel, secondModel)).IsTrue();
+        await Assert.That(ReferenceEquals(((IViewFor)first).ViewModel, firstModel)).IsTrue();
+        ((IViewFor)first).ViewModel = null;
+        await Assert.That(first.ViewModel).IsNull();
+        await Assert.That(ReferenceEquals(second.ViewModel, secondModel)).IsTrue();
+    }
+
+    /// <summary>Verifies different generic window types register one XAML-addressable property.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public Task GenericWindowsUseNonGenericPropertyOwner() => AvaloniaTestUiThread.RunAsync(static async () =>
+    {
+        var first = new CrissCross.Avalonia.NavigationWindow<FirstViewModel>();
+        var second = new CrissCross.Avalonia.NavigationWindow<SecondViewModel>();
+        var firstModel = new FirstViewModel();
+        var secondModel = new SecondViewModel();
+        first.ViewModel = firstModel;
+        _ = second.SetValue(NavigationWindow.ViewModelProperty, secondModel);
+
+        await Assert.That(NavigationWindow.ViewModelProperty.OwnerType).IsEqualTo(typeof(NavigationWindow));
+        await Assert.That(ReferenceEquals(first.GetValue(NavigationWindow.ViewModelProperty), firstModel)).IsTrue();
+        await Assert.That(ReferenceEquals(second.ViewModel, secondModel)).IsTrue();
+        await Assert.That(ReferenceEquals(((IViewFor)first).ViewModel, firstModel)).IsTrue();
+        ((IViewFor)first).ViewModel = null;
+        await Assert.That(first.ViewModel).IsNull();
+        first.Close();
+        second.Close();
+    });
+
+    /// <summary>Provides the first strongly typed navigation model.</summary>
+    public sealed class FirstViewModel : RxObject;
+
+    /// <summary>Provides the second strongly typed navigation model.</summary>
+    public sealed class SecondViewModel : RxObject;
+}

--- a/src/Tests/CrissCross.NavigationView.Tests/AvaloniaWorkflowTemplateTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/AvaloniaWorkflowTemplateTests.cs
@@ -1,0 +1,365 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Avalonia.Controls;
+using Avalonia.VisualTree;
+using ReactiveUI;
+using Controls = CrissCross.Avalonia.UI.Controls;
+
+namespace CrissCross.NavigationView.Tests;
+
+/// <summary>Exercises workflow templates and commands in an attached Avalonia window.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
+public sealed class AvaloniaWorkflowTemplateTests
+{
+    /// <summary>The pressure field used by the form and search examples.</summary>
+    private const string PressureField = "pressure";
+
+    /// <summary>The title typography size supplied by the CrissCross theme.</summary>
+    private const double TitleFontSize = 28;
+
+    /// <summary>The caption typography size supplied by the CrissCross theme.</summary>
+    private const double CaptionFontSize = 12;
+
+    /// <summary>Bounds an asynchronous gallery operation regression.</summary>
+    private const int OperationTimeoutSeconds = 5;
+
+    /// <summary>The rounded corner size used by the native-template interop regression.</summary>
+    private const double CornerSize = 6;
+
+    /// <summary>The disabled opacity used by standard light and dark themes.</summary>
+    private const double StandardDisabledOpacity = 0.5;
+
+    /// <summary>Verifies filter labels, removal permissions, command payloads, and state clearing.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task FilterBar_RendersTokensAndDispatchesActions()
+    {
+        var removable = new FilterToken("area", FilterOperator.Equals, "A", "Area A");
+        var fixedToken = new FilterToken("plant", FilterOperator.Equals, "North", "North plant", false);
+        FilterToken? removed = null;
+        var cleared = false;
+        using var remove = ReactiveCommand.Create<FilterToken>(token => removed = token);
+        using var clear = ReactiveCommand.Create(() => cleared = true);
+        var control = new Controls.FilterBar { QueryState = new(filters: [removable, fixedToken]), RemoveFilterCommand = remove, ClearAllCommand = clear };
+        var window = new Window { Content = control };
+        try
+        {
+            window.Show();
+            window.UpdateLayout();
+            await Assert.That(HasText(control, removable.DisplayText)).IsTrue();
+            await Assert.That(HasText(control, fixedToken.DisplayText)).IsTrue();
+            var removeButton = FindVisual<Button>(control, button => ReferenceEquals(button.CommandParameter, removable));
+            var fixedButton = FindVisual<Button>(control, button => ReferenceEquals(button.CommandParameter, fixedToken));
+            await Assert.That(removeButton.IsVisible).IsTrue();
+            await Assert.That(fixedButton.IsVisible).IsFalse();
+            removeButton.Command!.Execute(removeButton.CommandParameter);
+            await Assert.That(removed).IsSameReferenceAs(removable);
+            var clearButton = FindVisual<Button>(control, static button => Equals(button.Content, "Clear"));
+            clearButton.Command!.Execute(clearButton.CommandParameter);
+            await Assert.That(cleared).IsTrue();
+            control.QueryState = null;
+            window.UpdateLayout();
+            await Assert.That(control.ItemsSource is null).IsTrue();
+            await Assert.That(HasText(control, removable.DisplayText)).IsFalse();
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies workflow and validation item templates display model labels and dispatch their commands.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task StepperAndValidation_RenderModelContentAndClearState()
+    {
+        var prepare = new StepDescriptor("prepare", "Prepare equipment");
+        var run = new StepDescriptor("run", "Run equipment");
+        var message = new ValidationMessage(PressureField, "Pressure", "Set a safe pressure");
+        string? requestedStep = null;
+        ValidationMessage? requestedMessage = null;
+        using var stepCommand = ReactiveCommand.Create<string>(key => requestedStep = key);
+        using var fieldCommand = ReactiveCommand.Create<ValidationMessage>(value => requestedMessage = value);
+        var stepper = new Controls.Stepper { State = new([prepare, run], prepare.Key), StepRequestedCommand = stepCommand };
+        var validation = new Controls.ValidationSummary { SummaryState = new([message]), NavigateToFieldCommand = fieldCommand };
+        var window = new Window { Content = new StackPanel { Children = { stepper, validation } } };
+        try
+        {
+            window.Show();
+            window.UpdateLayout();
+            await Assert.That(HasText(stepper, prepare.DisplayTitle)).IsTrue();
+            await Assert.That(HasText(stepper, run.DisplayTitle)).IsTrue();
+            await Assert.That(HasText(validation, message.DisplayText)).IsTrue();
+            var next = FindVisual<Button>(stepper, static button => Equals(button.Content, "Next"));
+            await Assert.That(next.IsEnabled).IsTrue();
+            next.Command!.Execute(next.CommandParameter);
+            await Assert.That(requestedStep).IsEqualTo(run.Key);
+            var field = FindVisual<Button>(validation, static _ => true);
+            field.Command!.Execute(field.CommandParameter);
+            await Assert.That(requestedMessage).IsSameReferenceAs(message);
+            stepper.State = null;
+            validation.SummaryState = null;
+            window.UpdateLayout();
+            await Assert.That(stepper.CurrentKey).IsNull();
+            await Assert.That(stepper.ItemsSource is null).IsTrue();
+            await Assert.That(validation.ItemsSource is null).IsTrue();
+            await Assert.That(next.IsEnabled).IsFalse();
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies group commands override model commands and fall back when cleared.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task ChipGroup_UsesGroupCommandsAndModelFallback()
+    {
+        ChipModel? selected = null;
+        ChipModel? removed = null;
+        var usedGroup = false;
+        using var modelSelect = ReactiveCommand.Create<ChipModel>(chip => selected = chip);
+        using var modelRemove = ReactiveCommand.Create<ChipModel>(chip => removed = chip);
+        using var groupSelect = ReactiveCommand.Create<ChipModel>(_ => usedGroup = true);
+        var model = new ChipModel("pump", "Pump 101", new() { IsRemovable = true, SelectCommand = modelSelect, RemoveCommand = modelRemove });
+        var group = new Controls.ChipGroup { GroupState = new([model]), SelectChipCommand = groupSelect };
+        var window = new Window { Content = group };
+        try
+        {
+            window.Show();
+            window.UpdateLayout();
+            var chip = FindVisual<Controls.Chip>(group, static _ => true);
+            await Assert.That(HasText(chip, model.Text)).IsTrue();
+            var select = FindVisual<Button>(chip, button => Equals(button.Content, model.Text));
+            select.Command!.Execute(select.CommandParameter);
+            await Assert.That(usedGroup).IsTrue();
+            await Assert.That(selected).IsNull();
+            group.SelectChipCommand = null;
+            select.Command!.Execute(select.CommandParameter);
+            await Assert.That(selected).IsSameReferenceAs(model);
+            var remove = FindVisual<Button>(chip, static button => Equals(button.Content, "×"));
+            remove.Command!.Execute(remove.CommandParameter);
+            await Assert.That(removed).IsSameReferenceAs(model);
+            chip.IsRemovable = false;
+            await Assert.That(remove.IsVisible).IsFalse();
+            group.GroupState = null;
+            window.UpdateLayout();
+            await Assert.That(group.ItemsSource is null).IsTrue();
+            await Assert.That(HasVisual<Controls.Chip>(group, static _ => true)).IsFalse();
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies native template reuse preserves CrissCross wrapper styling and derived button templates.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task NativeWrappers_ApplyCustomStylesAndRetainTemplates()
+    {
+        var title = new Controls.TextBlock { Text = "Equipment", FontTypography = Controls.FontTypography.Title };
+        var suggestions = new Controls.AutoSuggestBox();
+        var list = new Controls.ListBox { ItemsSource = new[] { "Pump" } };
+        var command = new Controls.AsyncCommandButton { Content = "Start" };
+        var window = new Controls.Window { Content = new StackPanel { Children = { title, suggestions, list, command } } };
+        try
+        {
+            window.Show();
+            window.UpdateLayout();
+            await Assert.That(title.FontSize).IsEqualTo(TitleFontSize);
+            title.FontTypography = Controls.FontTypography.Caption;
+            await Assert.That(title.FontSize).IsEqualTo(CaptionFontSize);
+            await Assert.That(suggestions.Template).IsNotNull();
+            await Assert.That(suggestions.FilterMode).IsEqualTo(AutoCompleteFilterMode.Contains);
+            await Assert.That(suggestions.IsTextCompletionEnabled).IsTrue();
+            await Assert.That(list.Template).IsNotNull();
+            await Assert.That(HasText(list, "Pump")).IsTrue();
+            await Assert.That(window.Template).IsNotNull();
+            await Assert.That(command.Template).IsNotNull();
+            await Assert.That(HasVisual<Border>(command, static border => border.Name == "RootBorder")).IsTrue();
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies the transformed reactive package renders its own model and control namespaces.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task ReactivePackage_WorkflowTemplatesRenderAndDispatchCommands()
+    {
+        var token = new CrissCross.Reactive.FilterToken("area", CrissCross.Reactive.FilterOperator.Equals, "South", "South plant");
+        CrissCross.Reactive.FilterToken? removed = null;
+        using var remove = ReactiveCommand.Create<CrissCross.Reactive.FilterToken>(value => removed = value);
+        var filters = new CrissCross.Reactive.Avalonia.UI.Controls.FilterBar { QueryState = new(filters: [token]), RemoveFilterCommand = remove };
+        var stepper = new CrissCross.Reactive.Avalonia.UI.Controls.Stepper { State = new([new CrissCross.Reactive.StepDescriptor("start", "Prepare reactor")]) };
+        var button = new CrissCross.Reactive.Avalonia.UI.Controls.AsyncCommandButton { Content = "Import telemetry" };
+        var window = new Window { Content = new StackPanel { Children = { filters, stepper, button } } };
+        var styles = global::Avalonia.Markup.Xaml.AvaloniaXamlLoader.Load(new("avares://CrissCross.Avalonia.UI.Reactive/Themes/Index.axaml"));
+        window.Styles.Add((global::Avalonia.Styling.Styles)styles);
+        try
+        {
+            window.Show();
+            window.UpdateLayout();
+            await Assert.That(HasText(filters, token.DisplayText)).IsTrue();
+            await Assert.That(HasText(stepper, "Prepare reactor")).IsTrue();
+            await Assert.That(button.Template).IsNotNull();
+            var removeButton = FindVisual<Button>(filters, candidate => ReferenceEquals(candidate.CommandParameter, token));
+            removeButton.Command!.Execute(removeButton.CommandParameter);
+            await Assert.That(removed).IsSameReferenceAs(token);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies high contrast keeps disabled semantic text colors fully visible.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task DisabledTextControls_HighContrastAvoidsDoubleDimming()
+    {
+        var radio = new Controls.RadioButton { Content = "Disabled option", IsEnabled = false };
+        var check = new Controls.CheckBox { Content = "Disabled selection", IsEnabled = false };
+        var button = new Controls.Button { Content = "Disabled action", IsEnabled = false };
+        var window = new Window
+        {
+            Content = new StackPanel { Children = { radio, check, button } },
+            RequestedThemeVariant = CrissCross.Avalonia.UI.Appearance.ApplicationThemeManager.HighContrastThemeVariant,
+        };
+        try
+        {
+            window.Show();
+            window.UpdateLayout();
+            await Assert.That(radio.Opacity).IsEqualTo(1D);
+            await Assert.That(check.Opacity).IsEqualTo(1D);
+            await Assert.That(button.Opacity).IsEqualTo(1D);
+            window.RequestedThemeVariant = global::Avalonia.Styling.ThemeVariant.Light;
+            await Assert.That(radio.Opacity).IsEqualTo(StandardDisabledOpacity);
+            await Assert.That(check.Opacity).IsEqualTo(StandardDisabledOpacity);
+            await Assert.That(button.Opacity).IsEqualTo(StandardDisabledOpacity);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies wrapper properties are visible to reused native rendering code and templates.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task NativeTemplateProperties_ShareTheWrapperValues()
+    {
+        var radius = new global::Avalonia.CornerRadius(CornerSize);
+        var expander = new Controls.Expander { CornerRadius = radius };
+        var icon = new TextBlock { Text = "Pump" };
+        var menuItem = new Controls.MenuItem { Icon = icon };
+        var image = new Controls.GifImage { StretchDirection = global::Avalonia.Media.StretchDirection.DownOnly };
+        await Assert.That(((Expander)expander).CornerRadius).IsEqualTo(radius);
+        await Assert.That(((MenuItem)menuItem).Icon).IsSameReferenceAs(icon);
+        await Assert.That(((Image)image).StretchDirection).IsEqualTo(global::Avalonia.Media.StretchDirection.DownOnly);
+    }
+
+    /// <summary>Verifies gallery filter commands persist through subsequent query changes.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task GalleryFilters_RemainRemovedWhenSearchTextChanges()
+    {
+        using var model = new CrissCross.Avalonia.UI.Gallery.ViewModels.FeaturePlaygroundPageViewModel();
+        var token = model.SearchState.ActiveFilters[0];
+        ((System.Windows.Input.ICommand)model.RemoveFilterCommand).Execute(token);
+        await Assert.That(model.SearchState.ActiveFilterCount).IsEqualTo(1);
+        model.SearchText = PressureField;
+        await Assert.That(model.SearchState.ActiveFilterCount).IsEqualTo(1);
+        ((System.Windows.Input.ICommand)model.ClearFiltersCommand).Execute(null);
+        await Assert.That(model.SearchState.ActiveFilterCount).IsEqualTo(0);
+        await Assert.That(model.SearchText).IsEqualTo(PressureField);
+        model.SearchText = "pump";
+        await Assert.That(model.SearchState.ActiveFilterCount).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies cancellation stops the import and leaves the query untouched.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task GalleryImport_CancelPreservesSearchAndClearsBusyState()
+    {
+        using var model = new CrissCross.Avalonia.UI.Gallery.ViewModels.FeaturePlaygroundPageViewModel();
+        var originalQuery = model.SearchText;
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnPropertyChanged(object? _, System.ComponentModel.PropertyChangedEventArgs args)
+        {
+            if (args.PropertyName != nameof(model.CurrentOperation) || model.CurrentOperation is not null)
+            {
+                return;
+            }
+
+            completion.SetResult();
+        }
+
+        model.PropertyChanged += OnPropertyChanged;
+        try
+        {
+            ((System.Windows.Input.ICommand)model.RunImportCommand).Execute(null);
+            await Assert.That(model.CurrentOperation).IsNotNull();
+            model.CurrentOperation!.CancelCommand!.Execute(null);
+            await completion.Task.WaitAsync(TimeSpan.FromSeconds(OperationTimeoutSeconds));
+            await Assert.That(model.CurrentOperation).IsNull();
+            await Assert.That(model.CommandState).IsEqualTo(CommandButtonState.Cancelled);
+            await Assert.That(model.SearchText).IsEqualTo(originalQuery);
+        }
+        finally
+        {
+            model.PropertyChanged -= OnPropertyChanged;
+        }
+    }
+
+    /// <summary>Finds rendered text rather than an uninstantiated data template.</summary>
+    /// <param name="control">The rendered control.</param>
+    /// <param name="text">The expected text.</param>
+    /// <returns>Whether a visible text element contains the text.</returns>
+    private static bool HasText(Control control, string text) =>
+        HasVisual<TextBlock>(control, block => block.Text == text && block.IsEffectivelyVisible);
+
+    /// <summary>Finds an attached template element matching a predicate.</summary>
+    /// <typeparam name="TControl">The required element type.</typeparam>
+    /// <param name="control">The rendered control.</param>
+    /// <param name="predicate">The element condition.</param>
+    /// <returns>The matching element.</returns>
+    private static TControl FindVisual<TControl>(Control control, Predicate<TControl> predicate)
+        where TControl : Control
+    {
+        foreach (var descendant in control.GetVisualDescendants())
+        {
+            if (descendant is TControl candidate && predicate(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        throw new InvalidOperationException($"The template did not render a matching {typeof(TControl).Name}.");
+    }
+
+    /// <summary>Checks whether a matching template element is present.</summary>
+    /// <typeparam name="TControl">The required element type.</typeparam>
+    /// <param name="control">The rendered control.</param>
+    /// <param name="predicate">The element condition.</param>
+    /// <returns>Whether a matching element exists.</returns>
+    private static bool HasVisual<TControl>(Control control, Predicate<TControl> predicate)
+        where TControl : Control
+    {
+        foreach (var descendant in control.GetVisualDescendants())
+        {
+            if (descendant is TControl candidate && predicate(candidate))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Tests/CrissCross.NavigationView.Tests/CrissCross.NavigationView.Tests.csproj
+++ b/src/Tests/CrissCross.NavigationView.Tests/CrissCross.NavigationView.Tests.csproj
@@ -6,11 +6,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
-    <NoWarn>$(NoWarn);SA0001;SA1201;SA1600;SA1633;SA1513;SA1516;SA1122;SA1127;CS1591;CS0219;CS8620;CA1001;CA1812;CA1822;TUnitAssertions0005</NoWarn>
     <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ReactiveUI" />
+    <PackageReference Include="ReactiveUI.Core" />
     <ProjectReference Include="..\..\CrissCross.WPF.UI\CrissCross.WPF.UI.csproj" />
     <ProjectReference Include="..\..\CrissCross.Avalonia\CrissCross.Avalonia.csproj" />
     <ProjectReference Include="..\..\CrissCross.Avalonia.UI\CrissCross.Avalonia.UI.csproj" />

--- a/src/Tests/CrissCross.NavigationView.Tests/NavigationViewJournalRegressionTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/NavigationViewJournalRegressionTests.cs
@@ -10,6 +10,7 @@ using WpfControls = CrissCross.WPF.UI.Controls;
 namespace CrissCross.NavigationView.Tests;
 
 /// <summary>Regression tests for platform navigation view journal moves.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
 public class NavigationViewJournalRegressionTests
 {
     /// <summary>Provides the WpfGoForward_WhenRequestedJournalItemIsAlreadyStackTop_MovesJournalIndex member.</summary>
@@ -19,7 +20,7 @@ public class NavigationViewJournalRegressionTests
     {
         var result = RunOnStaThread(static () =>
         {
-            var item = new WpfControls.NavigationViewItem(typeof(WpfTestPage));
+            var item = new WpfControls.NavigationViewItem(typeof(System.Windows.Controls.UserControl));
             var navigationView = new TestWpfNavigationView();
             SeedWpfAlreadyCurrentJournalMove(navigationView, item, currentIndex: 0);
             var moved = navigationView.GoForward();
@@ -43,7 +44,7 @@ public class NavigationViewJournalRegressionTests
     {
         var result = RunOnStaThread(static () =>
         {
-            var item = new WpfControls.NavigationViewItem(typeof(WpfTestPage));
+            var item = new WpfControls.NavigationViewItem(typeof(System.Windows.Controls.UserControl));
             var navigationView = new TestWpfNavigationView();
             SeedWpfAlreadyCurrentJournalMove(navigationView, item, currentIndex: 1);
             var moved = navigationView.GoBack();
@@ -241,9 +242,6 @@ public class NavigationViewJournalRegressionTests
 
     /// <summary>Provides the TestAvaloniaNavigationView member.</summary>
     private sealed class TestAvaloniaNavigationView : AvaloniaControls.NavigationView;
-
-    /// <summary>Provides the WpfTestPage member.</summary>
-    private sealed class WpfTestPage : System.Windows.Controls.UserControl;
 
     /// <summary>Provides the AvaloniaTestPage member.</summary>
     private sealed class AvaloniaTestPage : global::Avalonia.Controls.UserControl;

--- a/src/Tests/CrissCross.NavigationView.Tests/ReactiveAvaloniaCoverageTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/ReactiveAvaloniaCoverageTests.cs
@@ -13,6 +13,7 @@ using ReactiveRichTextBox = CrissCross.Reactive.Avalonia.UI.Controls.RichTextBox
 namespace CrissCross.NavigationView.Tests;
 
 /// <summary>Exercises the reactive Avalonia UI assembly's constructible public surface.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
 public sealed class ReactiveAvaloniaCoverageTests
 {
     /// <summary>The offset at which the word selected for editing begins.</summary>
@@ -24,7 +25,7 @@ public sealed class ReactiveAvaloniaCoverageTests
     /// <summary>Verifies every public parameterless reactive styled element can be constructed.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
     [Test]
-    public async Task ReactivePublicParameterlessStyledElements_WhenConstructed_ProduceStyledElements()
+    public Task ReactivePublicParameterlessStyledElements_WhenConstructed_ProduceStyledElements() => AvaloniaTestUiThread.RunAsync(static async () =>
     {
         var assembly = typeof(ReactiveAppBar).Assembly;
         var constructedCount = 0;
@@ -32,7 +33,7 @@ public sealed class ReactiveAvaloniaCoverageTests
 
         foreach (var type in assembly.GetExportedTypes())
         {
-            if (type.IsAbstract || !typeof(StyledElement).IsAssignableFrom(type) || type.GetConstructor(Type.EmptyTypes) is null)
+            if (type.IsAbstract || type.ContainsGenericParameters || !typeof(StyledElement).IsAssignableFrom(type) || type.GetConstructor(Type.EmptyTypes) is null)
             {
                 continue;
             }
@@ -56,7 +57,7 @@ public sealed class ReactiveAvaloniaCoverageTests
 
         await Assert.That(constructedCount).IsGreaterThan(0);
         await Assert.That(roundTrippedPropertyCount).IsGreaterThan(0);
-    }
+    });
 
     /// <summary>Verifies the reactive converter variant keeps the same boolean semantics.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>

--- a/src/Tests/CrissCross.NavigationView.Tests/RichTextBoxCoreTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/RichTextBoxCoreTests.cs
@@ -8,6 +8,7 @@ using CrissCross.Avalonia.UI.Controls;
 namespace CrissCross.NavigationView.Tests;
 
 /// <summary>Regression tests for RichTextBox document offsets and core editing behavior.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
 public sealed class RichTextBoxCoreTests
 {
     /// <summary>The formatted Hello world fixture.</summary>

--- a/src/Tests/CrissCross.NavigationView.Tests/RichTextBoxFeatureTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/RichTextBoxFeatureTests.cs
@@ -10,6 +10,7 @@ using AvaloniaContextMenu = Avalonia.Controls.ContextMenu;
 namespace CrissCross.NavigationView.Tests;
 
 /// <summary>Comprehensive feature coverage for the Avalonia RichTextBox control surface.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
 public sealed partial class RichTextBoxFeatureTests
 {
     /// <summary>The image file URI used by drop tests.</summary>

--- a/src/Tests/CrissCross.NavigationView.Tests/RichTextBoxParityShimTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/RichTextBoxParityShimTests.cs
@@ -7,6 +7,7 @@ using CrissCross.Avalonia.UI.Controls;
 namespace CrissCross.NavigationView.Tests;
 
 /// <summary>Regression tests for the WPF interaction parity shims.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
 public sealed class RichTextBoxParityShimTests
 {
     /// <summary>Verifies that plain-text typing does not expose or discard surrounding markup.</summary>

--- a/src/Tests/CrissCross.NavigationView.Tests/ThemeParityTests.cs
+++ b/src/Tests/CrissCross.NavigationView.Tests/ThemeParityTests.cs
@@ -1,0 +1,328 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.IO;
+using System.Xml.Linq;
+using Avalonia.Markup.Xaml;
+using Avalonia.Styling;
+using CrissCross.Avalonia.UI.Appearance;
+
+namespace CrissCross.NavigationView.Tests;
+
+/// <summary>Verifies cross-theme resource parity for platform UI theme dictionaries.</summary>
+[TUnit.Core.Executors.TestExecutor<AvaloniaUiTestExecutor>]
+public sealed class ThemeParityTests
+{
+    /// <summary>Provides the Avalonia UI project directory name.</summary>
+    private const string AvaloniaUiProject = "CrissCross.Avalonia.UI";
+
+    /// <summary>Provides the WPF UI project directory name.</summary>
+    private const string WpfUiProject = "CrissCross.WPF.UI";
+
+    /// <summary>Provides the shared resources directory name.</summary>
+    private const string ResourcesDirectory = "Resources";
+
+    /// <summary>Provides the shared theme directory name.</summary>
+    private const string ThemeDirectory = "Theme";
+
+    /// <summary>Provides the high contrast theme name.</summary>
+    private const string HighContrastTheme = "HighContrast";
+
+    /// <summary>Provides the primary text contrast threshold required by WCAG 2.1 AA.</summary>
+    private const double PrimaryTextMinimumContrast = 4.5;
+
+    /// <summary>Provides the maximum color byte value.</summary>
+    private const byte ByteMaximum = byte.MaxValue;
+
+    /// <summary>Provides the RGB hex string length.</summary>
+    private const int RgbHexLength = 6;
+
+    /// <summary>Provides the ARGB hex string length.</summary>
+    private const int ArgbHexLength = 8;
+
+    /// <summary>Provides the length of one hexadecimal byte.</summary>
+    private const int HexByteLength = 2;
+
+    /// <summary>Provides the red byte offset in a hexadecimal color.</summary>
+    private const int RedOffset = 0;
+
+    /// <summary>Provides the green byte offset in a hexadecimal color.</summary>
+    private const int GreenOffset = 2;
+
+    /// <summary>Provides the blue byte offset in a hexadecimal color.</summary>
+    private const int BlueOffset = 4;
+
+    /// <summary>Provides the alpha byte offset in an ARGB hexadecimal color.</summary>
+    private const int AlphaOffset = 0;
+
+    /// <summary>Provides the red byte offset in an ARGB hexadecimal color.</summary>
+    private const int ArgbRedOffset = 2;
+
+    /// <summary>Provides the green byte offset in an ARGB hexadecimal color.</summary>
+    private const int ArgbGreenOffset = 4;
+
+    /// <summary>Provides the blue byte offset in an ARGB hexadecimal color.</summary>
+    private const int ArgbBlueOffset = 6;
+
+    /// <summary>Provides the WCAG contrast luminance offset.</summary>
+    private const double ContrastOffset = 0.05;
+
+    /// <summary>Provides the x namespace used by platform resource dictionaries.</summary>
+    private static readonly XNamespace XamlNamespace = "http://schemas.microsoft.com/winfx/2006/xaml";
+
+    /// <summary>Provides the source root used to locate platform resource dictionaries.</summary>
+    private static readonly string SourceRoot = LocateSourceRoot();
+
+    /// <summary>Verifies Avalonia exposes a dedicated high contrast theme variant.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task AvaloniaHighContrastThemeVariant_UsesDedicatedKeyAndDarkInheritance()
+    {
+        await Assert.That(ApplicationThemeManager.HighContrastThemeVariant.Key).IsEqualTo(HighContrastTheme);
+        await Assert.That(ApplicationThemeManager.HighContrastThemeVariant.InheritVariant).IsSameReferenceAs(ThemeVariant.Dark);
+    }
+
+    /// <summary>Verifies Avalonia's fluent resource dictionary includes all supported theme dictionaries.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task AvaloniaFluentTheme_WhenLoaded_IncludesHighContrastThemeResources()
+    {
+        var styles = (Styles)AvaloniaXamlLoader.Load(new("avares://CrissCross.Avalonia.UI/Resources/FluentTheme.axaml"));
+
+        await Assert.That(styles.Resources.ThemeDictionaries.ContainsKey(ThemeVariant.Dark)).IsTrue();
+        await Assert.That(styles.Resources.ThemeDictionaries.ContainsKey(ThemeVariant.Light)).IsTrue();
+        await Assert.That(styles.Resources.ThemeDictionaries.ContainsKey(ApplicationThemeManager.HighContrastThemeVariant)).IsTrue();
+
+        await Assert.That(File.Exists(GetAvaloniaThemePath(HighContrastTheme))).IsTrue();
+    }
+
+    /// <summary>Verifies Avalonia high contrast keeps the Light and Dark semantic resource key contract.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task AvaloniaHighContrastTheme_KeepsLightAndDarkResourceKeysInParity()
+    {
+        var lightKeys = ReadResourceKeys(GetAvaloniaThemePath("Light"));
+        var darkKeys = ReadResourceKeys(GetAvaloniaThemePath("Dark"));
+        var highContrastKeys = ReadResourceKeys(GetAvaloniaThemePath(HighContrastTheme));
+
+        await Assert.That(GetMissingKeys(lightKeys, highContrastKeys)).IsEmpty();
+        await Assert.That(GetMissingKeys(darkKeys, highContrastKeys)).IsEmpty();
+        await Assert.That(GetMissingKeys(highContrastKeys, lightKeys)).IsEmpty();
+        await Assert.That(GetMissingKeys(highContrastKeys, darkKeys)).IsEmpty();
+    }
+
+    /// <summary>Verifies high contrast dictionaries keep primary text readable on their application surface.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task HighContrastThemes_KeepPrimaryTextReadableOnTheApplicationSurface()
+    {
+        var avaloniaColors = ReadColorResources(GetAvaloniaThemePath(HighContrastTheme));
+        var wpfColors = ReadColorResources(GetWpfThemePath("HCBlack"));
+
+        await Assert.That(GetContrast(avaloniaColors["TextFillColorPrimary"], avaloniaColors["ApplicationBackgroundColor"]))
+            .IsGreaterThanOrEqualTo(PrimaryTextMinimumContrast);
+        await Assert.That(GetContrast(wpfColors["SystemColorWindowTextColor"], wpfColors["ApplicationBackgroundColor"]))
+            .IsGreaterThanOrEqualTo(PrimaryTextMinimumContrast);
+    }
+
+    /// <summary>Reads all keyed entries from a XAML resource dictionary.</summary>
+    /// <param name="path">The resource dictionary path.</param>
+    /// <returns>The resource keys.</returns>
+    private static HashSet<string> ReadResourceKeys(string path)
+    {
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var element in XDocument.Load(path).Descendants())
+        {
+            var key = GetXamlKey(element);
+            if (key is not null)
+            {
+                _ = keys.Add(key);
+            }
+        }
+
+        return keys;
+    }
+
+    /// <summary>Reads keyed literal colors from a desktop resource dictionary.</summary>
+    /// <param name="path">The resource dictionary path.</param>
+    /// <returns>The keyed colors.</returns>
+    private static Dictionary<string, RgbaColor> ReadColorResources(string path)
+    {
+        var colors = new Dictionary<string, RgbaColor>(StringComparer.Ordinal);
+        foreach (var element in XDocument.Load(path).Descendants())
+        {
+            if (element.Name.LocalName != "Color")
+            {
+                continue;
+            }
+
+            var key = GetXamlKey(element);
+            if (key is not null && element.Value.StartsWith('#'))
+            {
+                colors.Add(key, ParseColor(element.Value));
+            }
+        }
+
+        return colors;
+    }
+
+    /// <summary>Gets a resource key from the XAML namespace.</summary>
+    /// <param name="element">The resource dictionary element.</param>
+    /// <returns>The resource key when present.</returns>
+    private static string? GetXamlKey(XElement element) => (string?)element.Attribute(XamlNamespace + "Key");
+
+    /// <summary>Gets the required keys that are absent from the available resource keys.</summary>
+    /// <param name="requiredKeys">The keys that must exist.</param>
+    /// <param name="availableKeys">The keys currently supplied by a dictionary.</param>
+    /// <returns>The missing resource keys.</returns>
+    private static string[] GetMissingKeys(IEnumerable<string> requiredKeys, IEnumerable<string> availableKeys)
+    {
+        var available = new HashSet<string>(availableKeys, StringComparer.Ordinal);
+        var missing = new List<string>();
+        foreach (var key in requiredKeys)
+        {
+            if (!available.Contains(key))
+            {
+                missing.Add(key);
+            }
+        }
+
+        return missing.ToArray();
+    }
+
+    /// <summary>Calculates WCAG contrast after compositing a foreground color on an opaque background.</summary>
+    /// <param name="foreground">The foreground color.</param>
+    /// <param name="background">The opaque background color.</param>
+    /// <returns>The contrast ratio.</returns>
+    private static double GetContrast(RgbaColor foreground, RgbaColor background)
+    {
+        var foregroundLuminance = foreground.CompositeOn(background).GetRelativeLuminance();
+        var backgroundLuminance = background.GetRelativeLuminance();
+        return (Math.Max(foregroundLuminance, backgroundLuminance) + ContrastOffset)
+            / (Math.Min(foregroundLuminance, backgroundLuminance) + ContrastOffset);
+    }
+
+    /// <summary>Parses an RGB or ARGB hexadecimal resource color.</summary>
+    /// <param name="value">The resource color value.</param>
+    /// <returns>The parsed color.</returns>
+    private static RgbaColor ParseColor(string value)
+    {
+        var hex = value.Trim().TrimStart('#');
+        return hex.Length switch
+        {
+            RgbHexLength => new(ByteMaximum, ParseHexByte(hex, RedOffset), ParseHexByte(hex, GreenOffset), ParseHexByte(hex, BlueOffset)),
+            ArgbHexLength => new(ParseHexByte(hex, AlphaOffset), ParseHexByte(hex, ArgbRedOffset), ParseHexByte(hex, ArgbGreenOffset), ParseHexByte(hex, ArgbBlueOffset)),
+            _ => throw new FormatException($"Unsupported theme color '{value}'."),
+        };
+    }
+
+    /// <summary>Parses one two-character hexadecimal byte.</summary>
+    /// <param name="hex">The complete hexadecimal color.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <returns>The parsed byte.</returns>
+    private static byte ParseHexByte(string hex, int offset) =>
+        byte.Parse(hex.AsSpan(offset, HexByteLength), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+
+    /// <summary>Gets an Avalonia UI theme resource path.</summary>
+    /// <param name="themeName">The theme name.</param>
+    /// <returns>The theme resource file path.</returns>
+    private static string GetAvaloniaThemePath(string themeName) =>
+        Path.Combine(SourceRoot, AvaloniaUiProject, ResourcesDirectory, ThemeDirectory, $"{themeName}.axaml");
+
+    /// <summary>Gets a WPF UI theme resource path.</summary>
+    /// <param name="themeName">The theme name.</param>
+    /// <returns>The theme resource file path.</returns>
+    private static string GetWpfThemePath(string themeName) =>
+        Path.Combine(SourceRoot, WpfUiProject, ResourcesDirectory, ThemeDirectory, $"{themeName}.xaml");
+
+    /// <summary>Locates the source root while supporting MTP's test working directory.</summary>
+    /// <returns>The source root path.</returns>
+    private static string LocateSourceRoot()
+    {
+        var current = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "CrissCross.slnx")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate CrissCross.slnx from the current test working directory.");
+    }
+
+    /// <summary>Represents an RGBA color used by contrast calculations.</summary>
+    /// <param name="Alpha">The alpha component.</param>
+    /// <param name="Red">The red component.</param>
+    /// <param name="Green">The green component.</param>
+    /// <param name="Blue">The blue component.</param>
+    private readonly record struct RgbaColor(byte Alpha, byte Red, byte Green, byte Blue)
+    {
+        /// <summary>Provides the red coefficient used by relative luminance.</summary>
+        private const double RedLuminanceCoefficient = 0.2126;
+
+        /// <summary>Provides the green coefficient used by relative luminance.</summary>
+        private const double GreenLuminanceCoefficient = 0.7152;
+
+        /// <summary>Provides the blue coefficient used by relative luminance.</summary>
+        private const double BlueLuminanceCoefficient = 0.0722;
+
+        /// <summary>Provides the sRGB linear conversion threshold.</summary>
+        private const double SrgbLinearThreshold = 0.04045;
+
+        /// <summary>Provides the sRGB linear divisor.</summary>
+        private const double SrgbLinearDivisor = 12.92;
+
+        /// <summary>Provides the sRGB gamma offset.</summary>
+        private const double SrgbGammaOffset = 0.055;
+
+        /// <summary>Provides the sRGB gamma divisor.</summary>
+        private const double SrgbGammaDivisor = 1.055;
+
+        /// <summary>Provides the sRGB gamma exponent.</summary>
+        private const double SrgbGammaExponent = 2.4;
+
+        /// <summary>Composites this color over an opaque background.</summary>
+        /// <param name="background">The opaque background color.</param>
+        /// <returns>The opaque composited color.</returns>
+        public RgbaColor CompositeOn(RgbaColor background)
+        {
+            var opacity = Alpha / (double)ByteMaximum;
+            return new(
+                ByteMaximum,
+                Blend(Red, background.Red, opacity),
+                Blend(Green, background.Green, opacity),
+                Blend(Blue, background.Blue, opacity));
+        }
+
+        /// <summary>Calculates the WCAG relative luminance of this color.</summary>
+        /// <returns>The relative luminance.</returns>
+        public double GetRelativeLuminance() =>
+            (RedLuminanceCoefficient * ToLinear(Red))
+            + (GreenLuminanceCoefficient * ToLinear(Green))
+            + (BlueLuminanceCoefficient * ToLinear(Blue));
+
+        /// <summary>Blends a foreground channel over a background channel.</summary>
+        /// <param name="foreground">The foreground channel.</param>
+        /// <param name="background">The background channel.</param>
+        /// <param name="opacity">The foreground opacity.</param>
+        /// <returns>The blended channel.</returns>
+        private static byte Blend(byte foreground, byte background, double opacity) =>
+            (byte)Math.Round((foreground * opacity) + (background * (1D - opacity)), MidpointRounding.AwayFromZero);
+
+        /// <summary>Converts an sRGB byte channel to a linear channel.</summary>
+        /// <param name="channel">The sRGB channel.</param>
+        /// <returns>The linear channel.</returns>
+        private static double ToLinear(byte channel)
+        {
+            var normalized = channel / (double)ByteMaximum;
+            return normalized <= SrgbLinearThreshold
+                ? normalized / SrgbLinearDivisor
+                : Math.Pow((normalized + SrgbGammaOffset) / SrgbGammaDivisor, SrgbGammaExponent);
+        }
+    }
+}

--- a/src/Tests/CrissCross.Reactive.Tests/CrissCross.Reactive.Tests.csproj
+++ b/src/Tests/CrissCross.Reactive.Tests/CrissCross.Reactive.Tests.csproj
@@ -31,5 +31,6 @@
     <Compile Include="..\CrissCross.Tests\NavigationJournalTests.cs" Link="Shared\NavigationJournalTests.cs" />
     <Compile Include="..\CrissCross.Tests\SemanticThemePaletteTests.cs" Link="Shared\SemanticThemePaletteTests.cs" />
     <Compile Include="..\CrissCross.Tests\StateModelEdgeCaseTests.cs" Link="Shared\StateModelEdgeCaseTests.cs" />
+    <Compile Include="..\CrissCross.Tests\ProcessValueStateTests.cs" Link="Shared\ProcessValueStateTests.cs" />
   </ItemGroup>
 </Project>

--- a/src/Tests/CrissCross.Reactive.Tests/ReactiveRoutedHostBehaviorTests.cs
+++ b/src/Tests/CrissCross.Reactive.Tests/ReactiveRoutedHostBehaviorTests.cs
@@ -478,10 +478,10 @@ public sealed class ReactiveRoutedHostBehaviorTests
         await Assert.That(() => view.WhenNavigating(null!)).Throws<ArgumentNullException>();
     }
 
-    /// <summary>Verifies repeat registration reuses setup infrastructure while replacing the active host.</summary>
+    /// <summary>Verifies registration reuses the same host lifetime and replaces resources owned by a different host.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]
-    public async Task RepeatHostRegistration_ReusesSetupAndCleanupInfrastructure()
+    public async Task HostRegistration_ReusesSameHostAndDisposesReplacedHostLifetime()
     {
         const string hostName = "reuse-reactive-host";
         using var owner = new NavigationOwner(hostName);
@@ -492,12 +492,20 @@ public sealed class ReactiveRoutedHostBehaviorTests
         var originalSetupSubject = ViewModelRoutedViewHostMixins.WhenSetupSubjects[hostName];
         var originalDisposable = ViewModelRoutedViewHostMixins.CurrentViewDisposable[hostName];
         var originalResultSignal = ViewModelRoutedViewHostMixins.ResultNavigating[hostName];
+        owner.SetMainNavigationHost(firstHost);
+        await Assert.That(ReferenceEquals(ViewModelRoutedViewHostMixins.WhenSetupSubjects[hostName], originalSetupSubject)).IsTrue();
+        await Assert.That(ReferenceEquals(ViewModelRoutedViewHostMixins.CurrentViewDisposable[hostName], originalDisposable)).IsTrue();
+        await Assert.That(ReferenceEquals(ViewModelRoutedViewHostMixins.ResultNavigating[hostName], originalResultSignal)).IsTrue();
+
         owner.SetMainNavigationHost(replacementHost);
 
         await Assert.That(ViewModelRoutedViewHostMixins.NavigationHost[hostName]).IsEqualTo(replacementHost);
-        await Assert.That(ViewModelRoutedViewHostMixins.WhenSetupSubjects[hostName]).IsEqualTo(originalSetupSubject);
-        await Assert.That(ViewModelRoutedViewHostMixins.CurrentViewDisposable[hostName]).IsEqualTo(originalDisposable);
-        await Assert.That(ViewModelRoutedViewHostMixins.ResultNavigating[hostName]).IsEqualTo(originalResultSignal);
+        await Assert.That(originalSetupSubject.IsDisposed).IsTrue();
+        await Assert.That(originalDisposable.IsDisposed).IsTrue();
+        await Assert.That(originalResultSignal.IsDisposed).IsTrue();
+        await Assert.That(ReferenceEquals(ViewModelRoutedViewHostMixins.WhenSetupSubjects[hostName], originalSetupSubject)).IsFalse();
+        await Assert.That(ReferenceEquals(ViewModelRoutedViewHostMixins.CurrentViewDisposable[hostName], originalDisposable)).IsFalse();
+        await Assert.That(ReferenceEquals(ViewModelRoutedViewHostMixins.ResultNavigating[hostName], originalResultSignal)).IsFalse();
     }
 
     /// <summary>Verifies resolved navigation reports a missing navigator after all locator fallbacks are removed.</summary>
@@ -755,10 +763,10 @@ public sealed class ReactiveRoutedHostBehaviorTests
         await Assert.That(backStates).Contains(true);
     }
 
-    /// <summary>Verifies a renamed host without a matching setup signal does not publish a stale setup event.</summary>
+    /// <summary>Verifies a renamed visual host retains setup notifications through its registered logical name.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]
-    public async Task PrimarySetup_RenamedHostWithoutSetupSignalStaysSilent()
+    public async Task PrimarySetup_RenamedVisualHostRetainsLogicalSetupSignal()
     {
         const string initialHostName = "primary-setup-initial-host";
         const string renamedHostName = "primary-setup-renamed-host";
@@ -771,7 +779,9 @@ public sealed class ReactiveRoutedHostBehaviorTests
         using var subscription = owner.WhenSetup().Subscribe(setupStates.Add);
         AppLocator.CurrentMutable.SetupComplete();
 
-        await Assert.That(setupStates).IsEmpty();
+        await Assert.That(setupStates).Contains(true);
+        await Assert.That(host.Name).IsEqualTo(renamedHostName);
+        await Assert.That(ViewModelRoutedViewHostMixins.NavigationHost[initialHostName]).IsSameReferenceAs(host);
     }
 
     /// <summary>Registers the standard resolved view-model/view pair with explicitly typed factories.</summary>

--- a/src/Tests/CrissCross.Tests/CoreBehaviorBranchCoverageTests.cs
+++ b/src/Tests/CrissCross.Tests/CoreBehaviorBranchCoverageTests.cs
@@ -1,0 +1,427 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI;
+
+namespace CrissCross.Tests;
+
+/// <summary>Exercises public edge behavior that feeds core branch coverage.</summary>
+[System.Diagnostics.DebuggerDisplay("{DebuggerDisplay,nq}")]
+public sealed class CoreBehaviorBranchCoverageTests
+{
+    /// <summary>Provides the created-date field key used by filter scenarios.</summary>
+    private const string CreatedKey = "created";
+
+    /// <summary>Provides the display name used by created-date filter scenarios.</summary>
+    private const string CreatedDisplayName = "Created";
+
+    /// <summary>Provides a whitespace-padded navigation contract.</summary>
+    private const string DetailContract = " detail ";
+
+    /// <summary>Provides a key that should not match lookups.</summary>
+    private const string MissingKey = "missing";
+
+    /// <summary>Provides the name field key used by filter scenarios.</summary>
+    private const string NameKey = "name";
+
+    /// <summary>Provides the pending step key.</summary>
+    private const string PendingKey = "pending";
+
+    /// <summary>Provides the review category and step key.</summary>
+    private const string ReviewKey = "review";
+
+    /// <summary>Provides the status field key.</summary>
+    private const string StatusKey = "status";
+
+    /// <summary>Provides the summary field and step key.</summary>
+    private const string SummaryKey = "summary";
+
+    /// <summary>Provides the summary display name used by descriptor scenarios.</summary>
+    private const string SummaryDisplayName = "Summary";
+
+    /// <summary>Provides the trimmed title key expected from descriptor construction.</summary>
+    private const string TitleKey = "title";
+
+    /// <summary>Provides a common object value for token scenarios.</summary>
+    private const string ValueText = "value";
+
+    /// <summary>Provides the expected count for single-item assertions.</summary>
+    private const int ExpectedSingleCount = 1;
+
+    /// <summary>Provides a count used for date ranges and result summaries.</summary>
+    private const int ExpectedTwoCount = 2;
+
+    /// <summary>Provides the zero-based last page index for a five-item collection with two-item pages.</summary>
+    private const int LastPageIndex = 2;
+
+    /// <summary>Provides the minimum clamped page size.</summary>
+    private const int OneItemPageSize = 1;
+
+    /// <summary>Provides a standard two-item page size.</summary>
+    private const int TwoItemPageSize = 2;
+
+    /// <summary>Provides the total item count used by paging boundary tests.</summary>
+    private const int TotalItemCount = 5;
+
+    /// <summary>Provides an undefined enum value used by fallback formatting tests.</summary>
+    private const int UndefinedEnumValue = 999;
+
+    /// <summary>Gets a debugger-safe representation of this test fixture.</summary>
+    [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+    private string DebuggerDisplay => ToString() ?? GetType().Name;
+
+    /// <summary>Verifies disposal paths stay idempotent and protected false-dispose leaves owned disposables alive.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task DisposalLifetime_PublicAndProtectedPathsRemainIdempotent()
+    {
+        var rxObject = new ExposedDisposeRxObject();
+        var wasDisposed = false;
+        rxObject.GetDisposables().Add(new ActionDisposable(() => wasDisposed = true));
+
+        rxObject.DisposeFromTest(false);
+        var disposedAfterFalsePath = rxObject.IsDisposed;
+
+        rxObject.DisposeFromTest(true);
+        rxObject.DisposeFromTest(true);
+
+        await Assert.That(disposedAfterFalsePath).IsFalse();
+        await Assert.That(wasDisposed).IsTrue();
+        await Assert.That(rxObject.IsDisposed).IsTrue();
+    }
+
+    /// <summary>Verifies event-signal subscriptions remove handlers exactly once and stop forwarding after disposal.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task EventSignals_UnsubscribeOnceAndStopForwardingAfterDisposal()
+    {
+        var source = new EventSource();
+        var received = new List<EventArgs>();
+        var observable = EventSignal.From<EventArgs>(source.AddHandler, source.RemoveHandler);
+
+        var subscription = observable.Subscribe(received.Add);
+        source.Raise(EventArgs.Empty);
+        subscription.Dispose();
+        subscription.Dispose();
+        source.Raise(EventArgs.Empty);
+
+        await Assert.That(source.AddCount).IsEqualTo(ExpectedSingleCount);
+        await Assert.That(source.RemoveCount).IsEqualTo(ExpectedSingleCount);
+        await Assert.That(received.Count).IsEqualTo(ExpectedSingleCount);
+    }
+
+    /// <summary>Verifies date range projections for reversed ranges and inclusive/exclusive boundaries.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task DateRanges_ProjectReversedAndBoundaryContainmentStates()
+    {
+        var start = new DateTimeOffset(2026, 9, 6, 8, 0, 0, TimeSpan.Zero);
+        var end = start.AddHours(ExpectedTwoCount);
+        var reversedStart = end;
+        var reversedEnd = start;
+        var reversed = new DateTimeRange(reversedStart, reversedEnd, DateTimeRangePreset.Custom, ReviewKey);
+        var inclusive = new DateTimeRange(
+            start,
+            end,
+            DateTimeRangePreset.Today,
+            null,
+            true,
+            TimeSpan.FromHours(ExpectedTwoCount));
+        var exclusive = new DateTimeRange(start, end, DateTimeRangePreset.Yesterday, null, false, null);
+
+        await Assert.That(reversed.HasValue).IsTrue();
+        await Assert.That(reversed.IsReversed).IsTrue();
+        await Assert.That(reversed.ExceedsMaximumDuration).IsFalse();
+        await Assert.That(reversed.Duration).IsEqualTo(TimeSpan.Zero);
+        await Assert.That(reversed.ValidationMessage).IsEqualTo("Start must be before or equal to end.");
+        await Assert.That(reversed.DisplayText).IsEqualTo("review: invalid range");
+        await Assert.That(inclusive.Contains(end)).IsTrue();
+        await Assert.That(exclusive.Contains(start.AddTicks(-ExpectedSingleCount))).IsFalse();
+        await Assert.That(exclusive.Contains(end)).IsFalse();
+    }
+
+    /// <summary>Verifies search, pagination, and theme boundary states with nullable or unsupported inputs.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task SharedStates_ProjectNullableEmptyAndUnsupportedBoundaries()
+    {
+        var emptySearch = new SearchQueryState();
+        var filteredSearch = new SearchQueryState(
+            " query ",
+            resultCount: ExpectedTwoCount,
+            filters: [new FilterToken(StatusKey, FilterOperator.Equals, ValueText, "Status equals value")]);
+        var emptyPage = new PaginationState(0, 0, 0);
+        var lastPage = new PaginationState(LastPageIndex, TwoItemPageSize, TotalItemCount);
+        var unsupportedHighContrast = new ThemePreferenceState(ThemeChoice.HighContrast, ThemeChoice.Dark, false);
+        var unknownTheme = new ThemePreferenceState((ThemeChoice)UndefinedEnumValue, (ThemeChoice)UndefinedEnumValue, false);
+
+        await Assert.That(emptySearch.NormalizedText).IsEmpty();
+        await Assert.That(emptySearch.HasQuery).IsFalse();
+        await Assert.That(emptySearch.ActiveFilters.Count).IsEqualTo(0);
+        await Assert.That(filteredSearch.NormalizedText).IsEqualTo("query");
+        await Assert.That(filteredSearch.IsFiltered).IsTrue();
+        await Assert.That(filteredSearch.ResultSummary).IsEqualTo("2 results");
+        await Assert.That(emptyPage.PageSize).IsEqualTo(OneItemPageSize);
+        await Assert.That(emptyPage.FirstItemNumber).IsEqualTo(0);
+        await Assert.That(emptyPage.LastItemNumber).IsEqualTo(0);
+        await Assert.That(emptyPage.SummaryText).IsEqualTo("No items");
+        await Assert.That(lastPage.FirstItemNumber).IsEqualTo(TotalItemCount);
+        await Assert.That(lastPage.LastItemNumber).IsEqualTo(TotalItemCount);
+        await Assert.That(lastPage.CanGoNext).IsFalse();
+        await Assert.That(lastPage.CanGoLast).IsFalse();
+        await Assert.That(unsupportedHighContrast.SupportsChoice(ThemeChoice.HighContrast)).IsFalse();
+        await Assert.That(unsupportedHighContrast.DisplayText).IsEqualTo("High contrast (using Dark)");
+        await Assert.That(unknownTheme.EffectiveChoice).IsEqualTo(ThemeChoice.Light);
+        await Assert.That(unknownTheme.DisplayText).IsEqualTo("System");
+    }
+
+    /// <summary>Verifies filter descriptors and expressions expose fallback operator, value formatting, and activity behavior.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task Filters_ProjectFallbackOperatorsValueFormatsAndActivityStates()
+    {
+        var when = new DateTimeOffset(2026, 9, 6, 8, 0, 0, TimeSpan.Zero);
+        var explicitDescriptor = new FilterDescriptor(
+            CreatedKey,
+            CreatedDisplayName,
+            FilterEditorKind.DateTime,
+            [FilterOperator.NotEquals],
+            [],
+            null,
+            false);
+        var fallbackDescriptor = new FilterDescriptor(StatusKey, "Status", (FilterEditorKind)UndefinedEnumValue);
+        var disabledExpression = new FilterExpression(NameKey, FilterOperator.Contains, ValueText, NameKey, false);
+        var whitespaceExpression = new FilterExpression(NameKey, FilterOperator.Contains, "   ");
+        var objectExpression = new FilterExpression(CreatedKey, FilterOperator.Equals, when);
+        var fallbackToken = new FilterExpression(StatusKey, (FilterOperator)UndefinedEnumValue, ValueText).ToToken();
+        var describedToken = objectExpression.ToToken(explicitDescriptor);
+
+        await Assert.That(explicitDescriptor.DefaultOperator).IsEqualTo(FilterOperator.NotEquals);
+        await Assert.That(explicitDescriptor.HasChoices).IsFalse();
+        await Assert.That(explicitDescriptor.SupportsOperator(FilterOperator.Contains)).IsFalse();
+        await Assert.That(explicitDescriptor.CreateDisplayText(FilterOperator.Equals, when)).IsEqualTo("Created equals 2026-09-06 08:00");
+        await Assert.That(explicitDescriptor.CreateDisplayText((FilterOperator)UndefinedEnumValue, null)).IsEqualTo("Created 999 ");
+        await Assert.That(fallbackDescriptor.DefaultOperator).IsEqualTo(FilterOperator.Equals);
+        await Assert.That(disabledExpression.IsActive).IsFalse();
+        await Assert.That(whitespaceExpression.IsActive).IsFalse();
+        await Assert.That(objectExpression.IsActive).IsTrue();
+        await Assert.That(fallbackToken.DisplayText).IsEqualTo("status 999 value");
+        await Assert.That(describedToken.Operator).IsEqualTo(FilterOperator.Equals);
+        await Assert.That(describedToken.DisplayText).IsEqualTo("Created equals 2026-09-06 08:00");
+    }
+
+    /// <summary>Verifies property-grid descriptors and groups preserve fallback state and summary behavior.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task PropertyGrid_ProjectFallbackGroupsAndCommitBoundaries()
+    {
+        var resetCommand = new TestCommand();
+        var general = new PropertyDescriptorModel(
+            " title ",
+            " Title ",
+            new PropertyDescriptorOptions { Value = string.Empty, OriginalValue = string.Empty, TemplateKey = "   ", Choices = null, ValidationMessages = null });
+        var modified = new PropertyDescriptorModel(
+            StatusKey,
+            "Status",
+            new PropertyDescriptorOptions { Category = ReviewKey, Value = true, OriginalValue = false, ResetCommand = resetCommand });
+        var invalid = new PropertyDescriptorModel(
+            SummaryKey,
+            SummaryDisplayName,
+            new PropertyDescriptorOptions { Value = new DateTimeOffset(2026, 9, 6, 8, 0, 0, TimeSpan.Zero), ValidationMessages = [new ValidationMessage(SummaryKey, SummaryDisplayName, "Required")] });
+        var emptyGroup = new PropertyDescriptorGroup("   ");
+        var modifiedGroup = new PropertyDescriptorGroup(ReviewKey, [modified]);
+        var state = new PropertyGridState([general, modified, invalid], "TRUE", false);
+        var committingState = new PropertyGridState([modified], null, true);
+
+        await Assert.That(general.Key).IsEqualTo(TitleKey);
+        await Assert.That(general.Category).IsEqualTo("General");
+        await Assert.That(general.TemplateKey).IsNull();
+        await Assert.That(general.HasValue).IsFalse();
+        await Assert.That(general.HasChoices).IsFalse();
+        await Assert.That(general.IsModified).IsFalse();
+        await Assert.That(general.ValueDisplayText).IsEmpty();
+        await Assert.That(modified.ValueDisplayText).IsEqualTo("True");
+        await Assert.That(invalid.ValueDisplayText).IsEqualTo("2026-09-06 08:00");
+        await Assert.That(emptyGroup.Name).IsEqualTo("General");
+        await Assert.That(emptyGroup.HasModifiedDescriptors).IsFalse();
+        await Assert.That(emptyGroup.HasValidationErrors).IsFalse();
+        await Assert.That(modifiedGroup.HasModifiedDescriptors).IsTrue();
+        await Assert.That(state.VisibleDescriptorCount).IsEqualTo(ExpectedSingleCount);
+        await Assert.That(state.SummaryText).IsEqualTo("3 properties, 1 invalid");
+        await Assert.That(state.CanCommit).IsFalse();
+        await Assert.That(state.CanReset).IsTrue();
+        await Assert.That(committingState.CanReset).IsFalse();
+        await Assert.That(state.GetDescriptor(MissingKey)).IsNull();
+    }
+
+    /// <summary>Verifies step descriptors and steppers expose blocking, skipped, and missing-current boundaries.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task Stepper_ProjectBlockingSkippedAndMissingCurrentBoundaries()
+    {
+        var first = new StepDescriptor(
+            PendingKey,
+            "Pending",
+            new StepDescriptorOptions { CanLeave = false });
+        var blockedByValidation = new StepDescriptor(
+            ReviewKey,
+            "Review",
+            new StepDescriptorOptions { ValidationMessages = [new ValidationMessage(ReviewKey, "Review", "Fix review")] });
+        var skipped = new StepDescriptor(
+            SummaryKey,
+            SummaryDisplayName,
+            new StepDescriptorOptions { Status = StepStatus.Skipped, IsOptional = true });
+        var state = new StepperState([first, blockedByValidation, skipped], MissingKey, StepperOrientation.Vertical);
+        var finalBlockedState = new StepperState([blockedByValidation], ReviewKey);
+
+        await Assert.That(first.IsBlocking).IsFalse();
+        await Assert.That(first.IsAvailable).IsTrue();
+        await Assert.That(blockedByValidation.IsBlocking).IsTrue();
+        await Assert.That(blockedByValidation.IsAvailable).IsFalse();
+        await Assert.That(skipped.IsComplete).IsTrue();
+        await Assert.That(skipped.DisplayTitle).IsEqualTo($"{SummaryDisplayName} (optional)");
+        await Assert.That(state.CurrentKey).IsEqualTo(PendingKey);
+        await Assert.That(state.CurrentIndex).IsEqualTo(0);
+        await Assert.That(state.Orientation).IsEqualTo(StepperOrientation.Vertical);
+        await Assert.That(state.BlockingStepCount).IsEqualTo(ExpectedSingleCount);
+        await Assert.That(state.CanGoPrevious).IsFalse();
+        await Assert.That(state.CanGoNext).IsFalse();
+        await Assert.That(state.CanFinish).IsFalse();
+        await Assert.That(state.GetStep(MissingKey)).IsNull();
+        await Assert.That(finalBlockedState.CanFinish).IsFalse();
+    }
+
+    /// <summary>Verifies navigation value objects normalize empty contracts and preserve runtime keys.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task NavigationValueObjects_ProjectNullContractsAndRuntimeKeys()
+    {
+        var viewModel = new TestNavigationViewModel();
+        var view = new TestNavigationView { ViewModel = viewModel };
+        var request = new NavigationRequest(
+            NavigationSourceKind.ViewModel,
+            viewModel,
+            typeof(TestNavigationViewModel),
+            "   ",
+            null,
+            NavigationType.New,
+            default);
+        var lookup = new NavigationLookupKey(
+            NavigationSourceKind.ViewModel,
+            typeof(TestNavigationViewModel),
+            null);
+        var sameLookup = new NavigationLookupKey(
+            NavigationSourceKind.ViewModel,
+            typeof(TestNavigationViewModel),
+            null);
+        var differentLookup = new NavigationLookupKey(
+            NavigationSourceKind.View,
+            typeof(TestNavigationViewModel),
+            null);
+        var resolution = new NavigationResolution(viewModel, view, DetailContract, ValueText, NavigationType.Refresh);
+        var typedResolution = new NavigationResolution<TestNavigationViewModel, TestNavigationView>(
+            viewModel,
+            view,
+            "   ",
+            null,
+            NavigationType.New);
+
+        await Assert.That(request.Contract).IsNull();
+        await Assert.That(request.Parameter).IsNull();
+        await Assert.That(lookup.Equals((object?)sameLookup)).IsTrue();
+        await Assert.That(lookup == sameLookup).IsTrue();
+        await Assert.That(lookup != differentLookup).IsTrue();
+        await Assert.That(lookup.GetHashCode()).IsEqualTo(sameLookup.GetHashCode());
+        await Assert.That(resolution.Contract).IsEqualTo(DetailContract);
+        await Assert.That(resolution.Parameter).IsEqualTo(ValueText);
+        await Assert.That(typedResolution.Contract).IsNull();
+        await Assert.That(typedResolution.Parameter).IsNull();
+    }
+
+    /// <summary>Exposes protected disposal for lifecycle branch testing.</summary>
+    private sealed class ExposedDisposeRxObject : RxObject
+    {
+        /// <summary>Gets the disposable collection owned by the object.</summary>
+        /// <returns>The owned disposable collection.</returns>
+        public CompositeDisposable GetDisposables() => Disposables;
+
+        /// <summary>Invokes the protected dispose path with the supplied flag.</summary>
+        /// <param name="disposing">A value indicating whether managed resources should be disposed.</param>
+        public void DisposeFromTest(bool disposing) => Dispose(disposing);
+    }
+
+    /// <summary>Provides a delegate-backed disposable for disposal assertions.</summary>
+    /// <param name="onDispose">The callback to invoke on disposal.</param>
+    private sealed class ActionDisposable(Action onDispose) : IDisposable
+    {
+        /// <summary>Invokes the configured disposal callback.</summary>
+        public void Dispose() => onDispose();
+    }
+
+    /// <summary>Provides a counting event source for event-signal subscription tests.</summary>
+    private sealed class EventSource
+    {
+        /// <summary>Stores the subscribed event handlers.</summary>
+        private EventHandler<EventArgs>? _raised;
+
+        /// <summary>Gets the number of handler add operations.</summary>
+        public int AddCount { get; private set; }
+
+        /// <summary>Gets the number of handler remove operations.</summary>
+        public int RemoveCount { get; private set; }
+
+        /// <summary>Adds a handler and records the subscription.</summary>
+        /// <param name="handler">The handler to add.</param>
+        public void AddHandler(EventHandler<EventArgs> handler)
+        {
+            AddCount++;
+            _raised += handler;
+        }
+
+        /// <summary>Removes a handler and records the unsubscription.</summary>
+        /// <param name="handler">The handler to remove.</param>
+        public void RemoveHandler(EventHandler<EventArgs> handler)
+        {
+            RemoveCount++;
+            _raised -= handler;
+        }
+
+        /// <summary>Raises the event with the supplied arguments.</summary>
+        /// <param name="args">The event arguments.</param>
+        public void Raise(EventArgs args) => _raised?.Invoke(this, args);
+    }
+
+    /// <summary>Provides a simple command used by immutable state snapshots.</summary>
+    private sealed class TestCommand : System.Windows.Input.ICommand
+    {
+        /// <summary>Occurs when command availability changes.</summary>
+        public event EventHandler? CanExecuteChanged;
+
+        /// <summary>Determines whether the command can execute.</summary>
+        /// <param name="parameter">The optional command parameter.</param>
+        /// <returns><c>true</c>.</returns>
+        public bool CanExecute(object? parameter) => true;
+
+        /// <summary>Executes the command and raises the availability event.</summary>
+        /// <param name="parameter">The optional command parameter.</param>
+        public void Execute(object? parameter) => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>Provides a navigation view model for resolution value-object tests.</summary>
+    private sealed class TestNavigationViewModel : RxObject;
+
+    /// <summary>Provides a navigation view for typed and untyped resolution tests.</summary>
+    private sealed class TestNavigationView : IViewFor<TestNavigationViewModel>
+    {
+        /// <inheritdoc />
+        object? IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (TestNavigationViewModel?)value;
+        }
+
+        /// <inheritdoc />
+        public TestNavigationViewModel? ViewModel { get; set; }
+    }
+}

--- a/src/Tests/CrissCross.Tests/CoreCoverageEdgeBehaviorTests.cs
+++ b/src/Tests/CrissCross.Tests/CoreCoverageEdgeBehaviorTests.cs
@@ -670,7 +670,7 @@ public sealed class CoreCoverageEdgeBehaviorTests
     [Test]
     public async Task ObservableListHelpers_IgnoreNullSnapshots()
     {
-        using var source = new StateSignal<IEnumerable<IObservable<int>>?>(null);
+        using var source = new Signal<IEnumerable<IObservable<int>>>();
         var resultCount = 0;
         using var subscription = source.AnyMatch(static value => value > 0).Subscribe(_ => resultCount++);
 

--- a/src/Tests/CrissCross.Tests/CrissCross.Tests.csproj
+++ b/src/Tests/CrissCross.Tests/CrissCross.Tests.csproj
@@ -1,15 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NoWarn>$(NoWarn);SA0001;SA1201;SA1600;SA1633;SA1513;SA1516;SA1122;SA1127;CS1591;CS0219;CS8620;CA1001;CA1822;TUnitAssertions0005</NoWarn>
     <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\CrissCross.Maui.UI.Gallery\GalleryViewModel.cs" Link="Gallery\GalleryViewModel.cs" />
     <ProjectReference Include="..\..\CrissCross\CrissCross.csproj" />
     <ProjectReference Include="..\..\CrissCross.Maui.UI\CrissCross.Maui.UI.csproj" />
     <Using Include="TUnit.Core"/>

--- a/src/Tests/CrissCross.Tests/GalleryExampleCoverageTests.cs
+++ b/src/Tests/CrissCross.Tests/GalleryExampleCoverageTests.cs
@@ -187,11 +187,15 @@ public class GalleryExampleCoverageTests
         await Assert.That(view).Contains("mauiui:BusyOverlay");
         await Assert.That(view).Contains("mauiui:SearchBox");
         await Assert.That(view).Contains("mauiui:ThemeSwitcher");
+        await Assert.That(viewModel).Contains("supportsHighContrast: true");
+        await Assert.That(viewModel).Contains("UseCrissCrossMauiUiResources(ThemeState)");
+        await Assert.That(viewModel).Contains("Application.Current?.RequestedTheme");
         await Assert.That(view).Contains("mauiui:DataPager");
         await Assert.That(view).Contains("mauiui:DateTimeRangePicker");
         await Assert.That(view).Contains("mauiui:SegmentedControl");
         await Assert.That(view).Contains("mauiui:ChipGroup");
         await Assert.That(view).Contains("mauiui:Stepper");
+        await Assert.That(view).Contains("mauiui:ProcessValueIndicator");
         await Assert.That(app).Contains("UseCrissCrossMauiUiResources");
         await Assert.That(project).Contains("CrissCross.Maui.UI.csproj");
     }

--- a/src/Tests/CrissCross.Tests/MauiBusyOverlayCompositionTests.cs
+++ b/src/Tests/CrissCross.Tests/MauiBusyOverlayCompositionTests.cs
@@ -1,0 +1,265 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows.Input;
+using CrissCross.Maui.UI.Controls;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+
+namespace CrissCross.Tests;
+
+/// <summary>Verifies the MAUI busy overlay composes native visual content around consumer content.</summary>
+[System.Diagnostics.DebuggerDisplay("{DebuggerDisplay,nq}")]
+public sealed class MauiBusyOverlayCompositionTests
+{
+    /// <summary>Provides the determinate progress used by the busy operation test.</summary>
+    private const double DeterminateProgress = 0.4D;
+
+    /// <summary>Provides the expected single template part count.</summary>
+    private const int ExpectedSingleCount = 1;
+
+    /// <summary>Provides the expected root child count.</summary>
+    private const int ExpectedRootChildCount = 2;
+
+    /// <summary>Provides the operation title used by busy overlay tests.</summary>
+    private const string OperationTitle = "Saving";
+
+    /// <summary>Provides the operation message used by busy overlay tests.</summary>
+    private const string OperationMessage = "Writing values";
+
+    /// <summary>Gets a debugger-safe representation of this test fixture.</summary>
+    [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+    private string DebuggerDisplay => ToString() ?? GetType().Name;
+
+    /// <summary>Verifies the default control template preserves consumer content and layers a non-transparent blocker above it.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task Template_PreservesConsumerContentAndCreatesBusyOnlyBlockingLayer()
+    {
+        var coveredContent = new Label { Text = "Covered content" };
+        var overlay = new BusyOverlay { Content = coveredContent };
+        var root = CreateTemplateRoot(overlay);
+        var blockingLayer = GetBlockingLayer(root);
+
+        await Assert.That(overlay.Content).IsEqualTo(coveredContent);
+        await Assert.That(root.Children.Count).IsEqualTo(ExpectedRootChildCount);
+        await Assert.That(CountChildrenOfType<ContentPresenter>(root)).IsEqualTo(ExpectedSingleCount);
+        await Assert.That(ReferenceEquals(FindChild<ContentPresenter>(root).Content, coveredContent)).IsTrue();
+        await Assert.That(blockingLayer.InputTransparent).IsFalse();
+        await Assert.That(blockingLayer.IsVisible).IsFalse();
+        await Assert.That(FindSingleDescendant<ActivityIndicator>(root).IsRunning).IsFalse();
+    }
+
+    /// <summary>Verifies determinate operations show progress, text, and a command-backed cancel action.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task Template_DeterminateOperationShowsProgressTextAndCancelCommand()
+    {
+        var command = new TrackingCommand();
+        var overlay = new BusyOverlay { Operation = new(OperationTitle, OperationMessage, DeterminateProgress, command) };
+        var root = CreateTemplateRoot(overlay);
+        var labels = FindDescendants<Label>(root);
+        var progress = FindSingleDescendant<ProgressBar>(root);
+        var activity = FindSingleDescendant<ActivityIndicator>(root);
+        var cancel = FindSingleDescendant<Button>(root);
+
+        cancel.Command?.Execute(null);
+
+        await Assert.That(overlay.IsBusy).IsTrue();
+        await Assert.That(SemanticProperties.GetDescription(overlay)).IsEqualTo("Saving Writing values");
+        await Assert.That(labels.Exists(static label => label.Text == OperationTitle)).IsTrue();
+        await Assert.That(labels.Exists(static label => label.Text == OperationMessage)).IsTrue();
+        await Assert.That(progress.IsVisible).IsTrue();
+        await Assert.That(progress.Progress).IsEqualTo(DeterminateProgress);
+        await Assert.That(activity.IsVisible).IsFalse();
+        await Assert.That(activity.IsRunning).IsFalse();
+        await Assert.That(cancel.IsVisible).IsTrue();
+        await Assert.That(cancel.Text).IsEqualTo("Cancel");
+        await Assert.That(command.ExecutionCount).IsEqualTo(ExpectedSingleCount);
+    }
+
+    /// <summary>Verifies indeterminate operations show the activity indicator and hide optional determinate/cancel controls.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task Template_IndeterminateOperationShowsSpinnerAndHidesOptionalControls()
+    {
+        var overlay = new BusyOverlay { Operation = new(OperationTitle) };
+        var root = CreateTemplateRoot(overlay);
+        var progress = FindSingleDescendant<ProgressBar>(root);
+        var activity = FindSingleDescendant<ActivityIndicator>(root);
+        var cancel = FindSingleDescendant<Button>(root);
+        var message = FindDescendants<Label>(root).Find(static label => label.Text?.Length == 0) ?? throw new InvalidOperationException("Expected an empty message label.");
+
+        await Assert.That(activity.IsVisible).IsTrue();
+        await Assert.That(activity.IsRunning).IsTrue();
+        await Assert.That(progress.IsVisible).IsFalse();
+        await Assert.That(cancel.IsVisible).IsFalse();
+        await Assert.That(message.IsVisible).IsFalse();
+        overlay.Operation = new(" ");
+        await Assert.That(activity.IsRunning).IsFalse();
+        await Assert.That(overlay.IsBusy).IsFalse();
+        await Assert.That(SemanticProperties.GetDescription(overlay)).IsEqualTo("Idle");
+    }
+
+    /// <summary>Creates the root visual from an overlay template.</summary>
+    /// <param name="overlay">The overlay under test.</param>
+    /// <returns>The template root grid.</returns>
+    private static Grid CreateTemplateRoot(BusyOverlay overlay) =>
+        (Grid)GetSingleVisualChild(overlay);
+
+    /// <summary>Gets the overlay layer that blocks covered content while busy.</summary>
+    /// <param name="root">The template root.</param>
+    /// <returns>The blocking layer.</returns>
+    private static Grid GetBlockingLayer(Grid root) =>
+        FindChild<Grid>(root);
+
+    /// <summary>Finds a single descendant of the requested type.</summary>
+    /// <typeparam name="T">The descendant type.</typeparam>
+    /// <param name="root">The root element.</param>
+    /// <returns>The matching descendant.</returns>
+    private static T FindSingleDescendant<T>(Element root)
+        where T : Element =>
+        GetSingle(FindDescendants<T>(root));
+
+    /// <summary>Counts direct visual children of the requested type.</summary>
+    /// <typeparam name="T">The child type.</typeparam>
+    /// <param name="root">The root layout.</param>
+    /// <returns>The number of matching direct children.</returns>
+    private static int CountChildrenOfType<T>(Layout root)
+        where T : Element
+    {
+        var count = 0;
+        foreach (var child in root.Children)
+        {
+            if (child is T)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>Finds the single direct visual child of the requested type.</summary>
+    /// <typeparam name="T">The child type.</typeparam>
+    /// <param name="root">The root layout.</param>
+    /// <returns>The matching direct child.</returns>
+    private static T FindChild<T>(Layout root)
+        where T : Element
+    {
+        var matches = new List<T>();
+        foreach (var child in root.Children)
+        {
+            if (child is T typedChild)
+            {
+                matches.Add(typedChild);
+            }
+        }
+
+        return GetSingle(matches);
+    }
+
+    /// <summary>Gets the only visual child from a templated element.</summary>
+    /// <param name="element">The visual tree element.</param>
+    /// <returns>The only child element.</returns>
+    private static IVisualTreeElement GetSingleVisualChild(IVisualTreeElement element)
+    {
+        IVisualTreeElement? match = null;
+        foreach (var child in element.GetVisualChildren())
+        {
+            if (match is not null)
+            {
+                throw new InvalidOperationException("Expected a single visual child.");
+            }
+
+            match = child;
+        }
+
+        return match ?? throw new InvalidOperationException("Expected a visual child.");
+    }
+
+    /// <summary>Gets a single item from a list.</summary>
+    /// <typeparam name="T">The item type.</typeparam>
+    /// <param name="items">The items to inspect.</param>
+    /// <returns>The only item.</returns>
+    private static T GetSingle<T>(List<T> items)
+    {
+        if (items.Count != ExpectedSingleCount)
+        {
+            throw new InvalidOperationException("Expected a single matching item.");
+        }
+
+        return items[0];
+    }
+
+    /// <summary>Finds descendants of the requested type.</summary>
+    /// <typeparam name="T">The descendant type.</typeparam>
+    /// <param name="root">The root element.</param>
+    /// <returns>The matching descendants.</returns>
+    private static List<T> FindDescendants<T>(Element root)
+        where T : Element
+    {
+        var matches = new List<T>();
+        AddDescendants(root, matches);
+        return matches;
+    }
+
+    /// <summary>Adds descendants of the requested type to the supplied list.</summary>
+    /// <typeparam name="T">The descendant type.</typeparam>
+    /// <param name="element">The element to inspect.</param>
+    /// <param name="matches">The collected matches.</param>
+    private static void AddDescendants<T>(Element element, ICollection<T> matches)
+        where T : Element
+    {
+        if (element is T match)
+        {
+            matches.Add(match);
+        }
+
+        if (element is Layout layout)
+        {
+            foreach (var child in layout.Children)
+            {
+                if (child is not Element childElement)
+                {
+                    continue;
+                }
+
+                AddDescendants(childElement, matches);
+            }
+        }
+
+        if (element is Border { Content: Element borderContent })
+        {
+            AddDescendants(borderContent, matches);
+        }
+
+        if (element is not ContentView { Content: Element content })
+        {
+            return;
+        }
+
+        AddDescendants(content, matches);
+    }
+
+    /// <summary>Tracks command executions from the busy overlay cancel button.</summary>
+    private sealed class TrackingCommand : ICommand
+    {
+        /// <inheritdoc />
+        public event EventHandler? CanExecuteChanged;
+
+        /// <summary>Gets the number of executions.</summary>
+        public int ExecutionCount { get; private set; }
+
+        /// <inheritdoc />
+        public bool CanExecute(object? parameter) => true;
+
+        /// <inheritdoc />
+        public void Execute(object? parameter)
+        {
+            ExecutionCount++;
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/src/Tests/CrissCross.Tests/MauiCommandButtonStateTests.cs
+++ b/src/Tests/CrissCross.Tests/MauiCommandButtonStateTests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using CrissCross.Maui.UI.Controls;
+
+namespace CrissCross.Tests;
+
+/// <summary>Verifies command execution state transitions.</summary>
+public sealed class MauiCommandButtonStateTests
+{
+    /// <summary>Verifies ending execution clears the executing state.</summary>
+    /// <returns>The asynchronous test.</returns>
+    [Test]
+    public async Task Execution_EndingWithoutAnOutcome_ReturnsToIdle()
+    {
+        var button = new CommandButton { IsExecuting = true };
+        await Assert.That(button.State).IsEqualTo(CommandButtonState.Executing);
+        button.IsExecuting = false;
+        await Assert.That(button.State).IsEqualTo(CommandButtonState.Idle);
+    }
+
+    /// <summary>Verifies an explicitly supplied terminal outcome survives the execution transition.</summary>
+    /// <param name="outcome">The terminal command outcome.</param>
+    /// <returns>The asynchronous test.</returns>
+    [Test]
+    [Arguments(CommandButtonState.Failed)]
+    [Arguments(CommandButtonState.Succeeded)]
+    [Arguments(CommandButtonState.Cancelled)]
+    public async Task Execution_EndingAfterAnOutcome_PreservesOutcome(CommandButtonState outcome)
+    {
+        var button = new CommandButton { IsExecuting = true, State = outcome };
+        button.IsExecuting = false;
+        await Assert.That(button.State).IsEqualTo(outcome);
+    }
+}

--- a/src/Tests/CrissCross.Tests/MauiDescriptorPresenterBehaviorTests.cs
+++ b/src/Tests/CrissCross.Tests/MauiDescriptorPresenterBehaviorTests.cs
@@ -1,0 +1,224 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows.Input;
+using CrissCross.Maui.UI.Controls;
+using Microsoft.Maui.Controls;
+
+namespace CrissCross.Tests;
+
+/// <summary>Tests for MAUI descriptor-driven native filter and property presenters.</summary>
+[System.Diagnostics.DebuggerDisplay("{DebuggerDisplay,nq}")]
+public sealed class MauiDescriptorPresenterBehaviorTests
+{
+    /// <summary>Provides the active filter count used by filter bar tests.</summary>
+    private const int ActiveFilterCount = 2;
+
+    /// <summary>Provides the rendered root child count used by descriptor presenter tests.</summary>
+    private const int DescriptorRootChildCount = 3;
+
+    /// <summary>Provides the data filter result count used by filter panel tests.</summary>
+    private const int FilterPanelResultCount = 3;
+
+    /// <summary>Provides the rendered filter panel descriptor count.</summary>
+    private const int FilterDescriptorCount = 2;
+
+    /// <summary>Provides the rendered property group count.</summary>
+    private const int PropertyGroupCount = 2;
+
+    /// <summary>Provides the closed status value used by filter tests.</summary>
+    private const string ClosedStatus = "Closed";
+
+    /// <summary>Provides the flow property key used by property tests.</summary>
+    private const string FlowKey = "flow";
+
+    /// <summary>Provides the edited flow value used by property tests.</summary>
+    private const double FlowEditedValue = 12.5D;
+
+    /// <summary>Provides the original flow value used by property tests.</summary>
+    private const double FlowOriginalValue = 10D;
+
+    /// <summary>Provides the serial property key used by property tests.</summary>
+    private const string SerialKey = "serial";
+
+    /// <summary>Provides the serial value used by property tests.</summary>
+    private const string SerialValue = "A-100";
+
+    /// <summary>Provides the status field key used by filter tests.</summary>
+    private const string StatusKey = "status";
+
+    /// <summary>Gets a debugger-safe representation of this test fixture.</summary>
+    [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+    private string DebuggerDisplay => ToString() ?? GetType().Name;
+
+    /// <summary>Verifies the MAUI filter bar renders active chips and emits clear/remove command payloads.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task FilterBar_ActiveFilters_RendersChipsAndCommandPayloads()
+    {
+        var clearCommand = new CaptureCommand();
+        var removeCommand = new CaptureCommand();
+        var removable = new FilterToken(StatusKey, FilterOperator.Equals, "Open", "Status equals Open");
+        var fixedToken = new FilterToken("owner", FilterOperator.Equals, "Ops", "Owner equals Ops", false);
+        var state = new SearchQueryState("pump", submittedText: "pump", resultCount: 7, filters: [removable, fixedToken]);
+        var target = new FilterBar { ClearFiltersCommand = clearCommand, RemoveFilterCommand = removeCommand, SearchState = state };
+        var root = (VerticalStackLayout)target.Content!;
+        var chips = (FlexLayout)root.Children[1];
+
+        var removedActive = target.RemoveFilter(removable);
+        var removedFixed = target.RemoveFilter(fixedToken);
+        var cleared = target.ClearFilters();
+
+        await Assert.That(root.Children.Count).IsEqualTo(DescriptorRootChildCount);
+        await Assert.That(chips.Children.Count).IsEqualTo(ActiveFilterCount);
+        await Assert.That(removedActive).IsTrue();
+        await Assert.That(removedFixed).IsFalse();
+        await Assert.That(cleared).IsTrue();
+        await Assert.That(removeCommand.LastParameter).IsEqualTo(removable);
+        await Assert.That(clearCommand.LastParameter).IsEqualTo(state);
+        await Assert.That(SemanticProperties.GetDescription(target)).Contains("2 active filters");
+    }
+
+    /// <summary>Verifies the MAUI data filter panel renders descriptor editors and emits query-state payloads.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task DataFilterPanel_Descriptors_EditApplyAndClearCommandPayloads()
+    {
+        var applyCommand = new CaptureCommand();
+        var clearCommand = new CaptureCommand();
+        var status = new FilterDescriptor(StatusKey, "Status", FilterEditorKind.Enum, [FilterOperator.Equals], ["Open", ClosedStatus], "Open");
+        var priority = new FilterDescriptor("priority", "Priority", FilterEditorKind.Number);
+        var state = new DataFilterPanelState([status, priority], [new FilterExpression(StatusKey, FilterOperator.Equals, "Open", "Status")]);
+        var target = new DataFilterPanel
+        {
+            ApplyFiltersCommand = applyCommand,
+            ClearFiltersCommand = clearCommand,
+            FilterPanelState = state,
+            SearchText = "pump",
+            ResultCount = FilterPanelResultCount,
+        };
+        var root = (VerticalStackLayout)target.Content!;
+        var descriptors = (VerticalStackLayout)root.Children[1];
+
+        var acceptedEdit = target.SetFilterValue(StatusKey, ClosedStatus);
+        var rejectedEdit = target.SetFilterValue("missing", "ignored");
+        var applied = target.ApplyFilters();
+        var queryState = (SearchQueryState)applyCommand.LastParameter!;
+        var submittedBeforeClear = target.SubmittedQueryState;
+        var cleared = target.ClearFilters();
+
+        await Assert.That(descriptors.Children.Count).IsEqualTo(FilterDescriptorCount);
+        await Assert.That(acceptedEdit).IsTrue();
+        await Assert.That(rejectedEdit).IsFalse();
+        await Assert.That(applied).IsTrue();
+        await Assert.That(cleared).IsTrue();
+        await Assert.That(queryState.Text).IsEqualTo("pump");
+        await Assert.That(queryState.ResultCount).IsEqualTo(FilterPanelResultCount);
+        await Assert.That(queryState.ActiveFilters[0].Value).IsEqualTo(ClosedStatus);
+        await Assert.That(submittedBeforeClear).IsEqualTo(queryState);
+        await Assert.That(clearCommand.LastParameter).IsEqualTo(state);
+    }
+
+    /// <summary>Verifies the MAUI property grid renders grouped editors and commits edited descriptor state.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task PropertyGridLite_Descriptors_EditReadOnlyValidationAndCommitPayloads()
+    {
+        var setValueCommand = new CaptureCommand();
+        var commitCommand = new CaptureCommand();
+        var flow = new PropertyDescriptorModel(
+            FlowKey,
+            "Flow target",
+            new PropertyDescriptorOptions
+            {
+                Category = "Runtime",
+                EditorKind = PropertyEditorKind.Number,
+                Value = FlowOriginalValue,
+                OriginalValue = FlowOriginalValue,
+                SetValueCommand = setValueCommand,
+                ValidationMessages = [new ValidationMessage("flow", "Flow target", "verify instrument range", ValidationSeverity.Warning)],
+            });
+        var serial = new PropertyDescriptorModel(
+            SerialKey,
+            "Serial number",
+            new PropertyDescriptorOptions { Category = "Identity", Value = SerialValue, OriginalValue = SerialValue, IsReadOnly = true });
+        var state = new PropertyGridState([flow, serial]);
+        var target = new PropertyGridLite { CommitChangesCommand = commitCommand, PropertyGridState = state };
+        var root = (VerticalStackLayout)target.Content!;
+        var groups = (VerticalStackLayout)root.Children[1];
+
+        var edited = target.EditProperty(FlowKey, FlowEditedValue);
+        var rejectedReadOnly = target.EditProperty(SerialKey, "B-200");
+        var committed = target.CommitChanges();
+        var setValueDescriptor = (PropertyDescriptorModel)setValueCommand.LastParameter!;
+        var committedState = (PropertyGridState)commitCommand.LastParameter!;
+
+        await Assert.That(groups.Children.Count).IsEqualTo(PropertyGroupCount);
+        await Assert.That(GetLabelTexts(target).Exists(static text => text.Contains("verify instrument range", StringComparison.Ordinal))).IsTrue();
+        await Assert.That(edited).IsTrue();
+        await Assert.That(rejectedReadOnly).IsFalse();
+        await Assert.That(committed).IsTrue();
+        await Assert.That(setValueDescriptor.Value).IsEqualTo(FlowEditedValue);
+        await Assert.That(committedState.GetDescriptor(FlowKey)?.Value).IsEqualTo(FlowEditedValue);
+        await Assert.That(committedState.GetDescriptor(SerialKey)?.Value).IsEqualTo(SerialValue);
+        await Assert.That(committedState.CanCommit).IsTrue();
+        await Assert.That(SemanticProperties.GetDescription(target)).Contains("modified");
+    }
+
+    /// <summary>Gets label text values from a MAUI element tree.</summary>
+    /// <param name="root">The root view.</param>
+    /// <returns>The label text values.</returns>
+    private static List<string> GetLabelTexts(View root)
+    {
+        var labels = new List<string>();
+        AddLabelTexts(root, labels);
+        return labels;
+    }
+
+    /// <summary>Adds label text values from a MAUI element tree.</summary>
+    /// <param name="view">The view to inspect.</param>
+    /// <param name="labels">The label collection.</param>
+    private static void AddLabelTexts(IView view, List<string> labels)
+    {
+        if (view is Label label)
+        {
+            labels.Add(label.Text ?? string.Empty);
+        }
+
+        if (view is ContentView { Content: not null } contentView)
+        {
+            AddLabelTexts(contentView.Content, labels);
+        }
+
+        if (view is not Layout layout)
+        {
+            return;
+        }
+
+        foreach (var child in layout.Children)
+        {
+            AddLabelTexts(child, labels);
+        }
+    }
+
+    /// <summary>Captures command execution and the most recent command parameter.</summary>
+    private sealed class CaptureCommand : ICommand
+    {
+        /// <inheritdoc />
+        public event EventHandler? CanExecuteChanged;
+
+        /// <summary>Gets the most recent command parameter.</summary>
+        public object? LastParameter { get; private set; }
+
+        /// <inheritdoc />
+        public bool CanExecute(object? parameter) => true;
+
+        /// <inheritdoc />
+        public void Execute(object? parameter)
+        {
+            LastParameter = parameter;
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/src/Tests/CrissCross.Tests/MauiFunctionalControlBehaviorTests.cs
+++ b/src/Tests/CrissCross.Tests/MauiFunctionalControlBehaviorTests.cs
@@ -1,0 +1,195 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows.Input;
+using CrissCross.Maui.UI.Controls;
+using CrissCross.Maui.UI.Resources.Styles;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using CrissCrossStepper = CrissCross.Maui.UI.Controls.Stepper;
+
+namespace CrissCross.Tests;
+
+/// <summary>Tests for MAUI controls that now provide composed native default content.</summary>
+[System.Diagnostics.DebuggerDisplay("{DebuggerDisplay,nq}")]
+public sealed class MauiFunctionalControlBehaviorTests
+{
+    /// <summary>Provides the number of default EmptyState layout rows.</summary>
+    private const int EmptyStateDefaultRows = 4;
+
+    /// <summary>Provides the number of validation message rows used by the validation summary test.</summary>
+    private const int ValidationMessageCount = 2;
+
+    /// <summary>Provides the number of rendered step rows used by the stepper test.</summary>
+    private const int RenderedStepRowCount = 4;
+
+    /// <summary>Provides the first step key.</summary>
+    private const string DetailsStepKey = "details";
+
+    /// <summary>Provides the current step key.</summary>
+    private const string ReviewStepKey = "review";
+
+    /// <summary>Provides the empty state title text.</summary>
+    private const string EmptyStateTitle = "No pumps configured";
+
+    /// <summary>Provides the next step key.</summary>
+    private const string SubmitStepKey = "submit";
+
+    /// <summary>Gets a debugger-safe representation of this test fixture.</summary>
+    [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+    private string DebuggerDisplay => ToString() ?? GetType().Name;
+
+    /// <summary>Verifies the MAUI empty-state default content renders model text and exposes the primary action.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task EmptyState_ModelWithPrimaryAction_RendersDefaultContentAndInvokesCommand()
+    {
+        var command = new CaptureCommand();
+        var model = new EmptyStateModel(
+            EmptyStateTitle,
+            "Create the first pump before starting acquisition.",
+            EmptyStateVariant.NoData,
+            "Add pump");
+        var target = new EmptyState { Model = model, PrimaryCommand = command };
+        var root = (VerticalStackLayout)target.Content!;
+        var title = (Label)root.Children[1];
+        var message = (Label)root.Children[2];
+        var actions = (HorizontalStackLayout)root.Children[3];
+        var primary = (Button)actions.Children[0];
+
+        primary.Command!.Execute(null);
+
+        await Assert.That(root.Children.Count).IsEqualTo(EmptyStateDefaultRows);
+        await Assert.That(title.Text).IsEqualTo(EmptyStateTitle);
+        await Assert.That(message.Text).Contains("Create the first pump");
+        await Assert.That(primary.Text).IsEqualTo("Add pump");
+        await Assert.That(primary.IsVisible).IsTrue();
+        await Assert.That(command.WasExecuted).IsTrue();
+        await Assert.That(SemanticProperties.GetDescription(target)).Contains(EmptyStateTitle);
+    }
+
+    /// <summary>Verifies the MAUI validation summary renders actual message rows from the shared state.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task ValidationSummary_State_RendersMessagesWithSeverityText()
+    {
+        var state = new ValidationSummaryState(
+            [
+                new ValidationMessage("name", "Name", "is required", ValidationSeverity.Error),
+                new ValidationMessage("flow", "Flow", "is above nominal", ValidationSeverity.Warning),
+            ]);
+        var target = new ValidationSummary { SummaryState = state };
+        var root = (VerticalStackLayout)target.Content!;
+        var heading = (Label)root.Children[0];
+        var messages = (VerticalStackLayout)root.Children[1];
+        var firstMessage = (Label)messages.Children[0];
+        var secondMessage = (Label)messages.Children[1];
+
+        await Assert.That(heading.Text).IsEqualTo("1 error, 1 warning");
+        await Assert.That(messages.Children.Count).IsEqualTo(ValidationMessageCount);
+        await Assert.That(firstMessage.Text).IsEqualTo("Error: Name: is required");
+        await Assert.That(secondMessage.Text).IsEqualTo("Warning: Flow: is above nominal");
+        await Assert.That(SemanticProperties.GetDescription(target)).IsEqualTo("1 error, 1 warning");
+    }
+
+    /// <summary>Verifies the MAUI stepper renders steps and emits only allowed navigation requests.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task Stepper_State_RendersStepsAndRejectsUnavailableCommands()
+    {
+        var aggregateCommand = new CaptureCommand();
+        var enterCommand = new CaptureCommand();
+        var leaveCommand = new CaptureCommand();
+        var completed = new StepDescriptor(DetailsStepKey, "Details", new() { Status = StepStatus.Completed });
+        var current = new StepDescriptor(ReviewStepKey, "Review", new() { Status = StepStatus.Active, LeaveCommand = leaveCommand });
+        var next = new StepDescriptor(SubmitStepKey, "Submit", new StepDescriptorOptions { EnterCommand = enterCommand });
+        var unavailable = new StepDescriptor("blocked", "Blocked", new StepDescriptorOptions { CanEnter = false });
+        var target = new CrissCrossStepper { StepCommand = aggregateCommand, StepperState = new([completed, current, next, unavailable], ReviewStepKey, StepperOrientation.Vertical) };
+        var root = (VerticalStackLayout)target.Content!;
+        var steps = (VerticalStackLayout)root.Children[1];
+        var actions = (HorizontalStackLayout)root.Children[2];
+        var nextButton = (Button)actions.Children[1];
+
+        var renderedStepCount = steps.Children.Count;
+        var canMoveNext = nextButton.Command?.CanExecute(null) == true;
+        nextButton.Command!.Execute(null);
+        target.StepperState = new([current, unavailable], ReviewStepKey, StepperOrientation.Vertical);
+        var blockedNextButton = (Button)((HorizontalStackLayout)((VerticalStackLayout)target.Content!).Children[2]).Children[1];
+        var blocked = blockedNextButton.Command?.CanExecute(null) == true;
+
+        await Assert.That(renderedStepCount).IsEqualTo(RenderedStepRowCount);
+        await Assert.That(canMoveNext).IsTrue();
+        await Assert.That(blocked).IsFalse();
+        await Assert.That(leaveCommand.LastParameter).IsEqualTo(current);
+        await Assert.That(enterCommand.LastParameter).IsEqualTo(next);
+        await Assert.That(aggregateCommand.LastParameter).IsEqualTo(next);
+    }
+
+    /// <summary>Verifies disabled MAUI Stepper commands guard execution because MAUI Command does not enforce CanExecute in Execute.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task Stepper_DisabledCommandExecute_DoesNotEmitBlockedRequests()
+    {
+        var aggregateCommand = new CaptureCommand();
+        var current = new StepDescriptor(ReviewStepKey, "Review", new() { Status = StepStatus.Active, CanLeave = false });
+        var next = new StepDescriptor(SubmitStepKey, "Submit");
+        var target = new CrissCrossStepper { StepCommand = aggregateCommand, StepperState = new([current, next], ReviewStepKey) };
+        var actions = (HorizontalStackLayout)((VerticalStackLayout)target.Content!).Children[2];
+        var previousButton = (Button)actions.Children[0];
+        var nextButton = (Button)actions.Children[1];
+        var finishButton = (Button)actions.Children[2];
+        var previousCommand = previousButton.Command!;
+        var nextCommand = nextButton.Command!;
+        var finishCommand = finishButton.Command!;
+
+        previousCommand.Execute(null);
+        nextCommand.Execute(null);
+        finishCommand.Execute(null);
+
+        await Assert.That(previousCommand.CanExecute(null)).IsFalse();
+        await Assert.That(nextCommand.CanExecute(null)).IsFalse();
+        await Assert.That(finishCommand.CanExecute(null)).IsFalse();
+        await Assert.That(aggregateCommand.WasExecuted).IsFalse();
+    }
+
+    /// <summary>Verifies PersonPicture initials consume the accent text dynamic resource for high-contrast readability.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task PersonPicture_Initials_UseAccentTextDynamicResource()
+    {
+        var target = new PersonPicture { DisplayName = "Grace Hopper" };
+        var page = new ContentPage { Content = target };
+        page.Resources.MergedDictionaries.Add(new CrissCrossMauiHighContrastTheme());
+        var grid = (Grid)target.Content!;
+        var initials = (Label)grid.Children[0];
+
+        await Assert.That(initials.Text).IsEqualTo("GH");
+        await Assert.That(initials.TextColor).IsEqualTo(Colors.Black);
+        await Assert.That(SemanticProperties.GetDescription(target)).IsEqualTo("Grace Hopper");
+    }
+
+    /// <summary>Captures command execution and the most recent command parameter.</summary>
+    private sealed class CaptureCommand : ICommand
+    {
+        /// <inheritdoc />
+        public event EventHandler? CanExecuteChanged;
+
+        /// <summary>Gets the most recent command parameter.</summary>
+        public object? LastParameter { get; private set; }
+
+        /// <summary>Gets a value indicating whether the command has executed.</summary>
+        public bool WasExecuted { get; private set; }
+
+        /// <inheritdoc />
+        public bool CanExecute(object? parameter) => true;
+
+        /// <inheritdoc />
+        public void Execute(object? parameter)
+        {
+            LastParameter = parameter;
+            WasExecuted = true;
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/src/Tests/CrissCross.Tests/MauiGalleryCommandTests.cs
+++ b/src/Tests/CrissCross.Tests/MauiGalleryCommandTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using CrissCross.Maui.UI.Gallery;
+using Microsoft.Maui.Controls;
+
+namespace CrissCross.Tests;
+
+/// <summary>Verifies the actual gallery accepts payloads emitted by its composed controls.</summary>
+public sealed class MauiGalleryCommandTests
+{
+    /// <summary>The explicit and system theme transitions exercised by the gallery.</summary>
+    private static readonly ThemeChoice[] ThemeChoices = [ThemeChoice.HighContrast, ThemeChoice.Light, ThemeChoice.Dark, ThemeChoice.System];
+
+    /// <summary>Verifies explicit theme transitions update the gallery state and resources.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task ThemeCommand_CyclesBetweenHighContrastLightAndDark()
+    {
+        var previousApplication = Application.Current;
+        Application.SetCurrentApplication(new());
+        try
+        {
+            using var gallery = new GalleryViewModel();
+            foreach (var choice in ThemeChoices)
+            {
+                gallery.SetThemeCommand.Execute(choice);
+                await Assert.That(gallery.ThemeState.SelectedChoice).IsEqualTo(choice);
+                await Assert.That(gallery.ThemeDescription).IsEqualTo(gallery.ThemeState.DisplayText);
+            }
+        }
+        finally
+        {
+            Application.Current = previousApplication;
+        }
+    }
+
+    /// <summary>Verifies step selection consumes a descriptor and updates the selected key.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task StepCommand_AcceptsTheControlDescriptorPayload()
+    {
+        using var gallery = new GalleryViewModel();
+        var step = gallery.StepperState.Steps[0];
+        gallery.SelectStepCommand.Execute(step);
+        await Assert.That(gallery.StepperState.CurrentStep?.Key).IsEqualTo(step.Key);
+    }
+
+    /// <summary>Verifies submitted filters become the gallery search state.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task ApplyFilters_AcceptsTheSubmittedQuery()
+    {
+        using var gallery = new GalleryViewModel();
+        var query = new SearchQueryState("pump");
+        gallery.ApplyFiltersCommand.Execute(query);
+        await Assert.That(gallery.SearchState).IsSameReferenceAs(query);
+        await Assert.That(gallery.FilterPanelState.Descriptors.Count).IsGreaterThan(0);
+    }
+
+    /// <summary>Verifies committing an edited descriptor establishes a new unmodified baseline.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task CommitProperties_PreservesTheEditedValueAsTheBaseline()
+    {
+        using var gallery = new GalleryViewModel();
+        var edited = new PropertyDescriptorModel("tag", "Equipment tag", new() { Value = "PUMP-102", OriginalValue = "PUMP-101" });
+        gallery.UpdatePropertyCommand.Execute(new PropertyGridState([edited]));
+        var committed = gallery.PropertyGridState.Descriptors[0];
+        await Assert.That(committed.Value).IsEqualTo(edited.Value);
+        await Assert.That(committed.OriginalValue).IsEqualTo(edited.Value);
+        await Assert.That(committed.IsModified).IsFalse();
+    }
+}

--- a/src/Tests/CrissCross.Tests/MauiHighContrastThemeTests.cs
+++ b/src/Tests/CrissCross.Tests/MauiHighContrastThemeTests.cs
@@ -1,0 +1,414 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Xml.Linq;
+using CrissCross.Maui.UI;
+using CrissCross.Maui.UI.Resources.Styles;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls;
+
+namespace CrissCross.Tests;
+
+/// <summary>Verifies the MAUI high-contrast theme resource path.</summary>
+public sealed class MauiHighContrastThemeTests
+{
+    /// <summary>Provides the primary text contrast threshold required by WCAG 2.1 AA.</summary>
+    private const double PrimaryTextMinimumContrast = 4.5;
+
+    /// <summary>Provides the maximum color byte value.</summary>
+    private const byte ByteMaximum = byte.MaxValue;
+
+    /// <summary>Provides the RGB hex string length.</summary>
+    private const int RgbHexLength = 6;
+
+    /// <summary>Provides the ARGB hex string length.</summary>
+    private const int ArgbHexLength = 8;
+
+    /// <summary>Provides the length of one hexadecimal byte.</summary>
+    private const int HexByteLength = 2;
+
+    /// <summary>Provides the red byte offset in a hexadecimal color.</summary>
+    private const int RedOffset = 0;
+
+    /// <summary>Provides the green byte offset in a hexadecimal color.</summary>
+    private const int GreenOffset = 2;
+
+    /// <summary>Provides the blue byte offset in a hexadecimal color.</summary>
+    private const int BlueOffset = 4;
+
+    /// <summary>Provides the alpha byte offset in an ARGB hexadecimal color.</summary>
+    private const int AlphaOffset = 0;
+
+    /// <summary>Provides the red byte offset in an ARGB hexadecimal color.</summary>
+    private const int ArgbRedOffset = 2;
+
+    /// <summary>Provides the green byte offset in an ARGB hexadecimal color.</summary>
+    private const int ArgbGreenOffset = 4;
+
+    /// <summary>Provides the blue byte offset in an ARGB hexadecimal color.</summary>
+    private const int ArgbBlueOffset = 6;
+
+    /// <summary>Provides the WCAG contrast luminance offset.</summary>
+    private const double ContrastOffset = 0.05;
+
+    /// <summary>Provides the MAUI UI project directory name.</summary>
+    private const string MauiUiProject = "CrissCross.Maui.UI";
+
+    /// <summary>Provides the shared resource directory name.</summary>
+    private const string ResourcesDirectory = "Resources";
+
+    /// <summary>Provides the MAUI styles directory name.</summary>
+    private const string StylesDirectory = "Styles";
+
+    /// <summary>Provides the x namespace used by MAUI resource dictionaries.</summary>
+    private static readonly XNamespace MauiXamlNamespace = "http://schemas.microsoft.com/winfx/2009/xaml";
+
+    /// <summary>Provides the source root used to locate platform resource dictionaries.</summary>
+    private static readonly string SourceRoot = LocateSourceRoot();
+
+    /// <summary>Verifies high contrast can be activated and removed through the MAUI resource extension.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task UseCrissCrossMauiUiResources_HighContrastTogglesOverrideDictionary()
+    {
+        var resources = new ResourceDictionary();
+        var highContrast = new ThemePreferenceState(ThemeChoice.HighContrast, ThemeChoice.Light, supportsHighContrast: true);
+
+        _ = resources.UseCrissCrossMauiUiResources(highContrast);
+        _ = resources.UseCrissCrossMauiUiResources(highContrast);
+
+        await Assert.That(CountDictionaries<CrissCrossMauiUi>(resources)).IsEqualTo(1);
+        await Assert.That(CountDictionaries<CrissCrossMauiHighContrastTheme>(resources)).IsEqualTo(1);
+        await Assert.That(CountDictionaries<CrissCrossMauiLightTheme>(resources)).IsEqualTo(0);
+
+        _ = resources.UseCrissCrossMauiUiResources(ThemeChoice.Dark);
+
+        await Assert.That(CountDictionaries<CrissCrossMauiUi>(resources)).IsEqualTo(1);
+        await Assert.That(CountDictionaries<CrissCrossMauiHighContrastTheme>(resources)).IsEqualTo(0);
+        await Assert.That(CountDictionaries<CrissCrossMauiDarkTheme>(resources)).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies a System theme snapshot can use a Dark fallback when no application is available.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task UseCrissCrossMauiUiResources_SystemThemeStateUsesDarkFallbackWhenHeadless()
+    {
+        var previousApplication = Application.Current;
+        Application.Current = null;
+
+        try
+        {
+            var resources = new ResourceDictionary();
+            var systemDark = new ThemePreferenceState(ThemeChoice.System, ThemeChoice.Dark, supportsHighContrast: true);
+
+            _ = resources.UseCrissCrossMauiUiResources(systemDark);
+
+            await Assert.That(CountDictionaries<CrissCrossMauiUi>(resources)).IsEqualTo(1);
+            await Assert.That(CountDictionaries<CrissCrossMauiDarkTheme>(resources)).IsEqualTo(1);
+            await Assert.That(CountDictionaries<CrissCrossMauiLightTheme>(resources)).IsEqualTo(0);
+            await Assert.That(CountDictionaries<CrissCrossMauiHighContrastTheme>(resources)).IsEqualTo(0);
+        }
+        finally
+        {
+            Application.Current = previousApplication;
+        }
+    }
+
+    /// <summary>Verifies the default and System-choice paths follow runtime requested-theme changes.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task UseCrissCrossMauiUiResources_SystemPathsFollowRequestedThemeChanges()
+    {
+        var previousApplication = Application.Current;
+        var application = new Application { UserAppTheme = AppTheme.Dark };
+        var systemChoiceResources = new ResourceDictionary();
+        Application.SetCurrentApplication(application);
+
+        try
+        {
+            _ = application.Resources.UseCrissCrossMauiUiResources();
+            _ = systemChoiceResources.UseCrissCrossMauiUiResources(ThemeChoice.System);
+
+            await AssertHasTheme<CrissCrossMauiDarkTheme>(application.Resources);
+            await AssertHasTheme<CrissCrossMauiDarkTheme>(systemChoiceResources);
+
+            application.UserAppTheme = AppTheme.Light;
+
+            await AssertHasTheme<CrissCrossMauiLightTheme>(application.Resources);
+            await AssertHasTheme<CrissCrossMauiLightTheme>(systemChoiceResources);
+        }
+        finally
+        {
+            Application.Current = previousApplication;
+        }
+    }
+
+    /// <summary>Verifies explicit high contrast remains fixed after runtime requested-theme changes.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task UseCrissCrossMauiUiResources_ExplicitHighContrastIgnoresRequestedThemeChanges()
+    {
+        var previousApplication = Application.Current;
+        var application = new Application { UserAppTheme = AppTheme.Light };
+        Application.SetCurrentApplication(application);
+
+        try
+        {
+            _ = application.Resources.UseCrissCrossMauiUiResources();
+            _ = application.Resources.UseCrissCrossMauiUiResources(ThemeChoice.HighContrast);
+
+            await AssertHasTheme<CrissCrossMauiHighContrastTheme>(application.Resources);
+
+            application.UserAppTheme = AppTheme.Dark;
+
+            await AssertHasTheme<CrissCrossMauiHighContrastTheme>(application.Resources);
+        }
+        finally
+        {
+            Application.Current = previousApplication;
+        }
+    }
+
+    /// <summary>Verifies MAUI control styles consume dynamic semantic tokens that high contrast can override.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task ControlsStyles_UseDynamicSemanticTokensForHighContrastOverride()
+    {
+        var styles = await File.ReadAllTextAsync(GetMauiStylePath("Controls.xaml"));
+
+        await Assert.That(styles).DoesNotContain("AppThemeBinding");
+        await Assert.That(styles).Contains("{DynamicResource CrissCrossAccentColor}");
+        await Assert.That(styles).Contains("{DynamicResource CrissCrossSurfaceColor}");
+        await Assert.That(styles).Contains("{DynamicResource CrissCrossSuccessColor}");
+        await Assert.That(styles).Contains("{DynamicResource CrissCrossDangerColor}");
+        await Assert.That(styles).Contains("{DynamicResource CrissCrossCautionColor}");
+        await Assert.That(styles).Contains("{DynamicResource CrissCrossNeutralSurfaceColor}");
+    }
+
+    /// <summary>Verifies high contrast defines every active MAUI semantic token with readable foregrounds.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task HighContrastTheme_OverridesAllActiveSemanticTokensAndKeepsTextReadable()
+    {
+        var lightColors = ReadColorResources(GetMauiStylePath("Light.xaml"));
+        var darkColors = ReadColorResources(GetMauiStylePath("Dark.xaml"));
+        var highContrastColors = ReadColorResources(GetMauiStylePath("HighContrast.xaml"));
+
+        await Assert.That(GetMissingKeys(lightColors.Keys, highContrastColors.Keys)).IsEmpty();
+        await Assert.That(GetMissingKeys(darkColors.Keys, highContrastColors.Keys)).IsEmpty();
+        await Assert.That(GetContrast(highContrastColors["CrissCrossTextColor"], highContrastColors["CrissCrossSurfaceColor"]))
+            .IsGreaterThanOrEqualTo(PrimaryTextMinimumContrast);
+        await Assert.That(GetContrast(highContrastColors["CrissCrossAccentTextColor"], highContrastColors["CrissCrossAccentColor"]))
+            .IsGreaterThanOrEqualTo(PrimaryTextMinimumContrast);
+    }
+
+    /// <summary>Verifies exactly one concrete MAUI theme override is active.</summary>
+    /// <typeparam name="T">The expected concrete MAUI theme resource dictionary type.</typeparam>
+    /// <param name="resources">The resources to inspect.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    private static async Task AssertHasTheme<T>(ResourceDictionary resources)
+        where T : ResourceDictionary
+    {
+        await Assert.That(CountDictionaries<CrissCrossMauiUi>(resources)).IsEqualTo(1);
+        await Assert.That(CountDictionaries<T>(resources)).IsEqualTo(1);
+        await Assert.That(CountDictionaries<CrissCrossMauiLightTheme>(resources)
+            + CountDictionaries<CrissCrossMauiDarkTheme>(resources)
+            + CountDictionaries<CrissCrossMauiHighContrastTheme>(resources)).IsEqualTo(1);
+    }
+
+    /// <summary>Counts merged dictionaries assignable to a requested type.</summary>
+    /// <typeparam name="T">The dictionary type to count.</typeparam>
+    /// <param name="resources">The resources to inspect.</param>
+    /// <returns>The matching dictionary count.</returns>
+    private static int CountDictionaries<T>(ResourceDictionary resources)
+        where T : ResourceDictionary
+    {
+        var count = 0;
+        foreach (var dictionary in resources.MergedDictionaries)
+        {
+            if (dictionary is T)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>Gets the path for a MAUI shared style dictionary.</summary>
+    /// <param name="fileName">The style dictionary file name.</param>
+    /// <returns>The style dictionary path.</returns>
+    private static string GetMauiStylePath(string fileName) =>
+        Path.Combine(SourceRoot, MauiUiProject, ResourcesDirectory, StylesDirectory, fileName);
+
+    /// <summary>Reads keyed literal colors from a MAUI resource dictionary.</summary>
+    /// <param name="path">The resource dictionary path.</param>
+    /// <returns>The keyed colors.</returns>
+    private static Dictionary<string, RgbaColor> ReadColorResources(string path)
+    {
+        var colors = new Dictionary<string, RgbaColor>(StringComparer.Ordinal);
+        foreach (var element in XDocument.Load(path).Descendants())
+        {
+            if (element.Name.LocalName != "Color")
+            {
+                continue;
+            }
+
+            var key = GetXamlKey(element);
+            if (key is not null)
+            {
+                colors.Add(key, ParseColor(element.Value));
+            }
+        }
+
+        return colors;
+    }
+
+    /// <summary>Gets a resource key from the MAUI x namespace.</summary>
+    /// <param name="element">The resource dictionary element.</param>
+    /// <returns>The resource key when present.</returns>
+    private static string? GetXamlKey(XElement element) => (string?)element.Attribute(MauiXamlNamespace + "Key");
+
+    /// <summary>Gets the required keys that are absent from the available resource keys.</summary>
+    /// <param name="requiredKeys">The keys that must exist.</param>
+    /// <param name="availableKeys">The keys currently supplied by a dictionary.</param>
+    /// <returns>The missing resource keys.</returns>
+    private static string[] GetMissingKeys(IEnumerable<string> requiredKeys, IEnumerable<string> availableKeys)
+    {
+        var available = new HashSet<string>(availableKeys, StringComparer.Ordinal);
+        var missing = new List<string>();
+        foreach (var key in requiredKeys)
+        {
+            if (!available.Contains(key))
+            {
+                missing.Add(key);
+            }
+        }
+
+        return missing.ToArray();
+    }
+
+    /// <summary>Calculates WCAG contrast after compositing a foreground color on an opaque background.</summary>
+    /// <param name="foreground">The foreground color.</param>
+    /// <param name="background">The opaque background color.</param>
+    /// <returns>The contrast ratio.</returns>
+    private static double GetContrast(RgbaColor foreground, RgbaColor background)
+    {
+        var foregroundLuminance = foreground.CompositeOn(background).GetRelativeLuminance();
+        var backgroundLuminance = background.GetRelativeLuminance();
+        return (Math.Max(foregroundLuminance, backgroundLuminance) + ContrastOffset)
+            / (Math.Min(foregroundLuminance, backgroundLuminance) + ContrastOffset);
+    }
+
+    /// <summary>Parses an RGB or ARGB hexadecimal resource color.</summary>
+    /// <param name="value">The resource color value.</param>
+    /// <returns>The parsed color.</returns>
+    private static RgbaColor ParseColor(string value)
+    {
+        var hex = value.Trim().TrimStart('#');
+        return hex.Length switch
+        {
+            RgbHexLength => new(ByteMaximum, ParseHexByte(hex, RedOffset), ParseHexByte(hex, GreenOffset), ParseHexByte(hex, BlueOffset)),
+            ArgbHexLength => new(ParseHexByte(hex, AlphaOffset), ParseHexByte(hex, ArgbRedOffset), ParseHexByte(hex, ArgbGreenOffset), ParseHexByte(hex, ArgbBlueOffset)),
+            _ => throw new FormatException($"Unsupported theme color '{value}'."),
+        };
+    }
+
+    /// <summary>Parses one two-character hexadecimal byte.</summary>
+    /// <param name="hex">The complete hexadecimal color.</param>
+    /// <param name="offset">The byte offset.</param>
+    /// <returns>The parsed byte.</returns>
+    private static byte ParseHexByte(string hex, int offset) =>
+        byte.Parse(hex.AsSpan(offset, HexByteLength), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+
+    /// <summary>Locates the source root while supporting MTP's test working directory.</summary>
+    /// <returns>The source root path.</returns>
+    private static string LocateSourceRoot()
+    {
+        var current = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "CrissCross.slnx")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Unable to locate CrissCross.slnx from the current test working directory.");
+    }
+
+    /// <summary>Represents an RGBA color used by contrast calculations.</summary>
+    /// <param name="Alpha">The alpha component.</param>
+    /// <param name="Red">The red component.</param>
+    /// <param name="Green">The green component.</param>
+    /// <param name="Blue">The blue component.</param>
+    private readonly record struct RgbaColor(byte Alpha, byte Red, byte Green, byte Blue)
+    {
+        /// <summary>Provides the red coefficient used by relative luminance.</summary>
+        private const double RedLuminanceCoefficient = 0.2126;
+
+        /// <summary>Provides the green coefficient used by relative luminance.</summary>
+        private const double GreenLuminanceCoefficient = 0.7152;
+
+        /// <summary>Provides the blue coefficient used by relative luminance.</summary>
+        private const double BlueLuminanceCoefficient = 0.0722;
+
+        /// <summary>Provides the sRGB linear conversion threshold.</summary>
+        private const double SrgbLinearThreshold = 0.04045;
+
+        /// <summary>Provides the sRGB linear divisor.</summary>
+        private const double SrgbLinearDivisor = 12.92;
+
+        /// <summary>Provides the sRGB gamma offset.</summary>
+        private const double SrgbGammaOffset = 0.055;
+
+        /// <summary>Provides the sRGB gamma divisor.</summary>
+        private const double SrgbGammaDivisor = 1.055;
+
+        /// <summary>Provides the sRGB gamma exponent.</summary>
+        private const double SrgbGammaExponent = 2.4;
+
+        /// <summary>Composites this color over an opaque background.</summary>
+        /// <param name="background">The opaque background color.</param>
+        /// <returns>The opaque composited color.</returns>
+        public RgbaColor CompositeOn(RgbaColor background)
+        {
+            var opacity = Alpha / (double)ByteMaximum;
+            return new(
+                ByteMaximum,
+                Blend(Red, background.Red, opacity),
+                Blend(Green, background.Green, opacity),
+                Blend(Blue, background.Blue, opacity));
+        }
+
+        /// <summary>Calculates the WCAG relative luminance of this color.</summary>
+        /// <returns>The relative luminance.</returns>
+        public double GetRelativeLuminance() =>
+            (RedLuminanceCoefficient * ToLinear(Red))
+            + (GreenLuminanceCoefficient * ToLinear(Green))
+            + (BlueLuminanceCoefficient * ToLinear(Blue));
+
+        /// <summary>Blends a foreground channel over a background channel.</summary>
+        /// <param name="foreground">The foreground channel.</param>
+        /// <param name="background">The background channel.</param>
+        /// <param name="opacity">The foreground opacity.</param>
+        /// <returns>The blended channel.</returns>
+        private static byte Blend(byte foreground, byte background, double opacity) =>
+            (byte)Math.Round((foreground * opacity) + (background * (1D - opacity)), MidpointRounding.AwayFromZero);
+
+        /// <summary>Converts an sRGB byte channel to a linear channel.</summary>
+        /// <param name="channel">The sRGB channel.</param>
+        /// <returns>The linear channel.</returns>
+        private static double ToLinear(byte channel)
+        {
+            var normalized = channel / (double)ByteMaximum;
+            return normalized <= SrgbLinearThreshold
+                ? normalized / SrgbLinearDivisor
+                : Math.Pow((normalized + SrgbGammaOffset) / SrgbGammaDivisor, SrgbGammaExponent);
+        }
+    }
+}

--- a/src/Tests/CrissCross.Tests/MauiNativeControlCompositionTests.cs
+++ b/src/Tests/CrissCross.Tests/MauiNativeControlCompositionTests.cs
@@ -1,0 +1,367 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows.Input;
+using CrissCross.Maui.UI.Controls;
+using Microsoft.Maui.Controls;
+
+namespace CrissCross.Tests;
+
+/// <summary>Verifies native MAUI composition for interactive controls that project shared state.</summary>
+public sealed class MauiNativeControlCompositionTests
+{
+    /// <summary>The selected time range label.</summary>
+    private const string ShiftWindowLabel = "Shift window";
+
+    /// <summary>Provides the pager page size used by tests.</summary>
+    private const int PageSize = 10;
+
+    /// <summary>Provides the pager total item count used by tests.</summary>
+    private const int TotalItemCount = 25;
+
+    /// <summary>Provides the middle page index used by tests.</summary>
+    private const int MiddlePageIndex = 1;
+
+    /// <summary>Provides the next page index expected after pressing Next.</summary>
+    private const int NextPageIndex = 2;
+
+    /// <summary>Provides the expected composed pager button count.</summary>
+    private const int PagerButtonCount = 4;
+
+    /// <summary>Provides the expected composed theme button count when high contrast is supported.</summary>
+    private const int ThemeButtonCount = 4;
+
+    /// <summary>Provides the expected single element count.</summary>
+    private const int ExpectedSingleCount = 1;
+
+    /// <summary>Provides the expected number of endpoint input pairs.</summary>
+    private const int EndpointInputCount = 2;
+
+    /// <summary>Provides the fixed sample year used by range tests.</summary>
+    private const int RangeYear = 2026;
+
+    /// <summary>Provides the fixed sample month used by range tests.</summary>
+    private const int RangeMonth = 9;
+
+    /// <summary>Provides the fixed sample day used by range tests.</summary>
+    private const int RangeDay = 6;
+
+    /// <summary>Provides the fixed sample start hour used by range tests.</summary>
+    private const int RangeStartHour = 8;
+
+    /// <summary>Provides the fixed sample end hour used by range tests.</summary>
+    private const int RangeEndHour = 10;
+
+    /// <summary>Provides the fixed minute/second component used by range tests.</summary>
+    private const int EmptyTimeComponent = 0;
+
+    /// <summary>Provides the end offset hour used by the mixed-offset range test.</summary>
+    private const int MixedRangeEndOffsetHours = 2;
+
+    /// <summary>Provides a valid range start offset used by tests.</summary>
+    private static readonly DateTimeOffset RangeStart = new(
+        RangeYear,
+        RangeMonth,
+        RangeDay,
+        RangeStartHour,
+        EmptyTimeComponent,
+        EmptyTimeComponent,
+        TimeSpan.Zero);
+
+    /// <summary>Provides a valid range end offset used by tests.</summary>
+    private static readonly DateTimeOffset RangeEnd = new(
+        RangeYear,
+        RangeMonth,
+        RangeDay,
+        RangeEndHour,
+        EmptyTimeComponent,
+        EmptyTimeComponent,
+        TimeSpan.Zero);
+
+    /// <summary>Verifies DataPager renders native labels/buttons and emits page requests from button interaction.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task DataPager_RendersNativeNavigationAndInvokesPageCommand()
+    {
+        var command = new CaptureCommand();
+        var pager = new DataPager { PaginationState = new(MiddlePageIndex, PageSize, TotalItemCount), PageRequestCommand = command, SortKey = "timestamp", SortDescending = true };
+
+        var buttons = FindDescendants<Button>(pager);
+        var labels = FindDescendants<Label>(pager);
+        FindButton(buttons, "Next").Command?.Execute(null);
+
+        await Assert.That(GetButtonTexts(buttons)).IsEquivalentTo(["First", "Previous", "Next", "Last"]);
+        await Assert.That(GetLabelTexts(labels)).IsEquivalentTo(["11-20 of 25", "Page 2 of 3"]);
+        await Assert.That(FindButton(buttons, "First").IsEnabled).IsTrue();
+        await Assert.That(FindButton(buttons, "Previous").IsEnabled).IsTrue();
+        await Assert.That(buttons.Count).IsEqualTo(PagerButtonCount);
+        await Assert.That(pager.CurrentRequest?.PageIndex).IsEqualTo(NextPageIndex);
+        await Assert.That(pager.CurrentRequest?.SortKey).IsEqualTo("timestamp");
+        await Assert.That(pager.CurrentRequest?.SortDescending).IsTrue();
+        await Assert.That(command.LastParameter).IsEqualTo(pager.CurrentRequest);
+    }
+
+    /// <summary>Verifies ThemeSwitcher renders allowed choices and emits ThemeChoice command parameters.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task ThemeSwitcher_RendersChoicesAndInvokesThemeChoiceCommand()
+    {
+        var command = new CaptureCommand();
+        var switcher = new ThemeSwitcher { ThemeState = new(ThemeChoice.System, ThemeChoice.Dark, supportsHighContrast: true), ChangeThemeCommand = command };
+
+        var buttons = FindDescendants<Button>(switcher);
+        var description = GetSingle(FindDescendants<Label>(switcher));
+        var highContrastButton = FindButton(buttons, "High contrast");
+        highContrastButton.Command?.Execute(highContrastButton.CommandParameter);
+
+        await Assert.That(GetButtonTexts(buttons)).IsEquivalentTo(["System", "Light", "Dark", "High contrast"]);
+        await Assert.That(AllButtonsUseCommand(buttons, command)).IsTrue();
+        await Assert.That(buttons.Count).IsEqualTo(ThemeButtonCount);
+        await Assert.That(description.Text).IsEqualTo("System (Dark)");
+        await Assert.That(command.LastParameter).IsEqualTo(ThemeChoice.HighContrast);
+    }
+
+    /// <summary>Verifies DateTimeRangePicker renders native inputs, blocks invalid ranges, and emits valid ranges.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task DateTimeRangePicker_ValidatesInputsAndInvokesRangeCommand()
+    {
+        var command = new CaptureCommand();
+        var picker = new DateTimeRangePicker { Range = new(RangeStart, RangeEnd, DateTimeRangePreset.Custom, ShiftWindowLabel), ApplyRangeCommand = command };
+        var datePickers = FindDescendants<DatePicker>(picker);
+        var timePickers = FindDescendants<TimePicker>(picker);
+        var applyButton = GetSingle(FindDescendants<Button>(picker));
+
+        datePickers[1].Date = RangeStart.Date.AddDays(-1);
+        var invalidApplied = picker.ApplyCurrentRange();
+        var invalidCommandParameter = command.LastParameter;
+
+        datePickers[1].Date = RangeEnd.Date;
+        timePickers[1].Time = RangeEnd.TimeOfDay;
+        var validApplied = picker.ApplyCurrentRange();
+        var appliedRange = (DateTimeRange?)command.LastParameter;
+
+        await Assert.That(datePickers.Count).IsEqualTo(EndpointInputCount);
+        await Assert.That(timePickers.Count).IsEqualTo(EndpointInputCount);
+        await Assert.That(applyButton.Text).IsEqualTo("Apply range");
+        await Assert.That(invalidApplied).IsFalse();
+        await Assert.That(invalidCommandParameter).IsNull();
+        await Assert.That(validApplied).IsTrue();
+        await Assert.That(appliedRange?.IsValid).IsTrue();
+        await Assert.That(appliedRange?.Start).IsEqualTo(RangeStart);
+        await Assert.That(appliedRange?.End).IsEqualTo(RangeEnd);
+    }
+
+    /// <summary>Verifies clearing native range inputs preserves null endpoints and prevents invalid apply.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task DateTimeRangePicker_ClearingNativeInputsPreservesNullAndDisablesApply()
+    {
+        var command = new CaptureCommand();
+        var picker = new DateTimeRangePicker { Range = new(RangeStart, RangeEnd, DateTimeRangePreset.Custom, ShiftWindowLabel), ApplyRangeCommand = command };
+        var datePickers = FindDescendants<DatePicker>(picker);
+        var timePickers = FindDescendants<TimePicker>(picker);
+        var applyButton = GetSingle(FindDescendants<Button>(picker));
+
+        datePickers[0].Date = null;
+        timePickers[0].Time = null;
+        var applied = picker.ApplyCurrentRange();
+
+        await Assert.That(datePickers.Count).IsEqualTo(EndpointInputCount);
+        await Assert.That(timePickers.Count).IsEqualTo(EndpointInputCount);
+        await Assert.That(applied).IsFalse();
+        await Assert.That(picker.Range?.Start).IsNull();
+        await Assert.That(picker.Range?.End).IsEqualTo(RangeEnd);
+        await Assert.That(picker.Range?.IsValid).IsFalse();
+        await Assert.That(applyButton.IsEnabled).IsFalse();
+        await Assert.That(command.LastParameter).IsNull();
+    }
+
+    /// <summary>Verifies DateTimeRangePicker updates apply availability when the caller command availability changes.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task DateTimeRangePicker_TracksApplyCommandCanExecuteChanges()
+    {
+        var command = new CaptureCommand { CanExecuteResult = false };
+        var picker = new DateTimeRangePicker { Range = new(RangeStart, RangeEnd, DateTimeRangePreset.Custom, ShiftWindowLabel), ApplyRangeCommand = command };
+        var applyButton = GetSingle(FindDescendants<Button>(picker));
+
+        command.CanExecuteResult = true;
+        command.RaiseCanExecuteChanged();
+        var enabledAfterCommandChange = applyButton.IsEnabled;
+
+        command.CanExecuteResult = false;
+        command.RaiseCanExecuteChanged();
+
+        await Assert.That(enabledAfterCommandChange).IsTrue();
+        await Assert.That(applyButton.IsEnabled).IsFalse();
+    }
+
+    /// <summary>Verifies DateTimeRangePicker preserves distinct start and end offsets.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task DateTimeRangePicker_PreservesMixedEndpointOffsets()
+    {
+        var command = new CaptureCommand();
+        var endOffset = TimeSpan.FromHours(MixedRangeEndOffsetHours);
+        var mixedEnd = new DateTimeOffset(
+            RangeYear,
+            RangeMonth,
+            RangeDay,
+            RangeEndHour,
+            EmptyTimeComponent,
+            EmptyTimeComponent,
+            endOffset);
+        var picker = new DateTimeRangePicker { Range = new(RangeStart, mixedEnd, DateTimeRangePreset.Custom, "Mixed offset window"), ApplyRangeCommand = command };
+
+        var applied = picker.ApplyCurrentRange();
+        var appliedRange = (DateTimeRange?)command.LastParameter;
+
+        await Assert.That(applied).IsTrue();
+        await Assert.That(appliedRange?.Start?.Offset).IsEqualTo(RangeStart.Offset);
+        await Assert.That(appliedRange?.End?.Offset).IsEqualTo(endOffset);
+    }
+
+    /// <summary>Finds descendants of the requested MAUI element type.</summary>
+    /// <typeparam name="T">The descendant element type.</typeparam>
+    /// <param name="root">The root element.</param>
+    /// <returns>The matching descendants.</returns>
+    private static List<T> FindDescendants<T>(Element root)
+        where T : Element
+    {
+        var matches = new List<T>();
+        AddDescendants(root, matches);
+        return matches;
+    }
+
+    /// <summary>Adds descendants of the requested type to the supplied list.</summary>
+    /// <typeparam name="T">The descendant element type.</typeparam>
+    /// <param name="element">The element to inspect.</param>
+    /// <param name="matches">The collected matches.</param>
+    private static void AddDescendants<T>(Element element, ICollection<T> matches)
+        where T : Element
+    {
+        if (element is T match)
+        {
+            matches.Add(match);
+        }
+
+        if (element is ContentView { Content: Element content })
+        {
+            AddDescendants(content, matches);
+        }
+
+        if (element is not Layout layout)
+        {
+            return;
+        }
+
+        foreach (var child in layout.Children)
+        {
+            if (child is not Element childElement)
+            {
+                continue;
+            }
+
+            AddDescendants(childElement, matches);
+        }
+    }
+
+    /// <summary>Finds a button by text.</summary>
+    /// <param name="buttons">The buttons to inspect.</param>
+    /// <param name="text">The requested text.</param>
+    /// <returns>The matching button.</returns>
+    private static Button FindButton(List<Button> buttons, string text) =>
+        buttons.Find(button => button.Text == text) ?? throw new InvalidOperationException("Expected a matching button.");
+
+    /// <summary>Gets button text values.</summary>
+    /// <param name="buttons">The buttons to inspect.</param>
+    /// <returns>The button text values.</returns>
+    private static string[] GetButtonTexts(List<Button> buttons)
+    {
+        var texts = new string[buttons.Count];
+        for (var index = 0; index < buttons.Count; index++)
+        {
+            texts[index] = buttons[index].Text ?? throw new InvalidOperationException("Expected button text.");
+        }
+
+        return texts;
+    }
+
+    /// <summary>Gets label text values.</summary>
+    /// <param name="labels">The labels to inspect.</param>
+    /// <returns>The label text values.</returns>
+    private static string[] GetLabelTexts(List<Label> labels)
+    {
+        var texts = new string[labels.Count];
+        for (var index = 0; index < labels.Count; index++)
+        {
+            texts[index] = labels[index].Text ?? throw new InvalidOperationException("Expected label text.");
+        }
+
+        return texts;
+    }
+
+    /// <summary>Checks that all buttons use the expected command.</summary>
+    /// <param name="buttons">The buttons to inspect.</param>
+    /// <param name="command">The expected command.</param>
+    /// <returns>Whether every button uses the command.</returns>
+    private static bool AllButtonsUseCommand(List<Button> buttons, ICommand command)
+    {
+        if (buttons.Count == 0)
+        {
+            return false;
+        }
+
+        for (var index = 0; index < buttons.Count; index++)
+        {
+            if (!ReferenceEquals(buttons[index].Command, command))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>Gets a single item from a list.</summary>
+    /// <typeparam name="T">The item type.</typeparam>
+    /// <param name="items">The items to inspect.</param>
+    /// <returns>The only item.</returns>
+    private static T GetSingle<T>(IReadOnlyList<T> items)
+    {
+        if (items.Count != ExpectedSingleCount)
+        {
+            throw new InvalidOperationException("Expected a single matching item.");
+        }
+
+        return items[0];
+    }
+
+    /// <summary>Captures the last command parameter.</summary>
+    private sealed class CaptureCommand : ICommand
+    {
+        /// <inheritdoc/>
+        public event EventHandler? CanExecuteChanged;
+
+        /// <summary>Gets or sets a value indicating whether the command can execute.</summary>
+        public bool CanExecuteResult { get; set; } = true;
+
+        /// <summary>Gets the last command parameter.</summary>
+        public object? LastParameter { get; private set; }
+
+        /// <inheritdoc/>
+        public bool CanExecute(object? parameter) => CanExecuteResult;
+
+        /// <inheritdoc/>
+        public void Execute(object? parameter)
+        {
+            LastParameter = parameter;
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>Raises command availability changes for tests.</summary>
+        public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/Tests/CrissCross.Tests/MauiNavigationShellBehaviorTests.cs
+++ b/src/Tests/CrissCross.Tests/MauiNavigationShellBehaviorTests.cs
@@ -104,6 +104,19 @@ public sealed class MauiNavigationShellBehaviorTests
         await Assert.That(shell.NavigationStack).IsEmpty();
     }
 
+    /// <summary>Verifies disposal removes a named shell from the shared navigation host registry.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Dispose_WhenNamed_RemovesNavigationHostRegistration()
+    {
+        const string shellName = "maui-shell-dispose-registration";
+        var shell = new NavigationShell { Name = shellName };
+
+        shell.Dispose();
+
+        await Assert.That(ViewModelRoutedViewHostMixins.NavigationHost.ContainsKey(shellName)).IsFalse();
+    }
+
     /// <summary>Exposes protected page projection for direct contract testing.</summary>
     private sealed class NavigationShellProbe : NavigationShell
     {

--- a/src/Tests/CrissCross.Tests/MauiProcessValueIndicatorTests.cs
+++ b/src/Tests/CrissCross.Tests/MauiProcessValueIndicatorTests.cs
@@ -1,0 +1,169 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using CrissCross.Maui.UI.Controls;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace CrissCross.Tests;
+
+/// <summary>Exercises MAUI process-value projections from the shared industrial state model.</summary>
+public sealed class MauiProcessValueIndicatorTests
+{
+    /// <summary>The process label used by layout and theme tests.</summary>
+    private const string LevelLabel = "Level";
+
+    /// <summary>The status child position in the composed readout.</summary>
+    private const int StatusIndex = 3;
+
+    /// <summary>The range child position in the composed readout.</summary>
+    private const int RangeIndex = 2;
+
+    /// <summary>The allowed rounding error for percentage projection.</summary>
+    private const double PercentageTolerance = 1e-10;
+
+    /// <summary>Defines the HighTemperature test value.</summary>
+    private const double HighTemperature = 126.8;
+
+    /// <summary>Defines the NormalFraction test value.</summary>
+    private const double NormalFraction = 0.55;
+
+    /// <summary>Defines the SpeedMaximum test value.</summary>
+    private const int SpeedMaximum = 500;
+
+    /// <summary>Defines the TemperatureMaximum test value.</summary>
+    private const int TemperatureMaximum = 140;
+
+    /// <summary>Defines the TemperatureAlarm test value.</summary>
+    private const int TemperatureAlarm = 120;
+
+    /// <summary>Defines the RangeMaximum test value.</summary>
+    private const int RangeMaximum = 100;
+
+    /// <summary>Defines the HighLimit test value.</summary>
+    private const int HighLimit = 90;
+
+    /// <summary>Defines the NormalReading test value.</summary>
+    private const int NormalReading = 55;
+
+    /// <summary>Defines the LowLimit test value.</summary>
+    private const int LowLimit = 10;
+
+    /// <summary>Verifies a missing state projects the shared safe fallback.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task State_WhenNull_ProjectsEmptyFallback()
+    {
+        var indicator = new ProcessValueIndicator();
+
+        await Assert.That(indicator.State).IsNull();
+        await Assert.That(indicator.Label).IsEqualTo("Process value");
+        await Assert.That(indicator.DisplayText).IsEqualTo("—");
+        await Assert.That(indicator.StatusText).IsEqualTo("Bad quality");
+        await Assert.That(indicator.Percentage).IsEqualTo(0);
+        await Assert.That(indicator.NormalizedValue).IsEqualTo(0);
+        await Assert.That(indicator.HasValidValue).IsFalse();
+        await Assert.That(indicator.IsAlarm).IsFalse();
+        await Assert.That(indicator.Status).IsEqualTo(ProcessValueStatus.BadQuality);
+        await Assert.That(SemanticProperties.GetDescription(indicator)).IsEqualTo("Process value — Bad quality");
+    }
+
+    /// <summary>Verifies normal state projects value, range, and accessible text.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task State_WhenNormal_ProjectsReadoutRangeAndStatus()
+    {
+        var state = new ProcessValueState("Tank level", NormalReading, "%", 0, RangeMaximum, LowLimit, HighLimit);
+        var indicator = new ProcessValueIndicator { State = state };
+
+        await Assert.That(indicator.Label).IsEqualTo("Tank level");
+        await Assert.That(indicator.DisplayText).IsEqualTo("55 %");
+        await Assert.That(indicator.StatusText).IsEqualTo("Normal");
+        await Assert.That(Math.Abs(indicator.Percentage - NormalReading)).IsLessThan(PercentageTolerance);
+        await Assert.That(indicator.NormalizedValue).IsEqualTo(NormalFraction);
+        await Assert.That(indicator.HasValidValue).IsTrue();
+        await Assert.That(indicator.IsAlarm).IsFalse();
+        await Assert.That(indicator.Status).IsEqualTo(ProcessValueStatus.Normal);
+        await Assert.That(SemanticProperties.GetDescription(indicator)).Contains("Tank level 55 % Normal");
+    }
+
+    /// <summary>Verifies alarm and quality states are surfaced without relying on color alone.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task State_WhenAlarmOrBadQuality_ProjectsStatusText()
+    {
+        var alarmState = new ProcessValueState("Pressure", HighTemperature, "bar", 0, TemperatureMaximum, new ProcessValueOptions { HighAlarmLimit = TemperatureAlarm });
+        var alarm = new ProcessValueIndicator { State = alarmState };
+        var badQualityState = new ProcessValueState("Flow", null, "L/min", 0, SpeedMaximum, new ProcessValueOptions { IsGoodQuality = false });
+        var badQuality = new ProcessValueIndicator { State = badQualityState };
+
+        await Assert.That(alarm.IsAlarm).IsTrue();
+        await Assert.That(alarm.Status).IsEqualTo(ProcessValueStatus.HighAlarm);
+        await Assert.That(alarm.StatusText).IsEqualTo("High alarm");
+        await Assert.That(alarm.HasValidValue).IsTrue();
+        await Assert.That(badQuality.IsAlarm).IsFalse();
+        await Assert.That(badQuality.Status).IsEqualTo(ProcessValueStatus.BadQuality);
+        await Assert.That(badQuality.StatusText).IsEqualTo("Bad quality");
+        await Assert.That(badQuality.HasValidValue).IsFalse();
+    }
+
+    /// <summary>Verifies theme changes recolor the visible status and range without replacing the reading.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ThemeColors_WhenChanged_UpdateComposedViews()
+    {
+        var indicator = new ProcessValueIndicator
+        {
+            State = new(LevelLabel, NormalReading, "%", 0, RangeMaximum, LowLimit, HighLimit),
+            NormalStatusColor = Colors.Green,
+            AlarmStatusColor = Colors.Red,
+            BadQualityStatusColor = Colors.Gray,
+            InvalidConfigurationStatusColor = Colors.Orange,
+            RangeTrackColor = Colors.Black
+        };
+        var layout = (VerticalStackLayout)indicator.Content;
+        var status = (Label)layout.Children[StatusIndex];
+        var track = (Grid)layout.Children[RangeIndex];
+        var fill = (BoxView)track.Children[0];
+
+        await Assert.That(status.TextColor).IsEqualTo(Colors.Green);
+        await Assert.That(fill.Color).IsEqualTo(Colors.Green);
+        await Assert.That(track.BackgroundColor).IsEqualTo(Colors.Black);
+        indicator.NormalStatusColor = Colors.Blue;
+        await Assert.That(status.TextColor).IsEqualTo(Colors.Blue);
+        indicator.State = new(LevelLabel, RangeMaximum, "%", 0, RangeMaximum, LowLimit, HighLimit);
+        await Assert.That(status.TextColor).IsEqualTo(Colors.Red);
+        indicator.State = null;
+        await Assert.That(status.TextColor).IsEqualTo(Colors.Gray);
+        indicator.State = new(LevelLabel, NormalReading, "%", RangeMaximum, 0);
+        await Assert.That(status.TextColor).IsEqualTo(Colors.Orange);
+        await Assert.That(status.Text).IsEqualTo("Invalid configuration");
+    }
+
+    /// <summary>Verifies arranged range fills resize and clear when a reading becomes unavailable.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Range_WhenArranged_TracksReadingAndAvailableWidth()
+    {
+        const double initialWidth = 200;
+        const double resizedWidth = 400;
+        const double barHeight = 8;
+        const double smallestReading = 0.01;
+        const double minimumVisibleWidth = 2;
+        var indicator = new ProcessValueIndicator { State = new(LevelLabel, NormalReading, "%", 0, RangeMaximum) };
+        var layout = (VerticalStackLayout)indicator.Content;
+        var track = (Grid)layout.Children[RangeIndex];
+        var fill = (BoxView)track.Children[0];
+
+        _ = ((IView)track).Arrange(new(0, 0, initialWidth, barHeight));
+        await Assert.That(Math.Abs(fill.WidthRequest - (initialWidth * NormalFraction))).IsLessThan(PercentageTolerance);
+        _ = ((IView)track).Arrange(new(0, 0, resizedWidth, barHeight));
+        await Assert.That(Math.Abs(fill.WidthRequest - (resizedWidth * NormalFraction))).IsLessThan(PercentageTolerance);
+        indicator.State = new(LevelLabel, smallestReading, "%", 0, RangeMaximum);
+        await Assert.That(fill.WidthRequest).IsEqualTo(minimumVisibleWidth);
+        indicator.State = null;
+        await Assert.That(fill.WidthRequest).IsEqualTo(0);
+    }
+}

--- a/src/Tests/CrissCross.Tests/MauiReactiveFormFieldTests.cs
+++ b/src/Tests/CrissCross.Tests/MauiReactiveFormFieldTests.cs
@@ -1,0 +1,136 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using CrissCross.Maui.UI.Controls;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace CrissCross.Tests;
+
+/// <summary>Verifies composed form metadata and validation feedback.</summary>
+public sealed class MauiReactiveFormFieldTests
+{
+    /// <summary>The required metadata row.</summary>
+    private const int RequiredIndex = 1;
+
+    /// <summary>The input row.</summary>
+    private const int InputIndex = 2;
+
+    /// <summary>The helper metadata row.</summary>
+    private const int HelperIndex = 3;
+
+    /// <summary>The validation status row.</summary>
+    private const int StatusIndex = 4;
+
+    /// <summary>The validation messages row.</summary>
+    private const int MessagesIndex = 5;
+
+    /// <summary>The success message position in the validation snapshot.</summary>
+    private const int SuccessIndex = 3;
+
+    /// <summary>The pending message position in the validation snapshot.</summary>
+    private const int PendingIndex = 4;
+
+    /// <summary>Verifies the default template preserves content and projects metadata.</summary>
+    /// <returns>The asynchronous test.</returns>
+    [Test]
+    public async Task Template_PreservesInputAndProjectsMetadata()
+    {
+        var input = new Entry { Text = "42" };
+        var field = new ReactiveFormField { Content = input, Header = "Pressure", FieldKey = "pressure", HelperText = "Enter bar", IsRequired = true };
+        var layout = (VerticalStackLayout)((IVisualTreeElement)field).GetVisualChildren()[0];
+        var inputLayout = (Grid)layout.Children[InputIndex];
+        var presenter = (ContentPresenter)inputLayout.Children[1];
+
+        await Assert.That(ReferenceEquals(field.Content, input)).IsTrue();
+        await Assert.That(ReferenceEquals(presenter.Content, input)).IsTrue();
+        await Assert.That(((Label)((ContentView)layout.Children[0]).Content).Text).IsEqualTo("Pressure");
+        await Assert.That(((Label)layout.Children[RequiredIndex]).IsVisible).IsTrue();
+        await Assert.That(((Label)layout.Children[HelperIndex]).Text).IsEqualTo("Enter bar");
+        await Assert.That(field.FieldKey).IsEqualTo("pressure");
+        await Assert.That(SemanticProperties.GetDescription(field)).Contains("Required");
+
+        var replacement = new Entry();
+        field.Content = replacement;
+        field.Header = null;
+        field.HelperText = null;
+        field.IsRequired = false;
+        await Assert.That(ReferenceEquals(presenter.Content, replacement)).IsTrue();
+        await Assert.That(((ContentView)layout.Children[0]).IsVisible).IsFalse();
+        await Assert.That(((Label)layout.Children[HelperIndex]).IsVisible).IsFalse();
+        await Assert.That(((Label)layout.Children[RequiredIndex]).IsVisible).IsFalse();
+
+        var header = new Label { Text = "Custom header" };
+        field.Header = header;
+        await Assert.That(ReferenceEquals(((ContentView)layout.Children[0]).Content, header)).IsTrue();
+    }
+
+    /// <summary>Verifies state aliases and semantic colors remain synchronized.</summary>
+    /// <param name="state">The state to project.</param>
+    /// <param name="text">The visible status text.</param>
+    /// <param name="resource">The semantic color key.</param>
+    /// <returns>The asynchronous test.</returns>
+    [Test]
+    [Arguments(FormFieldState.Normal, "", "CrissCrossBorderColor")]
+    [Arguments(FormFieldState.Focused, "Focused", "CrissCrossAccentColor")]
+    [Arguments(FormFieldState.Valid, "Valid", "CrissCrossSuccessColor")]
+    [Arguments(FormFieldState.Warning, "Warning", "CrissCrossCautionColor")]
+    [Arguments(FormFieldState.Invalid, "Invalid", "CrissCrossDangerColor")]
+    [Arguments(FormFieldState.Pending, "Validating…", "CrissCrossAccentColor")]
+    public async Task State_ProjectsTextAndFollowsTheme(FormFieldState state, string text, string resource)
+    {
+        var field = new ReactiveFormField();
+        field.Resources[resource] = Colors.Red;
+        field.FieldState = state;
+        var layout = (VerticalStackLayout)((IVisualTreeElement)field).GetVisualChildren()[0];
+        var status = (Label)layout.Children[StatusIndex];
+        var rail = (BoxView)((Grid)layout.Children[InputIndex]).Children[0];
+
+        await Assert.That(field.State).IsEqualTo(state);
+        await Assert.That(status.Text).IsEqualTo(text);
+        await Assert.That(status.IsVisible).IsEqualTo(state != FormFieldState.Normal);
+        await Assert.That(rail.Color).IsEqualTo(Colors.Red);
+        field.Resources[resource] = Colors.Blue;
+        await Assert.That(rail.Color).IsEqualTo(Colors.Blue);
+        field.State = FormFieldState.Valid;
+        await Assert.That(field.FieldState).IsEqualTo(FormFieldState.Valid);
+        field.FieldState = null;
+        await Assert.That(field.State).IsEqualTo(FormFieldState.Normal);
+    }
+
+    /// <summary>Verifies validation text and severity colors update with the message snapshot.</summary>
+    /// <returns>The asynchronous test.</returns>
+    [Test]
+    public async Task Messages_ProjectSeverityAndClearWhenReplaced()
+    {
+        var field = new ReactiveFormField();
+        field.Resources["CrissCrossDangerColor"] = Colors.Red;
+        field.Resources["CrissCrossCautionColor"] = Colors.Yellow;
+        field.Resources["CrissCrossMutedTextColor"] = Colors.Gray;
+        field.Resources["CrissCrossSuccessColor"] = Colors.Green;
+        field.Resources["CrissCrossAccentColor"] = Colors.Blue;
+        field.Messages =
+        [
+            new(null, null, "Invalid"),
+            new(null, null, "Warning", ValidationSeverity.Warning),
+            new(null, null, "Info", ValidationSeverity.Information),
+            new(null, null, "Valid", ValidationSeverity.Success),
+            new(null, null, "Checking", ValidationSeverity.Pending),
+        ];
+        var layout = (VerticalStackLayout)((IVisualTreeElement)field).GetVisualChildren()[0];
+        var messages = (VerticalStackLayout)layout.Children[MessagesIndex];
+
+        await Assert.That(((Label)messages.Children[0]).Text).IsEqualTo("Invalid");
+        await Assert.That(((Label)messages.Children[0]).TextColor).IsEqualTo(Colors.Red);
+        await Assert.That(((Label)messages.Children[1]).TextColor).IsEqualTo(Colors.Yellow);
+        await Assert.That(((Label)messages.Children[2]).TextColor).IsEqualTo(Colors.Gray);
+        await Assert.That(((Label)messages.Children[SuccessIndex]).TextColor).IsEqualTo(Colors.Green);
+        await Assert.That(((Label)messages.Children[PendingIndex]).TextColor).IsEqualTo(Colors.Blue);
+        await Assert.That(messages.IsVisible).IsTrue();
+        field.Messages = null;
+        await Assert.That(messages.Children.Count).IsEqualTo(0);
+        await Assert.That(messages.IsVisible).IsFalse();
+    }
+}

--- a/src/Tests/CrissCross.Tests/MauiTestDispatcher.cs
+++ b/src/Tests/CrissCross.Tests/MauiTestDispatcher.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Maui.Dispatching;
+
+namespace CrissCross.Tests;
+
+/// <summary>Provides deterministic dispatch for handler-free MAUI control tests.</summary>
+public sealed class MauiTestDispatcher : IDispatcher, IDispatcherProvider
+{
+    /// <summary>Stores the dispatcher provider to restore after testing.</summary>
+    private static IDispatcherProvider? _previousProvider;
+
+    /// <inheritdoc/>
+    public bool IsDispatchRequired => false;
+
+    /// <summary>Installs dispatch support before MAUI bindings are constructed.</summary>
+    [Before(HookType.Assembly)]
+    public static void Initialize()
+    {
+        _previousProvider = DispatcherProvider.Current;
+        _ = DispatcherProvider.SetCurrent(new MauiTestDispatcher());
+    }
+
+    /// <summary>Restores the original provider after the test assembly completes.</summary>
+    [After(HookType.Assembly)]
+    public static void Restore() => DispatcherProvider.SetCurrent(_previousProvider);
+
+    /// <inheritdoc/>
+    public IDispatcher GetForCurrentThread() => this;
+
+    /// <inheritdoc/>
+    public bool Dispatch(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        action();
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public bool DispatchDelayed(TimeSpan delay, Action action) => throw new NotSupportedException("Delayed work requires a timer-specific test dispatcher.");
+
+    /// <inheritdoc/>
+    public IDispatcherTimer CreateTimer() => throw new NotSupportedException("Timers require a timer-specific test dispatcher.");
+}

--- a/src/Tests/CrissCross.Tests/MauiUiControlBehaviorTests.cs
+++ b/src/Tests/CrissCross.Tests/MauiUiControlBehaviorTests.cs
@@ -418,6 +418,7 @@ public class MauiUiControlBehaviorTests
     /// <returns><c>true</c> when the property supports the round-trip test.</returns>
     private static bool IsRoundTrippableControlProperty(System.Reflection.PropertyInfo property) =>
         property is { CanRead: true, CanWrite: true }
+        && property.SetMethod?.IsPublic == true
         && property.GetIndexParameters().Length == 0
         && property.DeclaringType?.Namespace?.StartsWith("CrissCross.", StringComparison.Ordinal) == true;
 

--- a/src/Tests/CrissCross.Tests/MauiUiCoverageEdgeBehaviorTests.cs
+++ b/src/Tests/CrissCross.Tests/MauiUiCoverageEdgeBehaviorTests.cs
@@ -16,12 +16,12 @@ public sealed class MauiUiCoverageEdgeBehaviorTests
     [Test]
     public async Task DataPager_NavigationCommands_ExecuteAvailablePageTransitions()
     {
-        const int expectedExecutionCount = 4;
-        const int expectedPageIndex = 2;
-        const int pageSize = 10;
-        const int totalItemCount = 30;
+        const int ExpectedExecutionCount = 4;
+        const int ExpectedPageIndex = 2;
+        const int PageSize = 10;
+        const int TotalItemCount = 30;
         var command = new TrackingCommand(canExecute: true);
-        var pagination = new PaginationState(pageIndex: 1, pageSize, totalItemCount);
+        var pagination = new PaginationState(pageIndex: 1, PageSize, TotalItemCount);
         var pager = new DataPager { PaginationState = pagination, PageRequestCommand = command };
         var canExecuteChangedCount = 0;
         pager.NextPageCommand.CanExecuteChanged += (_, _) => canExecuteChangedCount++;
@@ -31,10 +31,10 @@ public sealed class MauiUiCoverageEdgeBehaviorTests
         pager.NextPageCommand.Execute(null);
         pager.LastPageCommand.Execute(null);
 
-        await Assert.That(command.ExecutionCount).IsEqualTo(expectedExecutionCount);
-        await Assert.That(canExecuteChangedCount).IsEqualTo(1);
-        await Assert.That(pager.CurrentRequest?.PageIndex).IsEqualTo(expectedPageIndex);
-        await Assert.That(pager.CurrentRequest?.PageSize).IsEqualTo(pageSize);
+        await Assert.That(command.ExecutionCount).IsEqualTo(ExpectedExecutionCount);
+        await Assert.That(canExecuteChangedCount).IsEqualTo(ExpectedExecutionCount);
+        await Assert.That(pager.CurrentRequest?.PageIndex).IsEqualTo(ExpectedPageIndex);
+        await Assert.That(pager.CurrentRequest?.PageSize).IsEqualTo(PageSize);
     }
 
     /// <summary>Verifies pager and segmented controls handle unavailable command and state paths safely.</summary>
@@ -88,9 +88,9 @@ public sealed class MauiUiCoverageEdgeBehaviorTests
     [Test]
     public async Task RatingAndVisualControls_ClampAndProjectInactiveBranches()
     {
-        const int maxRating = 3;
-        const int oversizedRating = 99;
-        var rating = new RatingControl { MaxRating = maxRating, Value = oversizedRating };
+        const int MaxRating = 3;
+        const int OversizedRating = 99;
+        var rating = new RatingControl { MaxRating = MaxRating, Value = OversizedRating };
         var busyOverlay = new BusyOverlay { Operation = new(string.Empty) };
         var imageSource = new FileImageSource { File = "ada.png" };
         var picture = new PersonPicture { DisplayName = "Ada Lovelace", Initials = "AL", Source = imageSource };
@@ -98,8 +98,8 @@ public sealed class MauiUiCoverageEdgeBehaviorTests
 
         chip.Model = null;
 
-        await Assert.That(rating.Value).IsEqualTo(maxRating);
-        await Assert.That(rating.Children.Count).IsEqualTo(maxRating);
+        await Assert.That(rating.Value).IsEqualTo(MaxRating);
+        await Assert.That(rating.Children.Count).IsEqualTo(MaxRating);
         await Assert.That(busyOverlay.IsBusy).IsFalse();
         await Assert.That(SemanticProperties.GetDescription(picture)).IsEqualTo("Ada Lovelace");
         await Assert.That(chip.Text).IsEqualTo("Chip");

--- a/src/Tests/CrissCross.Tests/NavigationEventArgsTests.cs
+++ b/src/Tests/CrissCross.Tests/NavigationEventArgsTests.cs
@@ -231,10 +231,16 @@ public class NavigationEventArgsTests
     [Test]
     public async Task NavigationType_Enum_HasCorrectValues()
     {
+        var values = new Dictionary<NavigationType, int>();
+        foreach (var value in Enum.GetValues<NavigationType>())
+        {
+            values.Add(value, (int)value);
+        }
+
         // Assert
-        await Assert.That((int)NavigationType.New).IsEqualTo(0);
-        await Assert.That((int)NavigationType.Back).IsEqualTo(1);
-        await Assert.That((int)NavigationType.Refresh).IsEqualTo(RefreshNavigationTypeValue);
+        await Assert.That(values[NavigationType.New]).IsEqualTo(0);
+        await Assert.That(values[NavigationType.Back]).IsEqualTo(1);
+        await Assert.That(values[NavigationType.Refresh]).IsEqualTo(RefreshNavigationTypeValue);
     }
 
     /// <summary>Provides the ViewModelNavigatingEventArgs_AllowsNullParameters member.</summary>

--- a/src/Tests/CrissCross.Tests/ProcessValueStateTests.cs
+++ b/src/Tests/CrissCross.Tests/ProcessValueStateTests.cs
@@ -1,0 +1,196 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace CrissCross.Tests;
+
+/// <summary>Verifies industrial measurement status, range normalization, and invalid-data handling.</summary>
+public sealed class ProcessValueStateTests
+{
+    /// <summary>Defines the QuarterRange test value.</summary>
+    private const double QuarterRange = 0.25;
+
+    /// <summary>Defines the RaisedHighLimit test value.</summary>
+    private const int RaisedHighLimit = 110;
+
+    /// <summary>Defines the RangeMaximum test value.</summary>
+    private const int RangeMaximum = 100;
+
+    /// <summary>Defines the HighLimit test value.</summary>
+    private const int HighLimit = 90;
+
+    /// <summary>Defines the QuarterReading test value.</summary>
+    private const int QuarterReading = 25;
+
+    /// <summary>Defines the LowLimit test value.</summary>
+    private const int LowLimit = 10;
+
+    /// <summary>Defines the TwoItemsPerPage test value.</summary>
+    private const int TwoItemsPerPage = 2;
+
+    /// <summary>Verifies the complete valid measurement snapshot.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task ValidMeasurementProjectsEngineeringUnitsAndRange()
+    {
+        var state = new ProcessValueState(" Pressure ", QuarterReading, " bar ", 0, RangeMaximum, LowLimit, HighLimit);
+
+        await Assert.That(state.Label).IsEqualTo("Pressure");
+        await Assert.That(state.Value).IsEqualTo(QuarterReading);
+        await Assert.That(state.Unit).IsEqualTo("bar");
+        await Assert.That(state.Minimum).IsEqualTo(0);
+        await Assert.That(state.Maximum).IsEqualTo(RangeMaximum);
+        await Assert.That(state.LowAlarmLimit).IsEqualTo(LowLimit);
+        await Assert.That(state.HighAlarmLimit).IsEqualTo(HighLimit);
+        await Assert.That(state.IsGoodQuality).IsTrue();
+        await Assert.That(state.Status).IsEqualTo(ProcessValueStatus.Normal);
+        await Assert.That(state.HasValidValue).IsTrue();
+        await Assert.That(state.IsAlarm).IsFalse();
+        await Assert.That(state.ValueText).IsEqualTo("25");
+        await Assert.That(state.DisplayText).IsEqualTo("25 bar");
+        await Assert.That(state.StatusText).IsEqualTo("Normal");
+        await Assert.That(state.NormalizedValue).IsEqualTo(QuarterRange);
+        await Assert.That(state.Percentage).IsEqualTo(QuarterReading);
+    }
+
+    /// <summary>Verifies inclusive low and high alarm boundaries without changing the measured value.</summary>
+    /// <param name="value">The measurement.</param>
+    /// <param name="expectedStatus">The expected alarm condition.</param>
+    /// <param name="expectedText">The expected text condition.</param>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    [Arguments(-1, ProcessValueStatus.LowAlarm, "Low alarm")]
+    [Arguments(10, ProcessValueStatus.LowAlarm, "Low alarm")]
+    [Arguments(90, ProcessValueStatus.HighAlarm, "High alarm")]
+    [Arguments(101, ProcessValueStatus.HighAlarm, "High alarm")]
+    public async Task AlarmLimitsAreInclusive(double value, ProcessValueStatus expectedStatus, string expectedText)
+    {
+        var state = new ProcessValueState(null, value, null, 0, RangeMaximum, LowLimit, HighLimit);
+
+        await Assert.That(state.Status).IsEqualTo(expectedStatus);
+        await Assert.That(state.StatusText).IsEqualTo(expectedText);
+        await Assert.That(state.IsAlarm).IsTrue();
+        await Assert.That(state.HasValidValue).IsTrue();
+        await Assert.That(state.Value).IsEqualTo(value);
+        await Assert.That(state.Label).IsEmpty();
+        await Assert.That(state.Unit).IsEmpty();
+        await Assert.That(state.DisplayText).IsEqualTo(state.ValueText);
+    }
+
+    /// <summary>Verifies a single configured alarm and an absent alarm do not create spurious conditions.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task OptionalAlarmLimitsAreIndependent()
+    {
+        await Assert.That(new ProcessValueState(null, 0, null, 0, RangeMaximum).Status).IsEqualTo(ProcessValueStatus.Normal);
+        await Assert.That(new ProcessValueState(null, 0, null, 0, RangeMaximum, null, HighLimit).Status).IsEqualTo(ProcessValueStatus.Normal);
+        await Assert.That(new ProcessValueState(null, RangeMaximum, null, 0, RangeMaximum, LowLimit, null).Status).IsEqualTo(ProcessValueStatus.Normal);
+    }
+
+    /// <summary>Verifies bad data is visibly unavailable and cannot appear as a healthy measurement.</summary>
+    /// <param name="value">The invalid measurement.</param>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    [Arguments(null)]
+    [Arguments(double.NaN)]
+    [Arguments(double.PositiveInfinity)]
+    [Arguments(double.NegativeInfinity)]
+    public async Task InvalidMeasurementsShowBadQuality(double? value)
+    {
+        var state = new ProcessValueState(null, value, null, 0, RangeMaximum);
+
+        await Assert.That(state.Status).IsEqualTo(ProcessValueStatus.BadQuality);
+        await Assert.That(state.StatusText).IsEqualTo("Bad quality");
+        await Assert.That(state.HasValidValue).IsFalse();
+        await Assert.That(state.IsAlarm).IsFalse();
+        await Assert.That(state.ValueText).IsEqualTo("—");
+        await Assert.That(state.NormalizedValue).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies bad source quality takes precedence over alarm thresholds.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task BadSourceQualityOverridesAlarm()
+    {
+        var options = new ProcessValueOptions { LowAlarmLimit = LowLimit, HighAlarmLimit = HighLimit, IsGoodQuality = false };
+        var state = new ProcessValueState(null, RangeMaximum, null, 0, RangeMaximum, options);
+        options.IsGoodQuality = true;
+        options.HighAlarmLimit = RaisedHighLimit;
+
+        await Assert.That(state.Status).IsEqualTo(ProcessValueStatus.BadQuality);
+        await Assert.That(state.IsGoodQuality).IsFalse();
+    }
+
+    /// <summary>Verifies invalid configuration takes precedence over unavailable data.</summary>
+    /// <param name="minimum">The range minimum.</param>
+    /// <param name="maximum">The range maximum.</param>
+    /// <param name="low">The optional low alarm.</param>
+    /// <param name="high">The optional high alarm.</param>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    [Arguments(0, 0, null, null)]
+    [Arguments(100, 0, null, null)]
+    [Arguments(double.NaN, 100, null, null)]
+    [Arguments(double.NegativeInfinity, 100, null, null)]
+    [Arguments(0, double.NaN, null, null)]
+    [Arguments(0, double.PositiveInfinity, null, null)]
+    [Arguments(0, 100, double.NaN, null)]
+    [Arguments(0, 100, double.PositiveInfinity, null)]
+    [Arguments(0, 100, null, double.NaN)]
+    [Arguments(0, 100, null, double.NegativeInfinity)]
+    [Arguments(0, 100, 50, 50)]
+    [Arguments(0, 100, 90, 10)]
+    public async Task InvalidConfigurationCannotDisplayNormal(double minimum, double maximum, double? low, double? high)
+    {
+        var state = new ProcessValueState(null, null, null, minimum, maximum, low, high);
+
+        await Assert.That(state.Status).IsEqualTo(ProcessValueStatus.InvalidConfiguration);
+        await Assert.That(state.StatusText).IsEqualTo("Invalid configuration");
+        await Assert.That(state.HasValidValue).IsFalse();
+        await Assert.That(state.NormalizedValue).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies clamping at and beyond both endpoints, plus overflow-safe range normalization.</summary>
+    /// <param name="value">The measurement.</param>
+    /// <param name="minimum">The range minimum.</param>
+    /// <param name="maximum">The range maximum.</param>
+    /// <param name="expected">The expected normalized result.</param>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    [Arguments(-1, 0, 100, 0)]
+    [Arguments(0, 0, 100, 0)]
+    [Arguments(100, 0, 100, 1)]
+    [Arguments(101, 0, 100, 1)]
+    [Arguments(0, -double.MaxValue, double.MaxValue, 0.5)]
+    [Arguments(0, -double.Epsilon, double.Epsilon, 0.5)]
+    public async Task RangeNormalizationIsFiniteAndClamped(double value, double minimum, double maximum, double expected)
+    {
+        var state = new ProcessValueState(null, value, null, minimum, maximum);
+
+        await Assert.That(state.NormalizedValue).IsEqualTo(expected);
+    }
+
+    /// <summary>Verifies paging over the maximum item count does not overflow the final item number.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task FinalPageOfLargeDatasetDoesNotOverflow()
+    {
+        var state = new PaginationState(int.MaxValue, TwoItemsPerPage, int.MaxValue);
+
+        await Assert.That(state.FirstItemNumber).IsEqualTo(int.MaxValue);
+        await Assert.That(state.LastItemNumber).IsEqualTo(int.MaxValue);
+        await Assert.That(state.SummaryText).IsEqualTo("2147483647-2147483647 of 2147483647");
+    }
+
+    /// <summary>Verifies an unrepresentable skip offset fails explicitly instead of wrapping to a negative offset.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task UnrepresentablePageOffsetThrowsWithoutCorruptingDisplayText()
+    {
+        var request = new PageRequest(int.MaxValue, TwoItemsPerPage);
+
+        await Assert.That(() => request.Offset).Throws<OverflowException>();
+        await Assert.That(request.DisplayText).IsEqualTo("Page 2147483648, 2 per page");
+        await Assert.That(new PageRequest(int.MaxValue, 1).Offset).IsEqualTo(int.MaxValue);
+    }
+}

--- a/src/Tests/CrissCross.Tests/RxObjectMixinsTests.cs
+++ b/src/Tests/CrissCross.Tests/RxObjectMixinsTests.cs
@@ -86,10 +86,9 @@ public class RxObjectMixinsTests
     {
         // Arrange
         var testObject = new TestRxObject();
-        var actionExecuted = false;
 
         // Act
-        var disposable = testObject.BuildCompleteDisposable(() => actionExecuted = true);
+        var disposable = testObject.BuildCompleteDisposable(static () => { });
 
         // Assert
         await Assert.That(disposable).IsNotNull();
@@ -276,14 +275,13 @@ public class RxObjectMixinsTests
     public async Task ToListOfObservables_HandlesNullSource()
     {
         // Arrange
-        var subject = new StateSignal<IEnumerable<TestReactiveObject>?>(null);
-        var result = subject.ToListOfObservables(x => x.TestProperty)!;
+        var subject = new Signal<IEnumerable<TestReactiveObject>>();
+        var result = subject.ToListOfObservables(x => x.TestProperty);
 
         var receivedValue = false;
         var subscription = result.Subscribe(_ => receivedValue = true);
 
-        // Give time for the observable to propagate
-        await Task.Delay(ObservablePropagationDelayMilliseconds);
+        subject.OnNext(null!);
 
         // Assert - Should not crash and should not emit for null
         await Assert.That(receivedValue).IsFalse();

--- a/src/Tests/CrissCross.Tests/RxObjectTests.cs
+++ b/src/Tests/CrissCross.Tests/RxObjectTests.cs
@@ -132,7 +132,7 @@ public class RxObjectTests
 
         // Act & Assert - should not throw
         rxObject.WhenNavigatedFrom(eventArgs);
-        await Assert.That(true).IsTrue();
+        await Assert.That(rxObject.IsDisposed).IsFalse();
     }
 
     /// <summary>Provides the WhenNavigatedTo_CanBeCalled member.</summary>
@@ -152,7 +152,7 @@ public class RxObjectTests
 
         // Act & Assert - should not throw
         rxObject.WhenNavigatedTo(eventArgs, disposables);
-        await Assert.That(true).IsTrue();
+        await Assert.That(rxObject.IsDisposed).IsFalse();
     }
 
     /// <summary>Provides the WhenNavigating_CanBeCalled member.</summary>
@@ -171,7 +171,7 @@ public class RxObjectTests
 
         // Act & Assert - should not throw
         rxObject.WhenNavigating(eventArgs);
-        await Assert.That(true).IsTrue();
+        await Assert.That(rxObject.IsDisposed).IsFalse();
     }
 
     /// <summary>Provides the PropertyChanged_IsRaisedWhenDisplayNameChanges member.</summary>

--- a/src/Tests/CrissCross.Tests/ViewModelRoutedViewHostMixinsLifecycleTests.cs
+++ b/src/Tests/CrissCross.Tests/ViewModelRoutedViewHostMixinsLifecycleTests.cs
@@ -25,10 +25,9 @@ public partial class ViewModelRoutedViewHostMixinsTests
         // Arrange
         using var vm = new TestViewModel(LifecycleTestHostName);
         using var view = new TestView(vm);
-        var called = false;
 
         // Act
-        view.WhenNavigatedFrom(_ => called = true);
+        view.WhenNavigatedFrom(static _ => { });
 
         // Assert
         await Assert.That(view.ISetupNavigatedFrom).IsTrue();
@@ -54,10 +53,9 @@ public partial class ViewModelRoutedViewHostMixinsTests
         // Arrange
         using var vm = new TestViewModel(LifecycleTestHostName);
         using var view = new TestView(vm);
-        var called = false;
 
         // Act
-        view.WhenNavigatedTo((_, _) => called = true);
+        view.WhenNavigatedTo(static (_, _) => { });
 
         // Assert
         await Assert.That(view.ISetupNavigatedTo).IsTrue();

--- a/src/Tests/CrissCross.Tests/ViewModelRoutedViewHostMixinsTestDoubles.cs
+++ b/src/Tests/CrissCross.Tests/ViewModelRoutedViewHostMixinsTestDoubles.cs
@@ -105,7 +105,8 @@ public partial class ViewModelRoutedViewHostMixinsTests
 
     /// <summary>Provides the TestViewModelRoutedViewHost member.</summary>
     /// <param name="name">The name value.</param>
-    public class TestViewModelRoutedViewHost(string name = TestDoubleHostName) : IViewModelRoutedViewHost
+    /// <param name="hostName">The host name value.</param>
+    public class TestViewModelRoutedViewHost(string name = TestDoubleHostName, string? hostName = null) : IViewModelRoutedViewHost, IDisposable
     {
         /// <summary>Provides the _currentViewModel member.</summary>
         private readonly StateSignal<INotifiyRoutableViewModel?> _currentViewModel = new(null);
@@ -136,11 +137,7 @@ public partial class ViewModelRoutedViewHostMixinsTests
         public string Name { get; set; } = name;
 
         /// <summary>Gets or sets the value.</summary>
-        public string HostName
-        {
-            get => Name;
-            set => Name = value;
-        }
+        public string HostName { get; set; } = hostName ?? name;
 
         /// <summary>Gets or sets a value indicating whether setup is required.</summary>
         public bool RequiresSetup { get; set; }
@@ -178,6 +175,13 @@ public partial class ViewModelRoutedViewHostMixinsTests
 
         /// <summary>Provides the Setup member.</summary>
         public void Setup() => SetupCallCount++;
+
+        /// <summary>Disposes signals owned by the test host.</summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
 
         /// <summary>Provides typed instance navigation.</summary>
         /// <typeparam name="T">The view model type.</typeparam>
@@ -252,12 +256,26 @@ public partial class ViewModelRoutedViewHostMixinsTests
         {
             // Refresh logic
         }
+
+        /// <summary>Releases the signals owned by this host.</summary>
+        /// <param name="disposing">Whether managed signals should be released.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposing)
+            {
+                return;
+            }
+
+            _canNavigateBack.Dispose();
+            _currentViewModel.Dispose();
+        }
     }
 
     /// <summary>Provides the TestResolvedViewModelRoutedViewHost member.</summary>
     /// <param name="name">The name value.</param>
-    public sealed class TestResolvedViewModelRoutedViewHost(string name = TestDoubleHostName)
-        : TestViewModelRoutedViewHost(name),
+    /// <param name="hostName">The host name value.</param>
+    public sealed class TestResolvedViewModelRoutedViewHost(string name = TestDoubleHostName, string? hostName = null)
+        : TestViewModelRoutedViewHost(name, hostName),
             IResolvedViewModelRoutedViewHost
     {
         /// <summary>Gets the value.</summary>

--- a/src/Tests/CrissCross.Tests/ViewModelRoutedViewHostMixinsTests.cs
+++ b/src/Tests/CrissCross.Tests/ViewModelRoutedViewHostMixinsTests.cs
@@ -12,6 +12,12 @@ public partial class ViewModelRoutedViewHostMixinsTests
     /// <summary>Provides the ProfileContract member.</summary>
     private const string ProfileContract = "profile";
 
+    /// <summary>The visual frame name, distinct from its logical navigation host name.</summary>
+    private const string VisualFrameName = "NavigationFrame";
+
+    /// <summary>Provides the expected history count after two navigation entries are recorded.</summary>
+    private const int ExpectedTwoItemHistoryCount = 2;
+
     /// <summary>Provides the propagation delay used by observable tests.</summary>
     private const int ObservablePropagationDelayMilliseconds = 100;
 
@@ -157,6 +163,68 @@ public partial class ViewModelRoutedViewHostMixinsTests
         await Assert.That(ViewModelRoutedViewHostMixins.NavigationHost[hostName]).IsEqualTo(viewHost);
     }
 
+    /// <summary>Verifies that a logical host name registers even when the visual host name differs.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task SetMainNavigationHost_RegistersLogicalHostNameAlias()
+    {
+        // Arrange
+        var hostName = GetUniqueHostName();
+        using var setNav = new TestSetNavigationViewModel(string.Empty);
+        var viewHost = new TestViewModelRoutedViewHost(VisualFrameName, hostName) { RequiresSetup = true };
+
+        // Act
+        setNav.SetMainNavigationHost(viewHost);
+
+        // Assert
+        await Assert.That(ViewModelRoutedViewHostMixins.NavigationHost.ContainsKey(hostName)).IsTrue();
+        await Assert.That(ViewModelRoutedViewHostMixins.NavigationHost[hostName]).IsEqualTo(viewHost);
+        await Assert.That(ViewModelRoutedViewHostMixins.NavigationHost[VisualFrameName]).IsEqualTo(viewHost);
+        await Assert.That(viewHost.SetupCallCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that an owning navigation name controls the host setup identity when a visual frame name is shared.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task SetMainNavigationHost_WithOwnerNameAndSharedFrameName_UsesOwnerHostNameForSetupIdentity()
+    {
+        // Arrange
+        var hostName = GetUniqueHostName();
+        using var setNav = new TestSetNavigationViewModel(hostName);
+        var viewHost = new TestViewModelRoutedViewHost(VisualFrameName, VisualFrameName) { RequiresSetup = true };
+
+        // Act
+        setNav.SetMainNavigationHost(viewHost);
+
+        // Assert
+        await Assert.That(viewHost.HostName).IsEqualTo(hostName);
+        await Assert.That(viewHost.Name).IsEqualTo(VisualFrameName);
+        await Assert.That(ViewModelRoutedViewHostMixins.NavigationHost[hostName]).IsEqualTo(viewHost);
+        await Assert.That(ViewModelRoutedViewHostMixins.NavigationHost[VisualFrameName]).IsEqualTo(viewHost);
+        await Assert.That(viewHost.SetupCallCount).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies that setup notifications use the logical host name when it differs from the view name.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task WhenSetup_WithLogicalHostNameAlias_NotifiesSubscriber()
+    {
+        // Arrange
+        var hostName = GetUniqueHostName();
+        var observed = false;
+        using var vm = new TestViewModel(hostName);
+        using var setNav = new TestSetNavigationViewModel(string.Empty);
+        using var subscription = vm.WhenSetup().Subscribe(value => observed = value);
+        var viewHost = new TestViewModelRoutedViewHost(VisualFrameName, hostName);
+
+        // Act
+        setNav.SetMainNavigationHost(viewHost);
+        await Task.Delay(ObservablePropagationDelayMilliseconds);
+
+        // Assert
+        await Assert.That(observed).IsTrue();
+    }
+
     /// <summary>Provides the SetMainNavigationHost_ThrowsWhenSetNavigationIsNull member.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
     [Test]
@@ -200,6 +268,67 @@ public partial class ViewModelRoutedViewHostMixinsTests
 
         // Assert - recreated shells/windows must not keep navigating through stale hosts.
         await Assert.That(ViewModelRoutedViewHostMixins.NavigationHost[hostName]).IsEqualTo(replacementHost);
+    }
+
+    /// <summary>Verifies that unregistering one visual host leaves another logical host usable.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task UnregisterNavigationHost_WithTwoLogicalHosts_RemovesOnlyDisposedHost()
+    {
+        // Arrange
+        var firstHostName = GetUniqueHostName();
+        var secondHostName = GetUniqueHostName();
+        using var firstSetup = new TestSetNavigationViewModel(string.Empty);
+        using var secondSetup = new TestSetNavigationViewModel(string.Empty);
+        using var hostedNavigation = new TestHostedViewModel();
+        var firstHost = new TestViewModelRoutedViewHost(VisualFrameName, firstHostName);
+        var secondHost = new TestViewModelRoutedViewHost(VisualFrameName, secondHostName);
+        RegisterTestViewModel(new(secondHostName));
+        firstSetup.SetMainNavigationHost(firstHost);
+        secondSetup.SetMainNavigationHost(secondHost);
+        firstHost.NavigationStack.Add(typeof(TestViewModel));
+        secondHost.NavigationStack.Add(typeof(TestHostedViewModel));
+
+        // Act
+        ViewModelRoutedViewHostMixins.UnregisterNavigationHost(firstHost);
+        hostedNavigation.NavigateToView(
+            new NavigationKeyRequest<TestViewModel> { Options = new NavigationRequestOptions { HostName = secondHostName }, });
+
+        // Assert
+        await Assert.That(ViewModelRoutedViewHostMixins.NavigationHost.ContainsKey(firstHostName)).IsFalse();
+        await Assert.That(ViewModelRoutedViewHostMixins.ResultNavigating.ContainsKey(firstHostName)).IsFalse();
+        await Assert.That(ViewModelRoutedViewHostMixins.WhenSetupSubjects.ContainsKey(firstHostName)).IsFalse();
+        await Assert.That(ViewModelRoutedViewHostMixins.CurrentViewDisposable.ContainsKey(firstHostName)).IsFalse();
+        await Assert.That(ViewModelRoutedViewHostMixins.NavigationHost[secondHostName]).IsEqualTo(secondHost);
+        await Assert.That(ViewModelRoutedViewHostMixins.NavigationHost[VisualFrameName]).IsEqualTo(secondHost);
+        await Assert.That(firstHost.NavigationStack.Count).IsEqualTo(1);
+        await Assert.That(secondHost.NavigationStack.Count).IsEqualTo(ExpectedTwoItemHistoryCount);
+    }
+
+    /// <summary>Verifies that unregistering a stale host does not remove a replacement registered under the same name.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task UnregisterNavigationHost_WithReplacementHost_DoesNotRemoveReplacement()
+    {
+        // Arrange
+        var hostName = GetUniqueHostName();
+        using var setup = new TestSetNavigationViewModel(hostName);
+        using var hostedNavigation = new TestHostedViewModel();
+        var staleHost = new TestViewModelRoutedViewHost(hostName);
+        var replacementHost = new TestViewModelRoutedViewHost(hostName);
+        RegisterTestViewModel(new(hostName));
+        setup.SetMainNavigationHost(staleHost);
+        setup.SetMainNavigationHost(replacementHost);
+
+        // Act
+        ViewModelRoutedViewHostMixins.UnregisterNavigationHost(staleHost);
+        hostedNavigation.NavigateToView(
+            new NavigationKeyRequest<TestViewModel> { Options = new NavigationRequestOptions { HostName = hostName }, });
+
+        // Assert
+        await Assert.That(ViewModelRoutedViewHostMixins.NavigationHost[hostName]).IsEqualTo(replacementHost);
+        await Assert.That(replacementHost.NavigationStack.Count).IsEqualTo(1);
+        await Assert.That(staleHost.NavigationStack.Count).IsEqualTo(0);
     }
 
     /// <summary>Provides the ClearHistory_WithIUseNavigation_ClearsHostHistory member.</summary>

--- a/src/Tests/CrissCross.WPF.Plot.Tests/ReactivePlotExampleCoverageTests.cs
+++ b/src/Tests/CrissCross.WPF.Plot.Tests/ReactivePlotExampleCoverageTests.cs
@@ -3,13 +3,24 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.IO;
+using System.Windows;
+using System.Windows.Threading;
+#if REACTIVELIST_REACTIVE
+using CrissCross.Reactive.WPF.Plot;
+using ReactiveUI.Reactive;
+using ReactiveUI.Reactive.Builder;
+#else
+using CrissCross.WPF.Plot;
+using ReactiveUI;
+using ReactiveUI.Builder;
+#endif
 
 namespace CrissCross.WPF.Plot.Tests;
 
 /// <summary>Static coverage tests for reactive WPF plot example and public control binding surface.</summary>
 public sealed class ReactivePlotExampleCoverageTests
 {
-    /// <summary>The WPF plot project name.</summary>
+    /// <summary>The source project linked into both WPF plot package variants.</summary>
     private const string PlotProjectName = "CrissCross.WPF.Plot";
 
     /// <summary>The views directory name.</summary>
@@ -49,11 +60,13 @@ public sealed class ReactivePlotExampleCoverageTests
     [Test]
     public async Task LiveChart_DisposesReactivePlotConnectionOnActivationTeardownAndUnload()
     {
-        var control = ReadSource(PlotProjectName, ViewsDirectoryName, "LiveChart.xaml.cs");
+        var snapshot = await RunOnStaThreadAsync(ExerciseLiveChartCrosshairLifecycle);
 
-        await Assert.That(control).Contains("DisposeReactivePlotConnection");
-        await Assert.That(control).Contains("new ActionDisposable(DisposeReactivePlotConnection).DisposeWith(d)");
-        await Assert.That(control).Contains("UnloadedObservable");
+        await Assert.That(snapshot.SignalCrosshairVisibleAfterEnable).IsTrue();
+        await Assert.That(snapshot.SignalCrosshairChangedAfterDisposedToggle).IsFalse();
+        await Assert.That(snapshot.ScatterCrosshairChangedAfterDisposedToggle).IsFalse();
+        await Assert.That(snapshot.ConnectionActiveBeforeUnload).IsTrue();
+        await Assert.That(snapshot.ConnectionClearedAfterUnload).IsTrue();
     }
 
     /// <summary>Verifies WPF adapters document retention and clear state reset contracts.</summary>
@@ -67,7 +80,7 @@ public sealed class ReactivePlotExampleCoverageTests
 
         await Assert.That(adapter).Contains("PrepareSnapshotUpdate");
         await Assert.That(adapter).Contains("update.MaxPoints ?? int.MaxValue");
-        await Assert.That(adapter).Contains("signal.ClearData()");
+        await Assert.That(adapter).Contains("signal.ClearData");
         await Assert.That(dataLogger).Contains("base.Dispose(disposing)");
         await Assert.That(signal).Contains("public void ClearData()");
     }
@@ -100,6 +113,121 @@ public sealed class ReactivePlotExampleCoverageTests
         return File.ReadAllText(path);
     }
 
+    /// <summary>Exercises LiveChart crosshair and unload lifecycle behavior on a Windows STA thread.</summary>
+    /// <returns>The observed lifecycle state.</returns>
+    private static LiveChartLifecycleSnapshot ExerciseLiveChartCrosshairLifecycle()
+    {
+        _ = RxAppBuilder.CreateReactiveUIBuilder().WithWpf().BuildApp();
+        var previousMainThreadScheduler = RxSchedulers.MainThreadScheduler;
+        RxSchedulers.MainThreadScheduler = ImmediateScheduler.Instance;
+        try
+        {
+            return ExerciseLiveChartCrosshairLifecycleSynchronously();
+        }
+        finally
+        {
+            RxSchedulers.MainThreadScheduler = previousMainThreadScheduler;
+        }
+    }
+
+    /// <summary>Exercises LiveChart lifecycle behavior with actual source rebinding.</summary>
+    /// <returns>The observed lifecycle state.</returns>
+    private static LiveChartLifecycleSnapshot ExerciseLiveChartCrosshairLifecycleSynchronously()
+    {
+        using var reactiveSignalTicks = new Signal<(string? Name, IList<double>? Value, IList<double> DateTime, int Axis)>();
+        using var signalTicks = new Signal<(string? Name, IList<double>? Y, IList<double> X, int Axis)>();
+        using var scatterPoints = new Signal<(string? Name, IList<double>? X, IList<double> Y, int Axis)>();
+        var chart = new LiveChart();
+        var window = new Window { Content = chart };
+        var windowClosed = false;
+
+        try
+        {
+            window.Show();
+            DrainDispatcher();
+
+            chart.ReactivePlotSources = [ReactivePlotSource.FromSignalTicks(reactiveSignalTicks)];
+            reactiveSignalTicks.OnNext(("ReactiveSignal", [1D], [1D], 0));
+            DrainDispatcher();
+
+            chart.AssignLiveChartData(
+                new LiveChart.SignalEnumObsTicks([signalTicks]),
+                UserPlotType.SignalEnumObsTicks);
+            signalTicks.OnNext(("Signal", [1D], [1D], 0));
+            DrainDispatcher();
+            var signalSetting = chart.ViewModel!.PlotLinesCollectionUI[
+                chart.ViewModel.PlotLinesCollectionUI.Count - 1].ChartSettings;
+            chart.ViewModel.CrossHairEnabled = true;
+            DrainDispatcher();
+            var signalCrosshairVisibleAfterEnable = signalSetting.IsCrossHairVisible;
+
+            chart.AssignLiveChartData(
+                new LiveChart.ScatterEnumObsPoints([scatterPoints]),
+                UserPlotType.ScatterEnumObsPoints);
+            scatterPoints.OnNext(("Scatter", [1D], [1D], 0));
+            DrainDispatcher();
+
+            var scatterSetting = chart.ViewModel.PlotLinesCollectionUI[
+                chart.ViewModel.PlotLinesCollectionUI.Count - 1].ChartSettings;
+            var signalCrosshairAfterRebind = signalSetting.IsCrossHairVisible;
+            var scatterCrosshairAfterRebind = scatterSetting.IsCrossHairVisible;
+            chart.ViewModel.CrossHairEnabled = true;
+            DrainDispatcher();
+
+            var connectionActiveBeforeUnload = reactiveSignalTicks.HasObservers;
+            window.Content = null;
+            window.Close();
+            windowClosed = true;
+            DrainDispatcher();
+
+            return new(
+                signalCrosshairVisibleAfterEnable,
+                signalSetting.IsCrossHairVisible != signalCrosshairAfterRebind,
+                scatterSetting.IsCrossHairVisible != scatterCrosshairAfterRebind,
+                connectionActiveBeforeUnload,
+                !reactiveSignalTicks.HasObservers);
+        }
+        finally
+        {
+            if (!windowClosed)
+            {
+                window.Content = null;
+                window.Close();
+            }
+
+            chart.ViewModel?.Dispose();
+        }
+    }
+
+    /// <summary>Runs queued reactive notifications on the current Windows dispatcher.</summary>
+    private static void DrainDispatcher() =>
+        Dispatcher.CurrentDispatcher.Invoke(static () => { }, DispatcherPriority.ApplicationIdle);
+
+    /// <summary>Runs work on a Windows STA thread.</summary>
+    /// <typeparam name="TResult">The result type.</typeparam>
+    /// <param name="action">The platform action.</param>
+    /// <returns>A task that completes with the action result.</returns>
+    private static Task<TResult> RunOnStaThreadAsync<TResult>(Func<TResult> action)
+    {
+        var completion = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(
+            () =>
+            {
+                try
+                {
+                    completion.SetResult(action());
+                }
+                catch (Exception exception)
+                {
+                    completion.SetException(exception);
+                }
+            });
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        return completion.Task;
+    }
+
     /// <summary>Locates the source root.</summary>
     /// <returns>The source root path.</returns>
     private static string LocateSourceRoot()
@@ -119,4 +247,20 @@ public sealed class ReactivePlotExampleCoverageTests
         throw new DirectoryNotFoundException(
             "Unable to locate CrissCross.slnx from the current test working directory.");
     }
+
+    /// <summary>Captures LiveChart lifecycle observations.</summary>
+    /// <param name="SignalCrosshairVisibleAfterEnable">Whether the signal setting responded to crosshair
+    /// enable.</param>
+    /// <param name="SignalCrosshairChangedAfterDisposedToggle">Whether the old signal setting changed after rebind
+    /// disposal.</param>
+    /// <param name="ScatterCrosshairChangedAfterDisposedToggle">Whether the scatter setting changed without a
+    /// subscription.</param>
+    /// <param name="ConnectionActiveBeforeUnload">Whether the source had an active subscription before unload.</param>
+    /// <param name="ConnectionClearedAfterUnload">Whether the reactive plot connection was cleared by unload.</param>
+    private sealed record LiveChartLifecycleSnapshot(
+        bool SignalCrosshairVisibleAfterEnable,
+        bool SignalCrosshairChangedAfterDisposedToggle,
+        bool ScatterCrosshairChangedAfterDisposedToggle,
+        bool ConnectionActiveBeforeUnload,
+        bool ConnectionClearedAfterUnload);
 }

--- a/src/Tests/CrissCross.WPF.UI.Gallery.Tests/GifImageAnimatorTests.cs
+++ b/src/Tests/CrissCross.WPF.UI.Gallery.Tests/GifImageAnimatorTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Windows.Media.Animation;
+using StandardImageAnimator = CrissCross.WPF.UI.Controls.ImageAnimator;
+using UnsupportedGifVersionException = CrissCross.WPF.UI.Controls.Decoding.UnsupportedGifVersionException;
+
+namespace CrissCross.WPF.UI.Gallery.Tests;
+
+/// <summary>Exercises GIF image animator regression paths.</summary>
+public sealed class GifImageAnimatorTests
+{
+    /// <summary>The first byte in the GIF file signature.</summary>
+    private const byte GifSignatureFirstByte = 0x47;
+
+    /// <summary>The second byte in the GIF file signature.</summary>
+    private const byte GifSignatureSecondByte = 0x49;
+
+    /// <summary>The third byte in the GIF file signature.</summary>
+    private const byte GifSignatureThirdByte = 0x46;
+
+    /// <summary>The first byte in the unsupported GIF version.</summary>
+    private const byte UnsupportedVersionFirstByte = 0x30;
+
+    /// <summary>The second byte in the unsupported GIF version.</summary>
+    private const byte UnsupportedVersionSecondByte = 0x30;
+
+    /// <summary>The third byte in the unsupported GIF version.</summary>
+    private const byte UnsupportedVersionThirdByte = 0x30;
+
+    /// <summary>Verifies the stream factory delegates to decoding and returns the awaited decoder fault.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task StreamFactory_WithUnsupportedGifVersion_ThrowsDecoderException()
+    {
+        var exception = await CaptureCreateAsyncExceptionAsync();
+
+        await Assert.That(exception).IsTypeOf<UnsupportedGifVersionException>();
+    }
+
+    /// <summary>Creates a minimal GIF stream with an unsupported version.</summary>
+    /// <returns>The stream used by the factory regression test.</returns>
+    private static MemoryStream CreateUnsupportedVersionGifStream() => new(
+        [
+            GifSignatureFirstByte,
+            GifSignatureSecondByte,
+            GifSignatureThirdByte,
+            UnsupportedVersionFirstByte,
+            UnsupportedVersionSecondByte,
+            UnsupportedVersionThirdByte,
+        ]);
+
+    /// <summary>Captures the exception thrown by the awaited stream factory.</summary>
+    /// <returns>The captured exception, or <see langword="null"/> when no exception was thrown.</returns>
+    private static async Task<Exception?> CaptureCreateAsyncExceptionAsync()
+    {
+        await using MemoryStream stream = CreateUnsupportedVersionGifStream();
+        try
+        {
+            using StandardImageAnimator animator = await StandardImageAnimator
+                .CreateAsync(stream, RepeatBehavior.Forever, null!)
+                .ConfigureAwait(false);
+            return null;
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+    }
+}

--- a/src/Tests/CrissCross.WPF.UI.Gallery.Tests/PersonPictureInitialsTests.cs
+++ b/src/Tests/CrissCross.WPF.UI.Gallery.Tests/PersonPictureInitialsTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using CrissCross.WPF.UI.Controls;
+
+namespace CrissCross.WPF.UI.Gallery.Tests;
+
+/// <summary>Verifies mixed scripts preserve the initials character-set precedence.</summary>
+public sealed class PersonPictureInitialsTests
+{
+    /// <summary>Verifies glyph and symbolic characters prevent unsafe truncation even when followed by Latin characters.</summary>
+    /// <param name="displayName">The display name to project.</param>
+    /// <param name="expectedInitials">The safe initials or null for the generic picture glyph.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [Arguments("John Smith", "JS")]
+    [Arguments("中A", null)]
+    [Arguments("اA", null)]
+    [Arguments("Aا", null)]
+    public async Task DisplayName_WithMixedScripts_PreservesCharacterPrecedence(string displayName, string? expectedInitials)
+    {
+        var completion = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                using var picture = new PersonPicture { DisplayName = displayName };
+                completion.SetResult(picture.TemplateSettings.ActualInitials);
+            }
+            catch (Exception exception)
+            {
+                completion.SetException(exception);
+            }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+
+        await Assert.That(await completion.Task).IsEqualTo(expectedInitials);
+    }
+}

--- a/src/Tests/CrissCross.WPF.UI.Gallery.Tests/PlatformHostRuntimeTests.cs
+++ b/src/Tests/CrissCross.WPF.UI.Gallery.Tests/PlatformHostRuntimeTests.cs
@@ -4,12 +4,14 @@
 
 using System.ComponentModel;
 using System.Drawing;
+using System.Windows;
 using System.Windows.Threading;
 using CrissCross.WPF;
 using ReactiveUI;
 using FormsHost = CrissCross.WinForms.ViewModelRoutedViewHost;
 using FormsUserControl = System.Windows.Forms.UserControl;
 using WpfHost = CrissCross.WPF.ViewModelRoutedViewHost;
+using WpfUserControl = System.Windows.Controls.UserControl;
 
 namespace CrissCross.WPF.UI.Gallery.Tests;
 
@@ -47,6 +49,11 @@ public sealed class PlatformHostRuntimeTests
         await Assert.That(snapshot.Background).IsEqualTo(System.Drawing.Color.Navy);
         await Assert.That(snapshot.Foreground).IsEqualTo(System.Drawing.Color.White);
         await Assert.That(snapshot.Content).IsSameReferenceAs(snapshot.Overlay);
+        await Assert.That(snapshot.HostCreatedAfterLoad).IsTrue();
+        await Assert.That(snapshot.HostClearedAfterDispose).IsTrue();
+        await Assert.That(snapshot.ParentClearedAfterDispose).IsTrue();
+        await Assert.That(snapshot.DisposedAfterExplicitDispose).IsTrue();
+        await Assert.That(snapshot.DisposeIsIdempotent).IsTrue();
     }
 
     /// <summary>Exercises both platform navigation hosts.</summary>
@@ -130,7 +137,7 @@ public sealed class PlatformHostRuntimeTests
     private static WebViewSnapshot ExerciseWebView()
     {
         var overlay = new System.Windows.Controls.Border();
-        using var browser = new WebView2Wpf
+        var browser = new WebView2Wpf
         {
             AllowExternalDrop = false,
             AutoDispose = false,
@@ -139,25 +146,52 @@ public sealed class PlatformHostRuntimeTests
             DesignModeForegroundColor = System.Drawing.Color.White,
             ZoomFactor = BrowserZoomFactor,
         };
+        var window = new Window { Content = browser };
 
-        browser.GoBack();
-        browser.GoForward();
-        bool reloadRequiresInitialization = ThrowsBeforeCoreInitialization(browser.Reload);
-        bool stopRequiresInitialization = ThrowsBeforeCoreInitialization(browser.Stop);
+        try
+        {
+            window.Show();
+            DrainDispatcher();
+            var hostCreatedAfterLoad = browser.IsOverlayHostLoaded;
 
-        return new(
-            browser.AllowExternalDrop,
-            browser.AutoDispose,
-            reloadRequiresInitialization,
-            stopRequiresInitialization,
-            browser.ZoomFactor,
-            browser.DefaultBackgroundColor,
-            browser.DesignModeForegroundColor,
-            browser.Content,
-            overlay);
+            browser.GoBack();
+            browser.GoForward();
+            bool reloadRequiresInitialization = ThrowsBeforeCoreInitialization(browser.Reload);
+            bool stopRequiresInitialization = ThrowsBeforeCoreInitialization(browser.Stop);
+
+            browser.Dispose();
+            DrainDispatcher();
+            var hostClearedAfterDispose = !browser.IsOverlayHostLoaded;
+            var parentClearedAfterDispose = !browser.IsParentWindowAssigned;
+            var disposedAfterExplicitDispose = browser.IsDisposed;
+            browser.Dispose();
+            var disposeIsIdempotent = browser.IsDisposed;
+
+            return new(
+                browser.AllowExternalDrop,
+                browser.AutoDispose,
+                reloadRequiresInitialization,
+                stopRequiresInitialization,
+                browser.ZoomFactor,
+                browser.DefaultBackgroundColor,
+                browser.DesignModeForegroundColor,
+                browser.Content,
+                overlay,
+                hostCreatedAfterLoad,
+                hostClearedAfterDispose,
+                parentClearedAfterDispose,
+                disposedAfterExplicitDispose,
+                disposeIsIdempotent);
+        }
+        finally
+        {
+            window.Content = null;
+            window.Close();
+            browser.Dispose();
+        }
     }
 
-    /// <summary>Invokes an operation that requires the WebView2 core and captures its documented pre-init failure.</summary>
+    /// <summary>Captures the documented WebView2 pre-init failure.</summary>
     /// <param name="operation">The WebView2 operation.</param>
     /// <returns><c>true</c> when the operation requires core initialization.</returns>
     private static bool ThrowsBeforeCoreInitialization(Action operation)
@@ -203,7 +237,7 @@ public sealed class PlatformHostRuntimeTests
 
     /// <summary>Provides a WPF view for resolved navigation.</summary>
     /// <param name="viewModel">The initial view model.</param>
-    private sealed class WpfTestView(TestViewModel viewModel) : System.Windows.Controls.UserControl, IViewFor<TestViewModel>
+    private sealed class WpfTestView(TestViewModel viewModel) : WpfUserControl, IViewFor<TestViewModel>
     {
         /// <inheritdoc/>
         public TestViewModel? ViewModel { get; set; } = viewModel;
@@ -260,6 +294,12 @@ public sealed class PlatformHostRuntimeTests
     /// <param name="Foreground">The configured design-mode foreground.</param>
     /// <param name="Content">The configured overlay content.</param>
     /// <param name="Overlay">The expected overlay.</param>
+    /// <param name="HostCreatedAfterLoad">Whether the overlay host was created when the wrapper loaded.</param>
+    /// <param name="HostClearedAfterDispose">Whether the overlay host was cleared by explicit disposal.</param>
+    /// <param name="ParentClearedAfterDispose">Whether the parent window reference was cleared by explicit
+    /// disposal.</param>
+    /// <param name="DisposedAfterExplicitDispose">Whether the wrapper marked itself disposed.</param>
+    /// <param name="DisposeIsIdempotent">Whether a second dispose call preserved the disposed state.</param>
     private sealed record WebViewSnapshot(
         bool AllowExternalDrop,
         bool AutoDispose,
@@ -269,5 +309,10 @@ public sealed class PlatformHostRuntimeTests
         Color Background,
         Color Foreground,
         object Content,
-        object Overlay);
+        object Overlay,
+        bool HostCreatedAfterLoad,
+        bool HostClearedAfterDispose,
+        bool ParentClearedAfterDispose,
+        bool DisposedAfterExplicitDispose,
+        bool DisposeIsIdempotent);
 }

--- a/src/Tests/CrissCross.WPF.UI.Gallery.Tests/ProcessValueIndicatorTests.cs
+++ b/src/Tests/CrissCross.WPF.UI.Gallery.Tests/ProcessValueIndicatorTests.cs
@@ -1,0 +1,286 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows;
+using System.Windows.Media;
+using Color = System.Windows.Media.Color;
+using ReactiveIndicator = CrissCross.Reactive.WPF.UI.Controls.ProcessValueIndicator;
+using ReactiveOptions = CrissCross.Reactive.ProcessValueOptions;
+using ReactiveState = CrissCross.Reactive.ProcessValueState;
+using ReactiveStatus = CrissCross.Reactive.ProcessValueStatus;
+using StandardIndicator = CrissCross.WPF.UI.Controls.ProcessValueIndicator;
+using StandardOptions = CrissCross.ProcessValueOptions;
+using StandardState = CrissCross.ProcessValueState;
+using StandardStatus = CrissCross.ProcessValueStatus;
+
+namespace CrissCross.WPF.UI.Gallery.Tests;
+
+/// <summary>Exercises WPF process value indicator state projection.</summary>
+public sealed class ProcessValueIndicatorTests
+{
+    /// <summary>The fallback label used when no process value state is supplied.</summary>
+    private const string FallbackLabel = "Process value";
+
+    /// <summary>The fallback display text used when no process value reading is available.</summary>
+    private const string FallbackDisplayText = "—";
+
+    /// <summary>The fallback status text used when no process value state is supplied.</summary>
+    private const string FallbackStatusText = "Bad quality";
+
+    /// <summary>The line pressure label used by projection tests.</summary>
+    private const string LinePressureLabel = "Line pressure";
+
+    /// <summary>The tank level label used by reactive projection tests.</summary>
+    private const string TankLevelLabel = "Tank level";
+
+    /// <summary>The flow rate label used by bad-quality projection tests.</summary>
+    private const string FlowRateLabel = "Flow rate";
+
+    /// <summary>The engineering unit used by pressure readings.</summary>
+    private const string PressureUnit = "bar";
+
+    /// <summary>The engineering unit used by percentage readings.</summary>
+    private const string PercentageUnit = "%";
+
+    /// <summary>The engineering unit used by flow readings.</summary>
+    private const string FlowUnit = "L/min";
+
+    /// <summary>The minimum range value used by the tests.</summary>
+    private const double MinimumValue = 0D;
+
+    /// <summary>The pressure reading used by standard projection tests.</summary>
+    private const double PressureValue = 8D;
+
+    /// <summary>The pressure maximum and high-alarm value.</summary>
+    private const double PressureMaximum = 10D;
+
+    /// <summary>The pressure low-alarm value.</summary>
+    private const double PressureLowAlarm = 2D;
+
+    /// <summary>The tank-level reading used by reactive projection tests.</summary>
+    private const double TankLevelValue = 72D;
+
+    /// <summary>The normalized percentage maximum.</summary>
+    private const double PercentageMaximum = 100D;
+
+    /// <summary>The tank-level low-alarm value.</summary>
+    private const double TankLowAlarm = 10D;
+
+    /// <summary>The tank-level high-alarm value.</summary>
+    private const double TankHighAlarm = 90D;
+
+    /// <summary>The flow reading used by bad-quality projection tests.</summary>
+    private const double FlowValue = 318D;
+
+    /// <summary>The flow display maximum.</summary>
+    private const double FlowMaximum = 500D;
+
+    /// <summary>The flow low-alarm value.</summary>
+    private const double FlowLowAlarm = 50D;
+
+    /// <summary>The flow high-alarm value.</summary>
+    private const double FlowHighAlarm = 450D;
+
+    /// <summary>Verifies each high-contrast palette distinguishes industrial status conditions.</summary>
+    /// <param name="theme">The high-contrast resource dictionary name.</param>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    [Arguments("HCWhite")]
+    [Arguments("HCBlack")]
+    [Arguments("HC1")]
+    [Arguments("HC2")]
+    public async Task HighContrastPalettes_DistinguishProcessStates(string theme)
+    {
+        var colors = await RunOnStaThreadAsync(() => ReadStatusColors(theme));
+        await Assert.That(colors.Success).IsNotEqualTo(colors.Caution);
+        await Assert.That(colors.Success).IsNotEqualTo(colors.Critical);
+        await Assert.That(colors.Caution).IsNotEqualTo(colors.Critical);
+        await Assert.That(colors.Background).IsNotEqualTo(Colors.Red);
+        await Assert.That(colors.Success).IsNotEqualTo(Colors.Red);
+        await Assert.That(colors.Caution).IsNotEqualTo(Colors.Red);
+        await Assert.That(colors.Critical).IsNotEqualTo(Colors.Red);
+    }
+
+    /// <summary>Verifies the standard WPF control projects null state as an empty fallback.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task StandardIndicator_WithNullState_ExposesEmptyFallback()
+    {
+        var snapshot = await RunOnStaThreadAsync(static () => Capture(new StandardIndicator()));
+
+        await Assert.That(snapshot.Label).IsEqualTo(FallbackLabel);
+        await Assert.That(snapshot.DisplayText).IsEqualTo(FallbackDisplayText);
+        await Assert.That(snapshot.StatusText).IsEqualTo(FallbackStatusText);
+        await Assert.That(snapshot.Percentage).IsEqualTo(MinimumValue);
+        await Assert.That(snapshot.NormalizedValue).IsEqualTo(MinimumValue);
+        await Assert.That(snapshot.HasValidValue).IsFalse();
+        await Assert.That(snapshot.IsAlarm).IsFalse();
+        await Assert.That(snapshot.Status).IsEqualTo((StandardStatus?)StandardStatus.BadQuality);
+    }
+
+    /// <summary>Verifies standard WPF state projection for templates and bindings.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task StandardIndicator_WithState_ProjectsTemplateBindableValues()
+    {
+        StandardState state = new(
+            LinePressureLabel,
+            PressureValue,
+            PressureUnit,
+            MinimumValue,
+            PressureMaximum,
+            PressureLowAlarm,
+            PressureValue);
+        var snapshot = await RunOnStaThreadAsync(() => Capture(new StandardIndicator { State = state }));
+
+        await Assert.That(snapshot.Label).IsEqualTo(state.Label);
+        await Assert.That(snapshot.DisplayText).IsEqualTo(state.DisplayText);
+        await Assert.That(snapshot.StatusText).IsEqualTo(state.StatusText);
+        await Assert.That(snapshot.Percentage).IsEqualTo(state.Percentage);
+        await Assert.That(snapshot.NormalizedValue).IsEqualTo(state.NormalizedValue);
+        await Assert.That(snapshot.HasValidValue).IsEqualTo(state.HasValidValue);
+        await Assert.That(snapshot.IsAlarm).IsTrue();
+        await Assert.That(snapshot.Status).IsEqualTo((StandardStatus?)StandardStatus.HighAlarm);
+    }
+
+    /// <summary>Verifies reactive WPF state projection from the reactive namespace variant.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task ReactiveIndicator_WithState_ProjectsTemplateBindableValues()
+    {
+        ReactiveState state = new(
+            TankLevelLabel,
+            TankLevelValue,
+            PercentageUnit,
+            MinimumValue,
+            PercentageMaximum,
+            CreateBadQualityReactiveOptions());
+        var snapshot = await RunOnStaThreadAsync(() => Capture(new ReactiveIndicator { State = state }));
+
+        await Assert.That(snapshot.Label).IsEqualTo(state.Label);
+        await Assert.That(snapshot.DisplayText).IsEqualTo(state.DisplayText);
+        await Assert.That(snapshot.StatusText).IsEqualTo(state.StatusText);
+        await Assert.That(snapshot.Percentage).IsEqualTo(state.Percentage);
+        await Assert.That(snapshot.NormalizedValue).IsEqualTo(state.NormalizedValue);
+        await Assert.That(snapshot.HasValidValue).IsFalse();
+        await Assert.That(snapshot.IsAlarm).IsFalse();
+        await Assert.That(snapshot.ReactiveStatus).IsEqualTo((ReactiveStatus?)ReactiveStatus.BadQuality);
+    }
+
+    /// <summary>Verifies the standard WPF control projects explicit bad-quality options.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task StandardIndicator_WithBadQualityOptions_ProjectsUnavailableStatus()
+    {
+        StandardState state = new(
+            FlowRateLabel,
+            FlowValue,
+            FlowUnit,
+            MinimumValue,
+            FlowMaximum,
+            CreateBadQualityStandardOptions());
+        var snapshot = await RunOnStaThreadAsync(() => Capture(new StandardIndicator { State = state }));
+
+        await Assert.That(snapshot.DisplayText).IsEqualTo(state.DisplayText);
+        await Assert.That(snapshot.StatusText).IsEqualTo(FallbackStatusText);
+        await Assert.That(snapshot.Percentage).IsEqualTo(MinimumValue);
+        await Assert.That(snapshot.HasValidValue).IsFalse();
+        await Assert.That(snapshot.Status).IsEqualTo((StandardStatus?)StandardStatus.BadQuality);
+    }
+
+    /// <summary>Loads actual high-contrast resources on their WPF owner thread.</summary>
+    /// <param name="theme">The resource dictionary name.</param>
+    /// <returns>The status and background palette colors.</returns>
+    private static (Color Success, Color Caution, Color Critical, Color Background) ReadStatusColors(string theme)
+    {
+        var resources = new ResourceDictionary { Source = new($"pack://application:,,,/CrissCross.WPF.UI;component/Resources/Theme/{theme}.xaml") };
+        return (
+            ((SolidColorBrush)resources["SystemFillColorSuccessBrush"]).Color,
+            ((SolidColorBrush)resources["SystemFillColorCautionBrush"]).Color,
+            ((SolidColorBrush)resources["SystemFillColorCriticalBrush"]).Color,
+            (Color)resources["CardBackgroundFillColorDefault"]);
+    }
+
+    /// <summary>Creates standard bad-quality process value options.</summary>
+    /// <returns>The configured standard options.</returns>
+    private static StandardOptions CreateBadQualityStandardOptions() => new() { LowAlarmLimit = FlowLowAlarm, HighAlarmLimit = FlowHighAlarm, IsGoodQuality = false, };
+
+    /// <summary>Creates reactive bad-quality process value options.</summary>
+    /// <returns>The configured reactive options.</returns>
+    private static ReactiveOptions CreateBadQualityReactiveOptions() => new() { LowAlarmLimit = TankLowAlarm, HighAlarmLimit = TankHighAlarm, IsGoodQuality = false, };
+
+    /// <summary>Captures standard indicator projection values.</summary>
+    /// <param name="indicator">The indicator to inspect.</param>
+    /// <returns>The captured projection values.</returns>
+    private static IndicatorSnapshot Capture(StandardIndicator indicator) => new(
+        indicator.Label,
+        indicator.DisplayText,
+        indicator.StatusText,
+        indicator.Percentage,
+        indicator.NormalizedValue,
+        indicator.HasValidValue,
+        indicator.IsAlarm,
+        indicator.Status,
+        null);
+
+    /// <summary>Captures reactive indicator projection values.</summary>
+    /// <param name="indicator">The indicator to inspect.</param>
+    /// <returns>The captured projection values.</returns>
+    private static IndicatorSnapshot Capture(ReactiveIndicator indicator) => new(
+        indicator.Label,
+        indicator.DisplayText,
+        indicator.StatusText,
+        indicator.Percentage,
+        indicator.NormalizedValue,
+        indicator.HasValidValue,
+        indicator.IsAlarm,
+        null,
+        indicator.Status);
+
+    /// <summary>Runs a factory on an STA thread for WPF dependency object access.</summary>
+    /// <param name="action">The factory to run.</param>
+    /// <typeparam name="TResult">The result type.</typeparam>
+    /// <returns>A task that completes with the factory result.</returns>
+    private static Task<TResult> RunOnStaThreadAsync<TResult>(Func<TResult> action)
+    {
+        var completion = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(
+            () =>
+            {
+                try
+                {
+                    completion.SetResult(action());
+                }
+                catch (Exception exception)
+                {
+                    completion.SetException(exception);
+                }
+            });
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        return completion.Task;
+    }
+
+    /// <summary>Stores process value projection values captured from an indicator instance.</summary>
+    /// <param name="Label">The projected label.</param>
+    /// <param name="DisplayText">The projected display text.</param>
+    /// <param name="StatusText">The projected status text.</param>
+    /// <param name="Percentage">The projected percentage.</param>
+    /// <param name="NormalizedValue">The projected normalized value.</param>
+    /// <param name="HasValidValue">Whether the reading is valid.</param>
+    /// <param name="IsAlarm">Whether the reading is in alarm.</param>
+    /// <param name="Status">The standard status value, when captured from the standard control.</param>
+    /// <param name="ReactiveStatus">The reactive status value, when captured from the reactive control.</param>
+    private sealed record IndicatorSnapshot(
+        string Label,
+        string DisplayText,
+        string StatusText,
+        double Percentage,
+        double NormalizedValue,
+        bool HasValidValue,
+        bool IsAlarm,
+        StandardStatus? Status,
+        ReactiveStatus? ReactiveStatus);
+}

--- a/src/Tests/CrissCross.WPF.UI.Gallery.Tests/PublicValueSurfaceTests.cs
+++ b/src/Tests/CrissCross.WPF.UI.Gallery.Tests/PublicValueSurfaceTests.cs
@@ -7,6 +7,7 @@ using CrissCross.WPF.UI.Appearance;
 using CrissCross.WPF.UI.Configuration;
 using CrissCross.WPF.UI.Hardware;
 using CrissCross.WPF.UI.Interop.WinDef;
+using CrissCross.WPF.UI.TaskBar;
 using ReactiveDisplayDpi = CrissCross.Reactive.WPF.UI.Hardware.DisplayDpi;
 using ReactiveRect = CrissCross.Reactive.WPF.UI.Interop.WinDef.RECT;
 using ReactiveRectLong = CrissCross.Reactive.WPF.UI.Interop.WinDef.RECTL;
@@ -96,6 +97,21 @@ public sealed class PublicValueSurfaceTests
 
     /// <summary>The dialog secondary-button text.</summary>
     private const string DialogSecondaryText = "Cancel";
+
+    /// <summary>The taskbar progress none flag value.</summary>
+    private const int TaskBarProgressNoneValue = 0;
+
+    /// <summary>The taskbar progress indeterminate flag value.</summary>
+    private const int TaskBarProgressIndeterminateValue = 1;
+
+    /// <summary>The taskbar progress normal flag value.</summary>
+    private const int TaskBarProgressNormalValue = 2;
+
+    /// <summary>The taskbar progress error flag value.</summary>
+    private const int TaskBarProgressErrorValue = 4;
+
+    /// <summary>The taskbar progress paused flag value.</summary>
+    private const int TaskBarProgressPausedValue = 8;
 
     /// <summary>Verifies rectangle projection, union, offset, equality, and hashing.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
@@ -212,5 +228,34 @@ public sealed class PublicValueSurfaceTests
         await Assert.That(dialog.SecondaryButtonText).IsEqualTo(DialogSecondaryText);
         await Assert.That(theme.CurrentApplicationTheme).IsEqualTo(ApplicationTheme.Dark);
         await Assert.That(theme.SystemAccent).IsEqualTo(Colors.CornflowerBlue);
+    }
+
+    /// <summary>Verifies taskbar progress state values preserve Windows flag-compatible semantics.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task TaskBarProgressState_UsesWindowsFlagCompatibleValues()
+    {
+        await Assert.That(typeof(TaskBarProgressState).IsDefined(typeof(FlagsAttribute), inherit: false)).IsTrue();
+        await Assert.That(GetTaskBarProgressValue(TaskBarProgressState.None)).IsEqualTo(TaskBarProgressNoneValue);
+        await Assert.That(GetTaskBarProgressValue(TaskBarProgressState.Indeterminate)).IsEqualTo(TaskBarProgressIndeterminateValue);
+        await Assert.That(GetTaskBarProgressValue(TaskBarProgressState.Normal)).IsEqualTo(TaskBarProgressNormalValue);
+        await Assert.That(GetTaskBarProgressValue(TaskBarProgressState.Error)).IsEqualTo(TaskBarProgressErrorValue);
+        await Assert.That(GetTaskBarProgressValue(TaskBarProgressState.Paused)).IsEqualTo(TaskBarProgressPausedValue);
+    }
+
+    /// <summary>Gets the integer value for a taskbar progress state through the public enum surface.</summary>
+    /// <param name="expectedState">The state to locate.</param>
+    /// <returns>The integer value for the matching state.</returns>
+    private static int GetTaskBarProgressValue(TaskBarProgressState expectedState)
+    {
+        foreach (var state in Enum.GetValues<TaskBarProgressState>())
+        {
+            if (state == expectedState)
+            {
+                return (int)state;
+            }
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(expectedState), expectedState, "State was not defined.");
     }
 }

--- a/src/Tests/CrissCross.WPF.UI.Gallery.Tests/ReactiveWindowsSurfaceTests.cs
+++ b/src/Tests/CrissCross.WPF.UI.Gallery.Tests/ReactiveWindowsSurfaceTests.cs
@@ -17,7 +17,7 @@ public sealed class ReactiveWindowsSurfaceTests
     {
         var snapshot = await RunOnStaThreadAsync(ExerciseReactiveHosts);
 
-        await Assert.That(snapshot.WpfRequiresSetup).IsFalse();
+        await Assert.That(snapshot.WpfRequiresSetup).IsTrue();
         await Assert.That(snapshot.WpfHostName).IsEqualTo("ReactiveWpf");
         await Assert.That(snapshot.WpfHistoryCount).IsEqualTo(EmptyHistoryCount);
         await Assert.That(snapshot.FormsRequiresSetup).IsTrue();

--- a/src/Tests/CrissCross.WPF.UI.Gallery.Tests/ResourceDictionaryRuntimeTests.cs
+++ b/src/Tests/CrissCross.WPF.UI.Gallery.Tests/ResourceDictionaryRuntimeTests.cs
@@ -39,6 +39,36 @@ public sealed class ResourceDictionaryRuntimeTests
         }
     }
 
+    /// <summary>Verifies a missing model never exposes blank empty-state actions.</summary>
+    /// <returns>The asynchronous test operation.</returns>
+    [Test]
+    public async Task EmptyState_WhenModelIsCleared_HidesBothActions()
+    {
+        var visibility = await RunOnStaThreadAsync(ReadEmptyStateActions);
+        foreach (var actionVisibility in visibility)
+        {
+            await Assert.That(actionVisibility).IsEqualTo(System.Windows.Visibility.Collapsed);
+        }
+    }
+
+    /// <summary>Loads the actual empty-state template before and after clearing its model.</summary>
+    /// <returns>The action visibility values.</returns>
+    private static System.Windows.Visibility[] ReadEmptyStateActions()
+    {
+        CrissCross.WPF.UI.Controls.EmptyState control = new();
+        CrissCross.WPF.UI.Markup.ControlsDictionary resources = new();
+        control.Resources.MergedDictionaries.Add(resources);
+        control.Style = (System.Windows.Style)resources[typeof(CrissCross.WPF.UI.Controls.EmptyState)];
+        _ = control.ApplyTemplate();
+        var primary = (System.Windows.Controls.Button)control.Template.FindName("PrimaryActionButton", control);
+        var secondary = (System.Windows.Controls.Button)control.Template.FindName("SecondaryActionButton", control);
+        var initialPrimary = primary.Visibility;
+        var initialSecondary = secondary.Visibility;
+        control.Model = new("No results");
+        control.Model = null;
+        return [initialPrimary, initialSecondary, primary.Visibility, secondary.Visibility];
+    }
+
     /// <summary>Loads resources and returns the selected pack URIs.</summary>
     /// <returns>The resource URI snapshot.</returns>
     private static ResourceSnapshot LoadResources()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature, bug fix, theme correction, navigation reliability improvement, and test expansion.

## What is the new behavior?

- WPF, Avalonia, MAUI, and WinForms navigation hosts use a more consistent routed-host lifecycle, stable logical host identities, and safe cleanup. Desktop platforms retain multiple-window navigation support.
- Avalonia now has explicit Light, Dark, and HighContrast semantic resources; wrapper controls preserve CrissCross selectors while reusing native templates. Button, Gel button, checkbox, radio button, workflow, filter, chip, and derived-control states use semantic theme resources.
- MAUI gains composed industrial and workflow controls, including `ProcessValueIndicator`, busy, validation, filtering, paging, date-range, property editor, form field, and stepper presentations. Gallery pages demonstrate the controls and themes.
- `ProcessValueState` centralizes industrial process state, quality, and inclusive alarm threshold behavior for WPF, Avalonia, and MAUI indicators.
- Plot bindings use ReactiveUI primitives and generated observable-event integrations where supported. Navigation, GIF lifecycle, WebView2 lifecycle, pagination, and reactive binding regressions are covered.

## What is the current behavior?

The UI platforms had inconsistent control theming and interaction states, incomplete shared gallery functionality, fragile navigation-host lifecycle behavior, and several user-visible contrast and template defects. MAUI exposed a smaller set of composed controls and Avalonia wrapper style keys could bypass CrissCross themes.

## Checklist

- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

## Additional information

Validation completed on Windows:

- `dotnet build CrissCross.slnx -c Release -warnaserror -m:2 -nodeReuse:false -p:UseSharedCompilation=false` — 0 warnings, 0 errors.
- Fresh TUnit/Microsoft Testing Platform suites — 711 passing tests: Core/MAUI 305, Reactive 155, Navigation 137, WPF gallery 32, standard plot 41, reactive plot 41.
- Native WPF, Avalonia, and MAUI gallery checks covered theme switching; Avalonia additionally covered two-window navigation, filter removal, workflow progression, Gel-button contrast, and checkbox wrapping/selection contrast.

The quality audit documents measured coverage and known remaining bounds: MAUI still has desktop-capable surface gaps, Avalonia `Frame`/`Page` remain compatibility wrappers, WPF has four high-contrast palettes versus one in Avalonia/MAUI, and no claim is made of full UI parity or 100% whole-solution coverage.
